### PR TITLE
Mesh 609/subsidize block rewards

### DIFF
--- a/custom/staking/src/lib.rs
+++ b/custom/staking/src/lib.rs
@@ -270,7 +270,8 @@ use sp_phragmen::{ExtendedBalance, PhragmenStakedAssignment};
 use sp_runtime::{
     curve::PiecewiseLinear,
     traits::{
-        Bounded, CheckedSub, Convert, EnsureOrigin, One, SaturatedConversion, Saturating,
+        Bounded, CheckedSub, Convert, EnsureOrigin, Hash,
+        One, SaturatedConversion, Saturating,
         SimpleArithmetic, StaticLookup, Zero,
     },
     Perbill, RuntimeDebug,
@@ -786,6 +787,12 @@ decl_storage! {
         /// The map from (wannabe) validators to the status of compliance
         pub PermissionedValidators get(permissioned_validators):
             linked_map T::AccountId => Option<PermissionedValidator>;
+
+        /// AccountId of the block rewards reserve
+        BlockRewardsReserve get(block_reward_reserve) build(|_| {
+            let h: T::Hash = T::Hashing::hash(&(b"BLOCK_REWARDS_RESERVE").encode());
+            T::AccountId::decode(&mut &h.encode()[..]).unwrap_or_default()
+        }): T::AccountId;
     }
     add_extra_genesis {
         config(stakers):
@@ -817,7 +824,6 @@ decl_storage! {
                     }, _ => Ok(())
                 };
             }
-
             StorageVersion::put(migration::CURRENT_VERSION);
         });
     }

--- a/custom/staking/src/lib.rs
+++ b/custom/staking/src/lib.rs
@@ -270,8 +270,7 @@ use sp_phragmen::{ExtendedBalance, PhragmenStakedAssignment};
 use sp_runtime::{
     curve::PiecewiseLinear,
     traits::{
-        Bounded, CheckedSub, Convert, EnsureOrigin, Hash,
-        One, SaturatedConversion, Saturating,
+        Bounded, CheckedSub, Convert, EnsureOrigin, One, SaturatedConversion, Saturating,
         SimpleArithmetic, StaticLookup, Zero,
     },
     Perbill, RuntimeDebug,
@@ -787,12 +786,6 @@ decl_storage! {
         /// The map from (wannabe) validators to the status of compliance
         pub PermissionedValidators get(permissioned_validators):
             linked_map T::AccountId => Option<PermissionedValidator>;
-
-        /// AccountId of the block rewards reserve
-        BlockRewardsReserve get(block_reward_reserve) build(|_| {
-            let h: T::Hash = T::Hashing::hash(&(b"BLOCK_REWARDS_RESERVE").encode());
-            T::AccountId::decode(&mut &h.encode()[..]).unwrap_or_default()
-        }): T::AccountId;
     }
     add_extra_genesis {
         config(stakers):
@@ -824,6 +817,7 @@ decl_storage! {
                     }, _ => Ok(())
                 };
             }
+
             StorageVersion::put(migration::CURRENT_VERSION);
         });
     }

--- a/runtime/src/balances.rs
+++ b/runtime/src/balances.rs
@@ -423,8 +423,6 @@ decl_storage! {
             let h: T::Hash = T::Hashing::hash(&(b"BLOCK_REWARDS_RESERVE").encode());
             T::AccountId::decode(&mut &h.encode()[..]).unwrap_or_default()
         }): T::AccountId;
