### PR TITLE
MESH-572: capture the funding round of a token

### DIFF
--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -2146,10 +2146,7 @@ mod tests {
                 num_tokens1,
                 vec![0x0]
             ));
-            assert_eq!(
-                Asset::funding_round(&token.name),
-                funding_round1.clone()
-            );
+            assert_eq!(Asset::funding_round(&token.name), funding_round1.clone());
             assert_eq!(
                 Asset::issued_in_funding_round((token.name.clone(), funding_round1.clone())),
                 num_tokens1


### PR DESCRIPTION
The following are the acceptance criteria. Please check if I implemented them OK.

* [ ] The asset should have a field called `fundingRound` which is a string and can be updated by the asset owner at any time.
* [ ] Every time tokens are issued (through a call to the `issue` function), the current funding round should be included in the event emitted.
* [ ] We should also keep a simple tally of how many tokens have been minted against each `fundingRound` value. See the map `issued_in_funding_round`.