### PR TITLE
Added support for multiple whitelists

### DIFF
--- a/polymesh_substrate/runtime/src/general_tm.rs
+++ b/polymesh_substrate/runtime/src/general_tm.rs
@@ -37,9 +37,13 @@ decl_storage! {
         //PABLO: TODO: Idea here is to have a mapping/array of restrictions with a type and then loop through them applying their type of restriction. Whitelist would be associated to restriction instead of token.
         //RestrictionsForToken get(restrictions_for_token): map u32 => Vec<Restriction>;
 
-        WhitelistsByToken get(whitelists_by_token): map Vec<u8> => Vec<Whitelist<T::Moment, T::AccountId>>;
+        // Tokens can have multiple whitelists that (for now) check entries individually within each other
+        WhitelistsByToken get(whitelists_by_token): map (Vec<u8>, u32) => Vec<Whitelist<T::Moment, T::AccountId>>;
 
-        WhitelistForTokenAndAddress get(whitelist_for_restriction): map (Vec<u8>,T::AccountId) => Whitelist<T::Moment, T::AccountId>;
+        WhitelistForTokenAndAddress get(whitelist_for_restriction): map (Vec<u8>, u32, T::AccountId) => Whitelist<T::Moment, T::AccountId>;
+
+        WhitelistEntriesCount get(whitelist_entries_count): map (Vec<u8>,u32) => u64;
+        WhitelistCount get(whitelist_count): u32;
 
 	}
 }
@@ -51,7 +55,7 @@ decl_module! {
 		// this is needed only if you are using events in your module
 		fn deposit_event<T>() = default;
 
-		pub fn add_to_whitelist(origin, _ticker: Vec<u8>, _investor: T::AccountId, expiry: T::Moment) -> Result {
+		pub fn add_to_whitelist(origin, _ticker: Vec<u8>, _whitelistId: u32, _investor: T::AccountId, expiry: T::Moment) -> Result {
             let sender = ensure_signed(origin)?;
 						let ticker = Self::_toUpper(_ticker);
             ensure!(Self::is_owner(ticker.clone(),sender.clone()),"Sender must be the token owner");
@@ -62,13 +66,29 @@ decl_module! {
                 can_receive_after:expiry
             };
 
-            let mut whitelists_for_token = Self::whitelists_by_token(ticker.clone());
+            //Get whitelist entries for this token + whitelistId
+            let mut whitelists_for_token = Self::whitelists_by_token((ticker.clone(), _whitelistId.clone()));
+
+            //Get how many entries this whiteslist has and increase it if we are adding a new entry
+            let entries_count = Self::whitelist_entries_count((ticker.clone(),_whitelistId.clone()));
+            
+            // TODO: Make sure we are only increasing the count if it's a new entry and not just an update of an existing entry
+            let new_entries_count = entries_count.checked_add(1).ok_or("overflow in calculating next entry count")?;
+            <WhitelistEntriesCount<T>>::insert((ticker.clone(), _whitelistId),new_entries_count);
+
+            // If this is the first entry for this whitelist, increase the whitelists count so then we can loop through them.
+            if new_entries_count == 1 {
+                let whitelist_count = Self::whitelist_count();
+                let new_whitelist_count = whitelist_count.checked_add(1).ok_or("overflow in calculating next whitelist count")?;
+                <WhitelistCount<T>>::put(new_whitelist_count);
+            }
+
             whitelists_for_token.push(whitelist.clone());
 
             //PABLO: TODO: don't add the restriction to the array if it already exists
-            <WhitelistsByToken<T>>::insert(ticker.clone(),whitelists_for_token);
+            <WhitelistsByToken<T>>::insert((ticker.clone(), _whitelistId.clone()), whitelists_for_token);
 
-            <WhitelistForTokenAndAddress<T>>::insert((ticker.clone(),_investor),whitelist);
+            <WhitelistForTokenAndAddress<T>>::insert((ticker.clone(), _whitelistId, _investor),whitelist);
 
             runtime_io::print("Created restriction!!!");
             //<general_tm::Module<T>>::add_to_whitelist(sender,token_id,_investor,expiry);
@@ -97,12 +117,21 @@ impl<T: Trait> Module<T> {
 	pub fn verify_restriction(_ticker: Vec<u8>, from: T::AccountId, to: T::AccountId, value: T::TokenBalance) -> Result {
 		let ticker = Self::_toUpper(_ticker);
 		let now = <timestamp::Module<T>>::get();
-		let whitelist_for_from = Self::whitelist_for_restriction((ticker.clone(),from));
-		let whitelist_for_to = Self::whitelist_for_restriction((ticker.clone(),to));
-		if (whitelist_for_from.can_send_after > T::Moment::sa(0) && now >= whitelist_for_from.can_send_after) && (whitelist_for_to.can_receive_after > T::Moment::sa(0) && now > whitelist_for_to.can_receive_after) {
-			return Ok(());
-		}
-		Err("Cannot Transfer: General TM restrictions not satisfied")
+
+        // loop through existing whitelists
+        let whitelist_count = Self::whitelist_count();
+
+        for x in 0..whitelist_count {
+            let whitelist_for_from = Self::whitelist_for_restriction((ticker.clone(),x,from.clone()));
+            let whitelist_for_to = Self::whitelist_for_restriction((ticker.clone(),x,to.clone()));
+            if (whitelist_for_from.can_send_after > T::Moment::sa(0) && now >= whitelist_for_from.can_send_after) && (whitelist_for_to.can_receive_after > T::Moment::sa(0) && now > whitelist_for_to.can_receive_after) {
+                return Ok(());
+            }
+        }
+
+        Err("Cannot Transfer: General TM restrictions not satisfied")
+
+		
 	}
 
 				fn _toUpper(_hexArray: Vec<u8>) -> Vec<u8> {


### PR DESCRIPTION
Whitelists are now identified by tokenID + WhitelistID, this way, entries can be added to different whitelists which verify restrictions independently.

This allows for a whitelist model where, assuming Alice is in whitelist 1; Bob is in whitelist 1 and whitelist 2; Charles is in whitelist 2 :
- Alice can transfer to Bob 
- Bob can transfer to Charles
- But Alice can NOT transfer to Charles, since they are not part of the same whitelist.
