### PR TITLE
Emit an event when roles are updated

### DIFF
--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -536,8 +536,11 @@ impl<T: Trait> Module<T> {
             }
         });
 
-        Self::deposit_event( RawEvent::SigningKeyRolesUpdated( target_did.clone(),
-                new_sk.unwrap_or_else( || SigningKey::default()), roles));
+        Self::deposit_event(RawEvent::SigningKeyRolesUpdated(
+            target_did.clone(),
+            new_sk.unwrap_or_else(|| SigningKey::default()),
+            roles,
+        ));
         Ok(())
     }
 


### PR DESCRIPTION

New event `SigningKeyRolesUpdated(Vec<u8>, SigningKey, Vec<KeyRole>)` at line 527 is emitted when roles of a singing key are updated.

New Unit Test `update_signing_key_roles` verifies that update behaviour is correct.