### PR TITLE
MESH-540: Addition of batches of claims in a single transaction

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -102,6 +102,12 @@
         "data_type": "DataTypes",
         "value": "Vec<u8>"
     },
+    "ClaimRecord": {
+        "did": "IdentityId",
+        "claim_key": "Vec<u8>",
+        "expiry": "Moment",
+        "claim_value": "ClaimValue"
+    },
     "DataTypes": {
         "_enum": [
             "U8",

--- a/primitives/src/identity_id.rs
+++ b/primitives/src/identity_id.rs
@@ -30,7 +30,11 @@ pub struct IdentityId([u8; UUID_LEN]);
 
 impl Display for IdentityId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "did:poly:{:?}", self.0)
+        write!(f, "did:poly:")?;
+        for byte in &self.0 {
+            f.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        Ok(())
     }
 }
 

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -90,7 +90,8 @@ pub struct ClaimValue {
 }
 
 #[derive(codec::Encode, codec::Decode, Default, Clone, PartialEq, Eq, Debug)]
-/// A structure for passing claims to `add_claims_batch`.
+/// A structure for passing claims to `add_claims_batch`. The type argument is required to be
+/// `timestamp::Trait::Moment`.
 pub struct ClaimRecord<U> {
     did: IdentityId,
     claim_key: Vec<u8>,
@@ -99,6 +100,7 @@ pub struct ClaimRecord<U> {
 }
 
 impl<U> ClaimRecord<U> {
+    /// Constructs a new claim record.
     pub fn new(
         did: IdentityId,
         claim_key: Vec<u8>,
@@ -113,18 +115,22 @@ impl<U> ClaimRecord<U> {
         }
     }
 
+    /// Returns a reference to the DID.
     pub fn did(&self) -> &IdentityId {
         &self.did
     }
 
+    /// Returns a reference to the claim key.
     pub fn claim_key(&self) -> &[u8] {
         self.claim_key.as_slice()
     }
 
+    /// Returns a reference to the expiry timestamp.
     pub fn expiry(&self) -> &U {
         &self.expiry
     }
 
+    /// Returns a reference to the claim calue.
     pub fn claim_value(&self) -> &ClaimValue {
         &self.claim_value
     }
@@ -492,12 +498,12 @@ decl_module! {
             Ok(())
         }
 
-        /// Adds a new batch of claim records or edits an existing one. Only called by did_issuer's
-        /// signing key.
+        /// Adds a new batch of claim records or edits an existing one. Only called by
+        /// `did_issuer`'s signing key.
         pub fn add_claims_batch(
             origin,
             did_issuer: IdentityId,
-            claims: Vec<ClaimRecord<T>>
+            claims: Vec<ClaimRecord<<T as timestamp::Trait>::Moment>>
         ) -> Result {
             let sender = ensure_signed(origin)?;
             ensure!(<DidRecords>::exists(did_issuer), "claim issuer DID must already exist");

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -72,15 +72,15 @@ use system::{self, ensure_signed};
 
 #[derive(codec::Encode, codec::Decode, Default, Clone, PartialEq, Eq, Debug)]
 pub struct Claim<U> {
-    issuance_date: U,
-    expiry: U,
-    claim_value: ClaimValue,
+    pub issuance_date: U,
+    pub expiry: U,
+    pub claim_value: ClaimValue,
 }
 
 #[derive(codec::Encode, codec::Decode, Default, Clone, PartialEq, Eq, Debug)]
 pub struct ClaimMetaData {
-    claim_key: Vec<u8>,
-    claim_issuer: IdentityId,
+    pub claim_key: Vec<u8>,
+    pub claim_issuer: IdentityId,
 }
 
 #[derive(codec::Encode, codec::Decode, Default, Clone, PartialEq, Eq, Debug)]
@@ -93,42 +93,10 @@ pub struct ClaimValue {
 /// A structure for passing claims to `add_claims_batch`. The type argument is required to be
 /// `timestamp::Trait::Moment`.
 pub struct ClaimRecord<U> {
-    did: IdentityId,
-    claim_key: Vec<u8>,
-    expiry: U,
-    claim_value: ClaimValue,
-}
-
-impl<U> ClaimRecord<U> {
-    /// Constructs a new claim record.
-    pub fn new(did: IdentityId, claim_key: Vec<u8>, expiry: U, claim_value: ClaimValue) -> Self {
-        ClaimRecord {
-            did,
-            claim_key,
-            expiry,
-            claim_value,
-        }
-    }
-
-    /// Returns a reference to the DID.
-    pub fn did(&self) -> &IdentityId {
-        &self.did
-    }
-
-    /// Returns a reference to the claim key.
-    pub fn claim_key(&self) -> &[u8] {
-        self.claim_key.as_slice()
-    }
-
-    /// Returns a reference to the expiry timestamp.
-    pub fn expiry(&self) -> &U {
-        &self.expiry
-    }
-
-    /// Returns a reference to the claim calue.
-    pub fn claim_value(&self) -> &ClaimValue {
-        &self.claim_value
-    }
+    pub did: IdentityId,
+    pub claim_key: Vec<u8>,
+    pub expiry: U,
+    pub claim_value: ClaimValue,
 }
 
 #[derive(codec::Encode, codec::Decode, Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord)]
@@ -239,19 +207,19 @@ decl_storage! {
         pub MultiPurposeNonce get(multi_purpose_nonce) build(|_| 1u64): u64;
 
         /// Pre-authorize join to Identity.
-        pub PreAuthorizedJoinDid get( pre_authorized_join_did): map Signer => Vec<PreAuthorizedKeyInfo>;
+        pub PreAuthorizedJoinDid get(pre_authorized_join_did): map Signer => Vec<PreAuthorizedKeyInfo>;
 
         /// Authorization nonce per Identity. Initially is 0.
-        pub OffChainAuthorizationNonce get( offchain_authorization_nonce): map IdentityId => AuthorizationNonce;
+        pub OffChainAuthorizationNonce get(offchain_authorization_nonce): map IdentityId => AuthorizationNonce;
 
         /// Inmediate revoke of any off-chain authorization.
-        pub RevokeOffChainAuthorization get( is_offchain_authorization_revoked): map (Signer, TargetIdAuthorization<T::Moment>) => bool;
+        pub RevokeOffChainAuthorization get(is_offchain_authorization_revoked): map (Signer, TargetIdAuthorization<T::Moment>) => bool;
 
         /// All authorizations that an identity has
         pub Authorizations get(authorizations): map(Signer, u64) => Authorization<T::Moment>;
 
         /// Auth id of the latest auth of an identity. Used to allow iterating over auths
-        pub LastAuthorization get(last_authorization): map(Signer) => u64;
+        pub LastAuthorization get(last_authorization): map Signer => u64;
     }
 }
 

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -101,12 +101,7 @@ pub struct ClaimRecord<U> {
 
 impl<U> ClaimRecord<U> {
     /// Constructs a new claim record.
-    pub fn new(
-        did: IdentityId,
-        claim_key: Vec<u8>,
-        expiry: U,
-        claim_value: ClaimValue,
-    ) -> Self {
+    pub fn new(did: IdentityId, claim_key: Vec<u8>, expiry: U, claim_value: ClaimValue) -> Self {
         ClaimRecord {
             did,
             claim_key,

--- a/runtime/src/test/identity.rs
+++ b/runtime/src/test/identity.rs
@@ -102,9 +102,9 @@ fn only_claim_issuers_can_add_claims_batch() {
         assert_ok!(Identity::add_claims_batch(
             Origin::signed(claim_issuer.clone()),
             claim_issuer_did.clone(),
-            claim_records.clone(),
+            claim_records,
         ));
-        claim_records.push(ClaimRecord::new(
+        let claim_records_err1 = vec![ClaimRecord::new(
             owner_did.clone(),
             claim_key.to_vec(),
             300u64,
@@ -112,17 +112,16 @@ fn only_claim_issuers_can_add_claims_batch() {
                 data_type: DataTypes::VecU8,
                 value: "value 3".as_bytes().to_vec(),
             },
-        ));
+        )];
         assert_err!(
             Identity::add_claims_batch(
                 Origin::signed(claim_issuer.clone()),
-                issuer_did,
-                claim_records,
+                claim_issuer_did,
+                claim_records_err1,
             ),
-            "did must be a claim issuer or master key for DID"
+            "did_issuer must be a claim issuer or master key for DID"
         );
-        let mut claim_records_err2 = Vec::new();
-        claim_records_err2.push(ClaimRecord::new(
+        let claim_records_err2 = vec![ClaimRecord::new(
             issuer_did.clone(),
             claim_key.to_vec(),
             400u64,
@@ -130,7 +129,7 @@ fn only_claim_issuers_can_add_claims_batch() {
                 data_type: DataTypes::VecU8,
                 value: "value 4".as_bytes().to_vec(),
             },
-        ));
+        )];
         assert_err!(
             Identity::add_claims_batch(
                 Origin::signed(issuer),

--- a/runtime/src/test/identity.rs
+++ b/runtime/src/test/identity.rs
@@ -11,7 +11,6 @@ use primitives::{AuthorizationData, Key, Permission, Signer, SignerType, Signing
 use rand::Rng;
 use sr_io::with_externalities;
 use srml_support::{assert_err, assert_ok, traits::Currency};
-use std::convert::TryInto;
 use substrate_primitives::H512;
 use test_client::AccountKeyring;
 
@@ -781,7 +780,7 @@ fn one_step_join_id_with_ext() {
         AccountKeyring::Charlie,
         AccountKeyring::Dave,
     ]
-    .into_iter()
+    .iter()
     .map(|acc| H512::from(acc.sign(&auth_encoded)))
     .collect::<Vec<_>>();
 
@@ -997,7 +996,8 @@ fn removing_authorizations() {
                 auth_ids_bob[auth_to_remove - 1]
             );
             assert_eq!(auth.next_authorization, auth_ids_bob[auth_to_remove + 1]);
-            Identity::remove_authorization(alice.clone(), bob_did, auth_ids_bob[auth_to_remove]);
+            Identity::remove_authorization(alice.clone(), bob_did, auth_ids_bob[auth_to_remove])
+                .unwrap();
             let removed_auth = Identity::authorizations((bob_did, auth_ids_bob[auth_to_remove]));
             assert_eq!(removed_auth.authorization_data, AuthorizationData::NoData);
             auth_ids_bob.remove(auth_to_remove);


### PR DESCRIPTION
- [x] The entire transaction rolls back in the event of an error.
- [x] The transaction fee is manually tested in the UI to be proportional to the size of the batch of claims.

The UI testing method is explained [below](https://github.com/PolymathNetwork/Polymesh/pull/156#issuecomment-574650396).