### PR TITLE
Mesh 532/DID for Assets

### DIFF
--- a/primitives/src/identity_id.rs
+++ b/primitives/src/identity_id.rs
@@ -82,8 +82,16 @@ impl TryFrom<&[u8]> for IdentityId {
     type Error = &'static str;
 
     fn try_from(did: &[u8]) -> Result<Self, Self::Error> {
-        let did_str = str::from_utf8(did).map_err(|_| "DID is not valid UTF-8")?;
-        IdentityId::try_from(did_str)
+        if did.len() == UUID_LEN {
+            // case where a 256 bit hash is being converted
+            let mut uuid_fixed = [0; 32];
+            uuid_fixed.copy_from_slice(&did);
+            Ok(IdentityId(uuid_fixed))
+        } else {
+            // case where a string represented as u8 is being converted
+            let did_str = str::from_utf8(did).map_err(|_| "DID is not valid UTF-8")?;
+            IdentityId::try_from(did_str)
+        }
     }
 }
 

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -1767,7 +1767,9 @@ mod tests {
                 total_supply: 1_000_000,
                 divisible: true,
             };
-
+            assert!(!<identity::DidRecords>::exists(
+                Identity::get_token_did(&token.name).unwrap()
+            ));
             assert_err!(
                 Asset::create_token(
                     owner_signed.clone(),
@@ -1792,6 +1794,10 @@ mod tests {
 
             // A correct entry is added
             assert_eq!(Asset::token_details(token.name.clone()), token);
+            //assert!(Identity::is_existing_identity(Identity::get_token_did(&token.name).unwrap()));
+            assert!(<identity::DidRecords>::exists(
+                Identity::get_token_did(&token.name).unwrap()
+            ));
         });
     }
 

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -317,7 +317,7 @@ decl_module! {
             }
             let remainder_fee = fee - (proportional_fee * validator_len);
             let _withdraw_result = <balances::Module<T>>::withdraw(&sender, remainder_fee, WithdrawReason::Fee, ExistenceRequirement::KeepAlive)?;
-
+            <identity::Module<T>>::register_asset_did(&ticker)?;
             if is_ticker_available_or_registered_to == TickerRegistrationStatus::Available {
                 // ticker not registered by anyone (or registry expired). we can charge fee and register this ticker
                 Self::_register_ticker(&ticker, sender, did, None);

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -44,6 +44,8 @@ pub mod fee {
 pub mod did {
     /// prefix for user dids
     pub const USER: [u8; 5] = *b"USER:";
+    /// prefix for security token dids
+    pub const SECURITY_TOKEN: [u8; 15] = *b"SECURITY_TOKEN:";
 }
 
 // ERC1400 transfer status codes

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -44,7 +44,11 @@
 
 use rstd::{convert::TryFrom, prelude::*};
 
-use crate::{asset::AcceptTickerTransfer, balances, constants::did::USER};
+use crate::{
+    asset::AcceptTickerTransfer,
+    balances,
+    constants::did::{SECURITY_TOKEN, USER},
+};
 use primitives::{
     Authorization, AuthorizationData, AuthorizationError, Identity as DidRecord, IdentityId, Key,
     Permission, PreAuthorizedKeyInfo, Signer, SignerType, SigningItem,
@@ -52,9 +56,10 @@ use primitives::{
 
 use codec::Encode;
 use core::convert::From;
+use core::result::Result as StdResult;
 use sr_io::blake2_256;
 use sr_primitives::{
-    traits::{Dispatchable, Verify},
+    traits::{Dispatchable, Hash, Verify},
     AnySignature, DispatchError,
 };
 use srml_support::{
@@ -1422,6 +1427,23 @@ impl<T: Trait> Module<T> {
         if is_pre_auth_list_empty {
             <PreAuthorizedJoinDid>::remove(signer);
         }
+    }
+
+    pub fn register_asset_did(ticker: &Vec<u8>) -> Result {
+        let did = Self::get_token_did(ticker)?;
+        // Making sure there's no pre-existing entry for the DID
+        // This should never happen but just being defensive here
+        ensure!(!<DidRecords>::exists(did), "DID must be unique");
+        <DidRecords>::insert(did, DidRecord::default());
+        Ok(())
+    }
+
+    pub fn get_token_did(ticker: &Vec<u8>) -> StdResult<IdentityId, &'static str> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&SECURITY_TOKEN.encode());
+        buf.extend_from_slice(&ticker.encode());
+        let did = IdentityId::try_from(T::Hashing::hash(&buf[..]).as_ref())?;
+        Ok(did)
     }
 }
 


### PR DESCRIPTION
Note: The original plan included a special function that allows the owner of an asset to add claim issuers to the identity of the asset. However, since the requirement of being a claim issuer for issuing claims is being dropped, we no longer need it.

This, in combination with general linked data PR, can be used to make add documents to an asset in an iterateable way.