### PR TITLE
Mesh 558/remove claim issuer and scripts

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -34,6 +34,12 @@
             "Group": "Vec<IdentityId>"
         }
     },
+    "LinkData": {
+        "_enum": {
+            "TickerOwned": "Vec<u8>",
+            "TokenOwned": "Vec<u8>"
+        }
+    },
     "Key": "[u8;32]",
     "Permission": {
         "_enum": [

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -2279,7 +2279,7 @@ mod tests {
     #[test]
     fn checkpoints_fuzz_test() {
         println!("Starting");
-        for i in 0..10 {
+        for _i in 0..10 {
             // When fuzzing in local, feel free to bump this number to add more fuzz runs.
             with_externalities(&mut identity_owned_by_alice(), || {
                 let now = Utc::now();

--- a/runtime/src/batch_dispatch_info.rs
+++ b/runtime/src/batch_dispatch_info.rs
@@ -1,9 +1,7 @@
 use primitives::IdentityId;
 
-use sr_primitives::weights::{
-    Weight, ClassifyDispatch, DispatchClass, WeighData
-};
-use rstd::{ cmp::max, vec::Vec };
+use rstd::{cmp::max, vec::Vec};
+use sr_primitives::weights::{ClassifyDispatch, DispatchClass, WeighData, Weight};
 
 /// It supports fee calculation when a transaction is made in batch mode (for a group of items).
 /// The total fee is maximum between:
@@ -11,25 +9,26 @@ use rstd::{ cmp::max, vec::Vec };
 ///     - and `min_weight`. It ensures a cost if number of items is 0, or you want a minimum threshold.
 ///
 pub struct BatchDispatchInfo {
-    pub dispatch_type : DispatchClass,
+    pub dispatch_type: DispatchClass,
     pub per_item_weight: Weight,
     pub min_weight: Weight,
 }
 
 impl BatchDispatchInfo {
-    pub fn new_normal( per_item: Weight, min: Weight,) -> Self {
-        Self::new( DispatchClass::Normal, per_item,  min)
+    pub fn new_normal(per_item: Weight, min: Weight) -> Self {
+        Self::new(DispatchClass::Normal, per_item, min)
     }
 
-    pub fn new_operational(per_item: Weight, min: Weight ) -> Self {
-        Self::new( DispatchClass::Operational, per_item, min)
+    pub fn new_operational(per_item: Weight, min: Weight) -> Self {
+        Self::new(DispatchClass::Operational, per_item, min)
     }
 
-    pub fn new(
-            dispatch_type: DispatchClass,
-            per_item_weight: Weight,
-            min_weight: Weight) -> Self {
-        BatchDispatchInfo{ dispatch_type, per_item_weight, min_weight }
+    pub fn new(dispatch_type: DispatchClass, per_item_weight: Weight, min_weight: Weight) -> Self {
+        BatchDispatchInfo {
+            dispatch_type,
+            per_item_weight,
+            min_weight,
+        }
     }
 }
 
@@ -42,12 +41,15 @@ impl<T> ClassifyDispatch<T> for BatchDispatchInfo {
 /// It adds support to any function like `fn x( _: IdentityId, items: Vec<_>)
 type IdentityAndVecParams<'a, T> = (&'a IdentityId, &'a Vec<T>);
 
-impl<'a, T> WeighData<IdentityAndVecParams<'a,T> > for BatchDispatchInfo {
+impl<'a, T> WeighData<IdentityAndVecParams<'a, T>> for BatchDispatchInfo {
     /// The weight is calculated base on the number of elements of the second parameter of the
     /// call.
-    fn weigh_data(&self, params: IdentityAndVecParams<'a,T>) -> Weight {
+    fn weigh_data(&self, params: IdentityAndVecParams<'a, T>) -> Weight {
         let (_, items) = params;
 
-        max( self.min_weight, self.per_item_weight * items.len() as Weight)
+        max(
+            self.min_weight,
+            self.per_item_weight * items.len() as Weight,
+        )
     }
 }

--- a/runtime/src/batch_dispatch_info.rs
+++ b/runtime/src/batch_dispatch_info.rs
@@ -45,11 +45,9 @@ impl<'a, T> WeighData<IdentityAndVecParams<'a, T>> for BatchDispatchInfo {
     /// The weight is calculated base on the number of elements of the second parameter of the
     /// call.
     fn weigh_data(&self, params: IdentityAndVecParams<'a, T>) -> Weight {
-        let (_, items) = params;
-
         max(
             self.min_weight,
-            self.per_item_weight * items.len() as Weight,
+            self.per_item_weight * params.1.len() as Weight,
         )
     }
 }

--- a/runtime/src/batch_dispatch_info.rs
+++ b/runtime/src/batch_dispatch_info.rs
@@ -1,0 +1,53 @@
+use primitives::IdentityId;
+
+use sr_primitives::weights::{
+    Weight, ClassifyDispatch, DispatchClass, WeighData
+};
+use rstd::{ cmp::max, vec::Vec };
+
+/// It supports fee calculation when a transaction is made in batch mode (for a group of items).
+/// The total fee is maximum between:
+///     - `per_item_weight` multiplied by number of items of one or more parameters.
+///     - and `min_weight`. It ensures a cost if number of items is 0, or you want a minimum threshold.
+///
+pub struct BatchDispatchInfo {
+    pub dispatch_type : DispatchClass,
+    pub per_item_weight: Weight,
+    pub min_weight: Weight,
+}
+
+impl BatchDispatchInfo {
+    pub fn new_normal( per_item: Weight, min: Weight,) -> Self {
+        Self::new( DispatchClass::Normal, per_item,  min)
+    }
+
+    pub fn new_operational(per_item: Weight, min: Weight ) -> Self {
+        Self::new( DispatchClass::Operational, per_item, min)
+    }
+
+    pub fn new(
+            dispatch_type: DispatchClass,
+            per_item_weight: Weight,
+            min_weight: Weight) -> Self {
+        BatchDispatchInfo{ dispatch_type, per_item_weight, min_weight }
+    }
+}
+
+impl<T> ClassifyDispatch<T> for BatchDispatchInfo {
+    fn classify_dispatch(&self, _: T) -> DispatchClass {
+        self.dispatch_type
+    }
+}
+
+/// It adds support to any function like `fn x( _: IdentityId, items: Vec<_>)
+type IdentityAndVecParams<'a, T> = (&'a IdentityId, &'a Vec<T>);
+
+impl<'a, T> WeighData<IdentityAndVecParams<'a,T> > for BatchDispatchInfo {
+    /// The weight is calculated base on the number of elements of the second parameter of the
+    /// call.
+    fn weigh_data(&self, params: IdentityAndVecParams<'a,T>) -> Weight {
+        let (_, items) = params;
+
+        max( self.min_weight, self.per_item_weight * items.len() as Weight)
+    }
+}

--- a/runtime/src/general_tm.rs
+++ b/runtime/src/general_tm.rs
@@ -540,12 +540,6 @@ mod tests {
             let (_claim_issuer, claim_issuer_did) =
                 make_account(&claim_issuer_acc.clone()).unwrap();
 
-            assert_ok!(Identity::add_claim_issuer(
-                token_owner_signed.clone(),
-                token_owner_did,
-                claim_issuer_did
-            ));
-
             let claim_value = ClaimValue {
                 data_type: DataTypes::VecU8,
                 value: "some_value".as_bytes().to_vec(),
@@ -625,12 +619,6 @@ mod tests {
             Balances::make_free_balance_be(&claim_issuer_acc, 1_000_000);
             let (_claim_issuer, claim_issuer_did) =
                 make_account(&claim_issuer_acc.clone()).unwrap();
-
-            assert_ok!(Identity::add_claim_issuer(
-                token_owner_signed.clone(),
-                token_owner_did.clone(),
-                claim_issuer_did
-            ));
 
             let claim_value = ClaimValue {
                 data_type: DataTypes::U8,

--- a/runtime/src/group.rs
+++ b/runtime/src/group.rs
@@ -20,7 +20,6 @@
 //! - `swap_member` - Replace one identity with the other.
 //! - `reset_members` - Re-initialize group members.
 //!
-use codec::{Decode, Encode, HasCompact};
 use primitives::IdentityId;
 use rstd::prelude::*;
 use sr_primitives::{traits::EnsureOrigin, weights::SimpleDispatchInfo};
@@ -177,7 +176,6 @@ mod tests {
 
     use sr_io::with_externalities;
     use srml_support::{assert_noop, assert_ok, impl_outer_origin, parameter_types};
-    use std::cell::RefCell;
     use substrate_primitives::{Blake2Hasher, H256};
 
     use sr_primitives::{

--- a/runtime/src/group.rs
+++ b/runtime/src/group.rs
@@ -206,6 +206,7 @@ mod tests {
     use srml_support::{assert_noop, assert_ok, impl_outer_origin, parameter_types};
     use substrate_primitives::{Blake2Hasher, H256};
 
+    use rstd::cell::RefCell;
     use sr_primitives::{
         testing::Header,
         traits::{BlakeTwo256, IdentityLookup},

--- a/runtime/src/group.rs
+++ b/runtime/src/group.rs
@@ -202,11 +202,11 @@ decl_module! {
 mod tests {
     use super::*;
 
+    use rstd::cell::RefCell;
     use sr_io::with_externalities;
     use srml_support::{assert_noop, assert_ok, impl_outer_origin, parameter_types};
     use substrate_primitives::{Blake2Hasher, H256};
 
-    use rstd::cell::RefCell;
     use sr_primitives::{
         testing::Header,
         traits::{BlakeTwo256, IdentityLookup},

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -37,7 +37,7 @@
 
 use rstd::{convert::TryFrom, prelude::*};
 
-use crate::{asset::AcceptTickerTransfer, balances, constants::did::USER};
+use crate::{asset::AcceptTickerTransfer, balances, constants::did::USER, BatchDispatchInfo};
 use primitives::{
     Authorization, AuthorizationData, AuthorizationError, Identity as DidRecord, IdentityId, Key,
     Permission, PreAuthorizedKeyInfo, Signer, SignerType, SigningItem,
@@ -153,6 +153,7 @@ pub struct SigningItemWithAuth {
     /// Off-chain authorization signature.
     pub auth_signature: H512,
 }
+
 
 /// The module's configuration trait.
 pub trait Trait: system::Trait + balances::Trait + timestamp::Trait {
@@ -369,7 +370,7 @@ decl_module! {
         }
 
         /// Adds new claim record or edits an existing one. Only called by did_issuer's signing key
-        #[weight = SimpleDispatchInfo::FixedNormal(5_000)]
+        #[weight = SimpleDispatchInfo::FixedNormal(10_000)]
         pub fn add_claim(
             origin,
             did: IdentityId,
@@ -417,7 +418,7 @@ decl_module! {
 
         /// Adds a new batch of claim records or edits an existing one. Only called by
         /// `did_issuer`'s signing key.
-        #[weight = SimpleDispatchInfo::FixedNormal(10_000)]
+        #[weight = BatchDispatchInfo::new_normal(3_000, 10_000)]
         pub fn add_claims_batch(
             origin,
             did_issuer: IdentityId,

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -417,6 +417,7 @@ decl_module! {
 
         /// Adds a new batch of claim records or edits an existing one. Only called by
         /// `did_issuer`'s signing key.
+        #[weight = SimpleDispatchInfo::FixedNormal(10_000)]
         pub fn add_claims_batch(
             origin,
             did_issuer: IdentityId,
@@ -440,8 +441,6 @@ decl_module! {
                 claim_value,
             } in claims {
                 ensure!(<DidRecords>::exists(did), "DID must already exist");
-                ensure!(Self::is_claim_issuer(did, did_issuer) || Self::is_master_key(did, &sender_key),
-                        "did_issuer must be a claim issuer or master key for DID");
                 let claim_meta_data = ClaimMetaData {
                     claim_key: claim_key.clone(),
                     claim_issuer: did_issuer.clone(),

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -16,20 +16,13 @@
 //! `MuliSign`, etc.) and/or its permission.
 //!
 //! Some operations at identity level are only allowed to its administrator account, like
-//! [set_master_key](./struct.Module.html#method.set_master_key) or
-//! [add_claim_issuer](./struct.Module.html#method.add_claim_issuer).
+//! [set_master_key](./struct.Module.html#method.set_master_key)
 //!
 //! ## Identity information
 //!
 //! Identity contains the following data:
 //!  - `master_key`. It is the administrator account of the identity.
 //!  - `signing_keys`. List of keys and their capabilities (type of key and its permissions) .
-//!
-//! ## Claim Issuers
-//!
-//! The administrator of the entity can add/remove claim issuers (see
-//! [add_claim_issuer](./struct.Module.html#method.add_claim_issuer) ). Only these claim issuers
-//! are able to add claims to that identity.
 //!
 //! ## Freeze signing keys
 //!
@@ -55,6 +48,7 @@ use core::convert::From;
 use sr_io::blake2_256;
 use sr_primitives::{
     traits::{Dispatchable, Verify},
+    weights::SimpleDispatchInfo,
     AnySignature, DispatchError,
 };
 use srml_support::{
@@ -365,6 +359,7 @@ decl_module! {
         }
 
         /// Adds new claim record or edits an existing one. Only called by did_issuer's signing key
+        #[weight = SimpleDispatchInfo::FixedNormal(5_000)]
         pub fn add_claim(
             origin,
             did: IdentityId,

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -154,7 +154,6 @@ pub struct SigningItemWithAuth {
     pub auth_signature: H512,
 }
 
-
 /// The module's configuration trait.
 pub trait Trait: system::Trait + balances::Trait + timestamp::Trait {
     /// The overarching event type.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -56,6 +56,9 @@ pub mod config {
 pub mod update_did_signed_extension;
 pub use update_did_signed_extension::UpdateDid;
 
+pub mod batch_dispatch_info;
+pub use batch_dispatch_info::BatchDispatchInfo;
+
 pub use sr_primitives::{Perbill, Permill};
 
 #[cfg(test)]

--- a/runtime/src/mips.rs
+++ b/runtime/src/mips.rs
@@ -441,7 +441,7 @@ mod tests {
         impl_outer_dispatch, impl_outer_origin, parameter_types,
     };
     use substrate_primitives::{Blake2Hasher, H256};
-    use system::{EnsureSignedBy, EventRecord, Phase};
+    use system::EnsureSignedBy;
 
     impl_outer_origin! {
         pub enum Origin for Test {}

--- a/runtime/src/test/identity.rs
+++ b/runtime/src/test/identity.rs
@@ -24,7 +24,7 @@ type Origin = <TestStorage as system::Trait>::Origin;
 #[test]
 fn add_claims_batch() {
     with_externalities(&mut build_ext(), || {
-        let owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
+        let _owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
         let issuer_did = register_keyring_account(AccountKeyring::Bob).unwrap();
         let issuer = AccountKeyring::Bob.public();
         let claim_issuer_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
@@ -75,15 +75,6 @@ fn add_claims_batch() {
                 value: "value 2".as_bytes().to_vec(),
             }
         );
-        let claim_records_err1 = vec![ClaimRecord {
-            did: owner_did.clone(),
-            claim_key: claim_key.to_vec(),
-            expiry: 300u64,
-            claim_value: ClaimValue {
-                data_type: DataTypes::VecU8,
-                value: "value 3".as_bytes().to_vec(),
-            },
-        }];
         let claim_records_err2 = vec![ClaimRecord {
             did: issuer_did.clone(),
             claim_key: claim_key.to_vec(),

--- a/runtime/src/test/identity.rs
+++ b/runtime/src/test/identity.rs
@@ -22,7 +22,7 @@ type Timestamp = timestamp::Module<TestStorage>;
 type Origin = <TestStorage as system::Trait>::Origin;
 
 #[test]
-fn only_claim_issuers_can_add_claims_batch() {
+fn add_claims_batch() {
     with_externalities(&mut build_ext(), || {
         let owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
         let issuer_did = register_keyring_account(AccountKeyring::Bob).unwrap();
@@ -84,25 +84,6 @@ fn only_claim_issuers_can_add_claims_batch() {
                 value: "value 3".as_bytes().to_vec(),
             },
         }];
-        assert_err!(
-            Identity::add_claims_batch(
-                Origin::signed(claim_issuer.clone()),
-                claim_issuer_did,
-                claim_records_err1,
-            ),
-            "did_issuer must be a claim issuer or master key for DID"
-        );
-        // Check that no claim has been stored.
-        assert_eq!(
-            Identity::claims((
-                owner_did.clone(),
-                ClaimMetaData {
-                    claim_key: claim_key.to_vec(),
-                    claim_issuer: claim_issuer_did.clone(),
-                },
-            )),
-            Claim::default(),
-        );
         let claim_records_err2 = vec![ClaimRecord {
             did: issuer_did.clone(),
             claim_key: claim_key.to_vec(),


### PR DESCRIPTION
@JMoore96 
There are some changes related to *Remove claim issuer* task.
The important points here are:

- New event at `identity.rs`:  `SignerJoinedToIdentityApproved( Signer, IdentityId)`. It will be thrown one Signing key approves the request to be added to an identity.
-  In  `scripts/cli/index.js`:
   - Add Claim Issuer is not needed.
   - New `authorizeJoinToIdentities` function in which we wait for `SignerJoinedToIdentityApproved` event