-
-        pub PendingRewards get(pending_rewards): T::Balance;
     }
     add_extra_genesis {
         config(balances): Vec<(T::AccountId, T::Balance)>;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -13,15 +13,15 @@ pub mod currency {
 /// Time and blocks.
 pub mod time {
     use primitives::{BlockNumber, Moment};
-    // Kusama & mainnet
-    pub const MILLISECS_PER_BLOCK: Moment = 6000;
+    // mainnet
+    // pub const MILLISECS_PER_BLOCK: Moment = 6000;
     // Testnet
-    //	pub const MILLISECS_PER_BLOCK: Moment = 1000;
+    pub const MILLISECS_PER_BLOCK: Moment = 1000;
     pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-    // Kusama & mainnet
-    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
+    // mainnet
+    // pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
     // Testnet
-    //	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 10 * MINUTES;
+    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 1 * MINUTES;
 
     // These time units are defined in number of blocks.
     pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/src/group.rs
+++ b/runtime/src/group.rs
@@ -27,7 +27,7 @@ use frame_support::{
 };
 use frame_system::{self as system, ensure_root};
 use primitives::IdentityId;
-use sp_runtime::traits::{EnsureOrigin, IsMember};
+use sp_runtime::traits::EnsureOrigin;
 use sp_std::prelude::*;
 
 pub trait Trait<I = DefaultInstance>: frame_system::Trait {

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -250,9 +250,9 @@ impl pallet_session::historical::Trait for Runtime {
 
 pallet_staking_reward_curve::build! {
     const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
-        min_inflation: 0_025_000,
-        max_inflation: 0_100_000,
-        ideal_stake: 0_500_000,
+        min_inflation: 0_500_000,
+        max_inflation: 1_000_000,
+        ideal_stake: 0_100_000,
         falloff: 0_050_000,
         max_piece_count: 40,
         test_precision: 0_005_000,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -92,7 +92,6 @@ impl Alternative {
                             get_account_id_from_seed::<sr25519::Public>("Alice"),
                             get_account_id_from_seed::<sr25519::Public>("Bob"),
                             get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                            get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                         ],
                         true,
                     )
@@ -212,7 +211,7 @@ fn testnet_genesis(
     endowed_accounts: Vec<AccountId>,
     enable_println: bool,
 ) -> GenesisConfig {
-    const STASH: u128 = 100_000_000 * POLY;
+    const STASH: u128 = 30_000_000_000 * POLY; //30G Poly
     let _desired_seats = (endowed_accounts.len() / 2 - initial_authorities.len()) as u32;
     GenesisConfig {
         frame_system: Some(SystemConfig {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -111,8 +111,6 @@ impl Alternative {
                         vec![
                             get_authority_keys_from_seed("Alice"),
                             get_authority_keys_from_seed("Bob"),
-                            get_authority_keys_from_seed("Charlie"),
-                            get_authority_keys_from_seed("Dave"),
                         ],
                         get_account_id_from_seed::<sr25519::Public>("Alice"),
                         vec![
@@ -120,14 +118,9 @@ impl Alternative {
                             get_account_id_from_seed::<sr25519::Public>("Bob"),
                             get_account_id_from_seed::<sr25519::Public>("Charlie"),
                             get_account_id_from_seed::<sr25519::Public>("Dave"),
-                            get_account_id_from_seed::<sr25519::Public>("Eve"),
-                            get_account_id_from_seed::<sr25519::Public>("Ferdie"),
                             get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                             get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                             get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                            get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                            get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                            get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                         ],
                         true,
                     )
@@ -219,7 +212,7 @@ fn testnet_genesis(
     endowed_accounts: Vec<AccountId>,
     enable_println: bool,
 ) -> GenesisConfig {
-    const STASH: u128 = 100 * POLY;
+    const STASH: u128 = 100_000_000 * POLY;
     let _desired_seats = (endowed_accounts.len() / 2 - initial_authorities.len()) as u32;
     GenesisConfig {
         frame_system: Some(SystemConfig {
@@ -244,7 +237,7 @@ fn testnet_genesis(
             balances: endowed_accounts
                 .iter()
                 .cloned()
-                .map(|k| (k, 1 << 60))
+                .map(|k| (k, 1 << 55))
                 .collect(),
             vesting: vec![],
         }),


### PR DESCRIPTION
There's a fixed BRR address. Anyone can send funds to it. Whenever a mint is supposed to happen, the balances module checks if BRR has funds and if it has, it transfers funds away from BRR rather than minting. If BRR is out of funds, normal mint happens.

There's another change in the PR: I have reduced block time to 1 second and epoch to 60 blocks (1 min) and era to 2 epochs (120 blocks or 2 min). I did this because I wanted to quickly test the PR but didn't revert these because I don't see any downside of having a more responsive internal testnet. When we do the fee analysis, we should revert to the default/mainnet values though.

I have also adjusted some chain spec params.