### PR TITLE
MESH-579: freezing and unfreezing of minting and transfers

### DIFF
--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -645,6 +645,7 @@ decl_module! {
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
+            ensure!(investor_dids.len() > 0, "list of investors is empty");
             ensure!(investor_dids.len() == values.len(), "Investor/amount list length inconsistent");
             ticker.canonize();
             ensure!(Self::is_owner(&ticker, did), "user is not authorized");

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -1644,7 +1644,6 @@ impl<T: Trait> Module<T> {
             Self::check_granularity(ticker, value),
             "Invalid granularity"
         );
-        ensure!(!Self::frozen(&ticker), "asset is frozen");
         //Increase receiver balance
         let ticker_to_did = (*ticker, to_did);
         let current_to_balance = Self::balance_of(&ticker_to_did);

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -549,7 +549,6 @@ decl_module! {
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
             ticker.canonize();
             ensure!(<BalanceOf<T>>::exists((ticker, did)), "Account does not own this token");
-            ensure!(!Self::frozen(&ticker), "token is frozen");
             let allowance = Self::allowance((ticker, did, spender_did));
             let updated_allowance = allowance.checked_add(&value).ok_or("overflow in calculating allowance")?;
             <Allowance<T>>::insert((ticker, did, spender_did), updated_allowance);
@@ -649,7 +648,6 @@ decl_module! {
             ensure!(investor_dids.len() == values.len(), "Investor/amount list length inconsistent");
             ticker.canonize();
             ensure!(Self::is_owner(&ticker, did), "user is not authorized");
-            ensure!(!Self::frozen(&ticker), "token is frozen");
 
             // A helper vec for calculated new investor balances
             let mut updated_balances = Vec::with_capacity(investor_dids.len());

--- a/runtime/src/test/asset_test.rs
+++ b/runtime/src/test/asset_test.rs
@@ -1077,14 +1077,11 @@ fn freeze_unfreeze_token() {
             Asset::issue(alice_signed.clone(), alice_did, ticker, bob_did, 1, vec![]),
             "token is frozen"
         );
-        // `batch_issue` succeeds vacuously on the empty vector of recipients.
-        assert_ok!(Asset::batch_issue(
-            alice_signed.clone(),
-            alice_did,
-            ticker,
-            vec![],
-            vec![]
-        ));
+        // `batch_issue` fails with the empty vector of investors with a different error message.
+        assert_err!(
+            Asset::batch_issue(alice_signed.clone(), alice_did, ticker, vec![], vec![]),
+            "list of investors is empty"
+        );
         // `batch_issue` fails when the vector of recipients is not empty.
         assert_err!(
             Asset::batch_issue(
@@ -1095,6 +1092,11 @@ fn freeze_unfreeze_token() {
                 vec![1]
             ),
             "token is frozen"
+        );
+        // `batch_issue` fails with the empty vector of investors with a different error message.
+        assert_err!(
+            Asset::batch_issue(alice_signed.clone(), alice_did, ticker, vec![], vec![]),
+            "list of investors is empty"
         );
         assert_ok!(Asset::unfreeze_token(alice_signed.clone(), ticker));
         assert_err!(

--- a/runtime/src/test/asset_test.rs
+++ b/runtime/src/test/asset_test.rs
@@ -1069,22 +1069,17 @@ fn freeze_unfreeze_asset() {
             Asset::issue(alice_signed.clone(), alice_did, ticker, bob_did, 1, vec![]),
             "asset is frozen"
         );
-        assert_ok!(
-            Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id)
-        );
+        assert_ok!(Asset::accept_token_ownership_transfer(
+            bob_signed.clone(),
+            auth_id
+        ));
         assert_err!(
             Asset::transfer(alice_signed.clone(), alice_did, ticker, bob_did, 1),
             "asset is frozen"
         );
         // `batch_issue` fails when the vector of recipients is not empty.
         assert_err!(
-            Asset::batch_issue(
-                bob_signed.clone(),
-                bob_did,
-                ticker,
-                vec![bob_did],
-                vec![1]
-            ),
+            Asset::batch_issue(bob_signed.clone(), bob_did, ticker, vec![bob_did], vec![1]),
             "asset is frozen"
         );
         // `batch_issue` fails with the empty vector of investors with a different error message.

--- a/runtime/src/test/asset_test.rs
+++ b/runtime/src/test/asset_test.rs
@@ -1077,11 +1077,6 @@ fn freeze_unfreeze_token() {
             Asset::issue(alice_signed.clone(), alice_did, ticker, bob_did, 1, vec![]),
             "token is frozen"
         );
-        // `batch_issue` fails with the empty vector of investors with a different error message.
-        assert_err!(
-            Asset::batch_issue(alice_signed.clone(), alice_did, ticker, vec![], vec![]),
-            "list of investors is empty"
-        );
         // `batch_issue` fails when the vector of recipients is not empty.
         assert_err!(
             Asset::batch_issue(


### PR DESCRIPTION
Note that controller transfers are still [allowed](https://github.com/PolymathNetwork/Polymesh/blob/cecd1c48ee862df7224ac280ae924cf5f0790d4c/runtime/src/asset.rs#L519) but I can disallow those if you think there should be no exceptions.