### PR TITLE
Mesh 640/rename conflicting modules and types

### DIFF
--- a/custom/staking/src/lib.rs
+++ b/custom/staking/src/lib.rs
@@ -1099,7 +1099,7 @@ decl_module! {
             // any key value will be greater than the threshold value of timestamp i.e current_timestamp + Bonding duration
             // then it break the loop and the given nominator in the nominator pool.
 
-            // if let Some(nominate_identity) = <identity::Module<T>>::get_identity(&(Key::try_from(stash.encode())?)) {
+            // if let Some(nominate_identity) = <identity::Module<T>>::get_identity(&(AccountKey::try_from(stash.encode())?)) {
             //     let (is_kyced, _) = <identity::Module<T>>::is_identity_has_valid_kyc(nominate_identity, Self::get_bonding_duration_period());
             //     if is_kyced {
                     let targets = targets.into_iter()
@@ -1285,7 +1285,7 @@ decl_module! {
 
                 //--if !(Self::nominators(target)).is_empty() {
                     // Access the identity of the nominator
-                    //--if let Some(nominate_identity) = <identity::Module<T>>::get_identity(&(Key::try_from(target.encode())?)) {
+                    //--if let Some(nominate_identity) = <identity::Module<T>>::get_identity(&(AccountKey::try_from(target.encode())?)) {
                         // Fetch all the claim values provided by the trusted service providers
                         // There is a possibility that nominator will have more than one claim for the same key,
                         // So we iterate all of them and if any one of the claim value doesn't expire then nominator posses

--- a/custom/transaction-payment/src/lib.rs
+++ b/custom/transaction-payment/src/lib.rs
@@ -38,7 +38,7 @@ use frame_support::{
     weights::{DispatchInfo, GetDispatchInfo, Weight},
 };
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
-use primitives::{traits::IdentityCurrency, Key, TransactionError};
+use primitives::{traits::IdentityCurrency, AccountKey, TransactionError};
 use sp_runtime::{
     traits::{Convert, SaturatedConversion, Saturating, SignedExtension, Zero},
     transaction_validity::{
@@ -234,7 +234,7 @@ where
         }
         let fee = Self::compute_fee(len as u32, info, 0u32.into());
         let encoded_transactor =
-            Key::try_from(who.encode()).map_err(|_| InvalidTransaction::BadProof)?;
+            AccountKey::try_from(who.encode()).map_err(|_| InvalidTransaction::BadProof)?;
         let imbalance;
         if let Some(did) = T::Currency::charge_fee_to_identity(&encoded_transactor) {
             sp_runtime::print("Charging fee to identity");

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -30,7 +30,7 @@
             "Group": "Vec<IdentityId>"
         }
     },
-    "Key": "[u8;32]",
+    "AccountKey": "[u8;32]",
     "Permission": {
         "_enum": [
             "Full",
@@ -62,7 +62,7 @@
     "Signer":{
        "_enum": {
             "Identity": "IdentityId",
-            "Key": "Key"
+            "AccountKey": "AccountKey"
         }
     },
     "SigningItem": {
@@ -94,7 +94,7 @@
     },
     "DidRecord": {
         "roles": "Vec<IdentityRole>",
-        "master_key": "Key",
+        "master_key": "AccountKey",
         "signing_items": "Vec<SigningItem>"
     },
     "Claim": {
@@ -212,7 +212,7 @@
         "end": "u64",
         "proposal_hash": "Hash"
     },
-    "Votes": {
+    "PolymeshVotes": {
         "index": "u32",
         "ayes": "Vec<(IdentityId, Balance)>",
         "nays": "Vec<(IdentityId, Balance)>"
@@ -228,7 +228,7 @@
         "index": "MipsIndex",
         "proposal":"Call"
     },
-    "ReferendumInfo": {
+    "PolymeshReferendumInfo": {
         "index": "MipsIndex",
         "priority": "MipsPriority",
         "proposal_hash": "Hash"
@@ -267,7 +267,7 @@
         ]
     },
     "ProportionMatch": {
-        "_enum": [ 
+        "_enum": [
             "AtLeast",
             "MoreThan"
         ]

--- a/primitives/src/account_key.rs
+++ b/primitives/src/account_key.rs
@@ -13,44 +13,44 @@ const KEY_SIZE: usize = 32;
 /// It stores a simple key.
 /// It uses fixed size to avoid dynamic memory allocation.
 #[derive(Encode, Decode, Default, PartialOrd, Ord, Eq, Copy, Clone, Debug)]
-pub struct Key([u8; KEY_SIZE]);
+pub struct AccountKey([u8; KEY_SIZE]);
 
-impl Key {
+impl AccountKey {
     /// It returns this key as a byte slice.
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl TryFrom<Vec<u8>> for Key {
+impl TryFrom<Vec<u8>> for AccountKey {
     type Error = &'static str;
 
     fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
-        Key::try_from(v.as_slice())
+        AccountKey::try_from(v.as_slice())
     }
 }
 
-impl TryFrom<&Vec<u8>> for Key {
+impl TryFrom<&Vec<u8>> for AccountKey {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u8>) -> Result<Self, Self::Error> {
-        Key::try_from(v.as_slice())
+        AccountKey::try_from(v.as_slice())
     }
 }
 
-impl TryFrom<&str> for Key {
+impl TryFrom<&str> for AccountKey {
     type Error = &'static str;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Key::try_from(s.as_bytes())
+        AccountKey::try_from(s.as_bytes())
     }
 }
 
-impl TryFrom<&[u8]> for Key {
+impl TryFrom<&[u8]> for AccountKey {
     type Error = &'static str;
 
     fn try_from(s: &[u8]) -> Result<Self, Self::Error> {
-        let mut k = Key::default();
+        let mut k = AccountKey::default();
         match s.len() {
             KEY_SIZE => k.0.copy_from_slice(s),
             KEY_SIZE_TEST => k.0[..KEY_SIZE_TEST].copy_from_slice(s),
@@ -60,19 +60,19 @@ impl TryFrom<&[u8]> for Key {
     }
 }
 
-impl From<[u8; KEY_SIZE]> for Key {
+impl From<[u8; KEY_SIZE]> for AccountKey {
     fn from(s: [u8; KEY_SIZE]) -> Self {
-        Key(s)
+        AccountKey(s)
     }
 }
 
-impl PartialEq for Key {
+impl PartialEq for AccountKey {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl PartialEq<&[u8]> for Key {
+impl PartialEq<&[u8]> for AccountKey {
     fn eq(&self, other: &&[u8]) -> bool {
         match other.len() {
             KEY_SIZE => self.0 == *other,
@@ -85,7 +85,7 @@ impl PartialEq<&[u8]> for Key {
     }
 }
 
-impl PartialEq<Vec<u8>> for Key {
+impl PartialEq<Vec<u8>> for AccountKey {
     fn eq(&self, other: &Vec<u8>) -> bool {
         self == &other.as_slice()
     }
@@ -93,7 +93,7 @@ impl PartialEq<Vec<u8>> for Key {
 
 #[cfg(test)]
 mod tests {
-    use super::{Key, KEY_SIZE};
+    use super::{AccountKey, KEY_SIZE};
     use std::convert::TryFrom;
 
     #[test]
@@ -101,10 +101,10 @@ mod tests {
         let k: [u8; KEY_SIZE] = [1u8; KEY_SIZE];
         let k2 = "ABCDABCD".as_bytes().to_vec();
 
-        assert!(Key::try_from(k).is_ok());
-        assert!(Key::try_from(k2.as_slice()).is_ok());
-        assert!(Key::try_from(k2).is_ok());
+        assert!(AccountKey::try_from(k).is_ok());
+        assert!(AccountKey::try_from(k2.as_slice()).is_ok());
+        assert!(AccountKey::try_from(k2).is_ok());
 
-        assert!(Key::try_from("ABCDABCDx".as_bytes()).is_err());
+        assert!(AccountKey::try_from("ABCDABCDx".as_bytes()).is_err());
     }
 }

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -1,14 +1,14 @@
 use codec::{Decode, Encode};
 use sp_std::prelude::Vec;
 
-use crate::{IdentityRole, Key, Signer, SigningItem};
+use crate::{AccountKey, IdentityRole, Signer, SigningItem};
 
 /// Identity information.
 #[allow(missing_docs)]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
 pub struct Identity {
     pub roles: Vec<IdentityRole>,
-    pub master_key: Key,
+    pub master_key: AccountKey,
     pub signing_items: Vec<SigningItem>,
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -72,8 +72,8 @@ pub mod identity;
 pub use identity::Identity;
 
 /// Key is strong type which stores bytes representing the key.
-pub mod key;
-pub use key::Key;
+pub mod account_key;
+pub use account_key::AccountKey;
 
 /// This module contains entities related with signing keys.
 pub mod signing_item;

--- a/primitives/src/signing_item.rs
+++ b/primitives/src/signing_item.rs
@@ -5,7 +5,7 @@ use sp_std::{
     vec,
 };
 
-use crate::{IdentityId, Key};
+use crate::{AccountKey, IdentityId};
 
 // use crate::entity::IgnoredCaseString;
 
@@ -46,7 +46,7 @@ impl Default for SignerType {
 #[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Signer {
     Identity(IdentityId),
-    Key(Key),
+    AccountKey(AccountKey),
 }
 
 impl Default for Signer {
@@ -55,9 +55,9 @@ impl Default for Signer {
     }
 }
 
-impl From<Key> for Signer {
-    fn from(v: Key) -> Self {
-        Signer::Key(v)
+impl From<AccountKey> for Signer {
+    fn from(v: AccountKey) -> Self {
+        Signer::AccountKey(v)
     }
 }
 
@@ -67,10 +67,10 @@ impl From<IdentityId> for Signer {
     }
 }
 
-impl PartialEq<Key> for Signer {
-    fn eq(&self, other: &Key) -> bool {
+impl PartialEq<AccountKey> for Signer {
+    fn eq(&self, other: &AccountKey) -> bool {
         match self {
-            Signer::Key(ref key) => key == other,
+            Signer::AccountKey(ref key) => key == other,
             _ => false,
         }
     }
@@ -87,9 +87,9 @@ impl PartialEq<IdentityId> for Signer {
 
 impl Signer {
     /// Checks if Signer is either a particular Identity or a particular key
-    pub fn eq_either(&self, other_identity: &IdentityId, other_key: &Key) -> bool {
+    pub fn eq_either(&self, other_identity: &IdentityId, other_key: &AccountKey) -> bool {
         match self {
-            Signer::Key(ref key) => key == other_key,
+            Signer::AccountKey(ref key) => key == other_key,
             Signer::Identity(ref id) => id == other_identity,
         }
     }
@@ -107,10 +107,10 @@ impl Ord for Signer {
         match self {
             Signer::Identity(id) => match other {
                 Signer::Identity(other_id) => id.cmp(other_id),
-                Signer::Key(..) => Ordering::Greater,
+                Signer::AccountKey(..) => Ordering::Greater,
             },
-            Signer::Key(key) => match other {
-                Signer::Key(other_key) => key.cmp(other_key),
+            Signer::AccountKey(key) => match other {
+                Signer::AccountKey(other_key) => key.cmp(other_key),
                 Signer::Identity(..) => Ordering::Less,
             },
         }
@@ -146,9 +146,9 @@ impl SigningItem {
     }
 }
 
-impl From<Key> for SigningItem {
-    fn from(s: Key) -> Self {
-        Self::new(Signer::Key(s), vec![])
+impl From<AccountKey> for SigningItem {
+    fn from(s: AccountKey) -> Self {
+        Self::new(Signer::AccountKey(s), vec![])
     }
 }
 
@@ -166,8 +166,8 @@ impl PartialEq for SigningItem {
     }
 }
 
-impl PartialEq<Key> for SigningItem {
-    fn eq(&self, other: &Key) -> bool {
+impl PartialEq<AccountKey> for SigningItem {
+    fn eq(&self, other: &AccountKey) -> bool {
         self.signer == *other
     }
 }
@@ -193,19 +193,19 @@ impl Ord for SigningItem {
 
 #[cfg(test)]
 mod tests {
-    use super::{Key, Permission, Signer, SigningItem};
+    use super::{AccountKey, Permission, Signer, SigningItem};
     use crate::IdentityId;
     use std::convert::{From, TryFrom};
 
     #[test]
     fn build_test() {
-        let key = Key::try_from("ABCDABCD".as_bytes()).unwrap();
-        let rk1 = SigningItem::new(Signer::Key(key.clone()), vec![]);
+        let key = AccountKey::try_from("ABCDABCD".as_bytes()).unwrap();
+        let rk1 = SigningItem::new(Signer::AccountKey(key.clone()), vec![]);
         let rk2 = SigningItem::from(key.clone());
         assert_eq!(rk1, rk2);
 
         let rk3 = SigningItem::new(
-            Signer::Key(key.clone()),
+            Signer::AccountKey(key.clone()),
             vec![Permission::Operator, Permission::Admin],
         );
         assert_ne!(rk1, rk3);
@@ -226,9 +226,9 @@ mod tests {
 
     #[test]
     fn full_permission_test() {
-        let key = Key::try_from("ABCDABCD".as_bytes()).unwrap();
-        let full_key = SigningItem::new(Signer::Key(key.clone()), vec![Permission::Full]);
-        let not_full_key = SigningItem::new(Signer::Key(key), vec![Permission::Operator]);
+        let key = AccountKey::try_from("ABCDABCD".as_bytes()).unwrap();
+        let full_key = SigningItem::new(Signer::AccountKey(key.clone()), vec![Permission::Full]);
+        let not_full_key = SigningItem::new(Signer::AccountKey(key), vec![Permission::Operator]);
         assert_eq!(full_key.has_permission(Permission::Operator), true);
         assert_eq!(full_key.has_permission(Permission::Admin), true);
 
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn signer_build_and_eq_tests() {
         let k = "ABCDABCD".as_bytes().to_vec();
-        let key = Key::try_from(k.as_slice()).unwrap();
+        let key = AccountKey::try_from(k.as_slice()).unwrap();
         let iden = IdentityId::try_from(
             "did:poly:f1d273950ddaf693db228084d63ef18282e00f91997ae9df4f173f09e86d0976",
         )

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{identity_id::IdentityId, key::Key};
+use crate::{account_key::AccountKey, identity_id::IdentityId};
 
 use frame_support::{dispatch::DispatchError, traits::Currency};
 use sp_std::result;
@@ -9,5 +9,5 @@ pub trait IdentityCurrency<AccountId>: Currency<AccountId> {
         value: Self::Balance,
     ) -> result::Result<Self::NegativeImbalance, DispatchError>;
 
-    fn charge_fee_to_identity(who: &Key) -> Option<IdentityId>;
+    fn charge_fee_to_identity(who: &AccountKey) -> Option<IdentityId>;
 }

--- a/runtime/src/asset.rs
+++ b/runtime/src/asset.rs
@@ -68,7 +68,7 @@ use frame_support::{
 };
 use frame_system::{self as system, ensure_signed};
 use pallet_session;
-use primitives::{AuthorizationData, AuthorizationError, IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, AuthorizationData, AuthorizationError, IdentityId, Signer, Ticker};
 use sp_runtime::traits::{CheckedAdd, CheckedSub, Verify};
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
@@ -241,8 +241,8 @@ decl_module! {
         /// * `ticker` ticker to register
         pub fn register_ticker(origin, ticker: Ticker) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
-            let signer = Signer::Key(sender_key.clone());
+            let sender_key = AccountKey::try_from(sender.encode())?;
+            let signer = Signer::AccountKey(sender_key.clone());
             let to_did =  match <identity::Module<T>>::current_did() {
                 Some(x) => x,
                 None => {
@@ -285,7 +285,7 @@ decl_module! {
         /// * `auth_id` Authorization ID of ticker transfer authorization
         pub fn accept_ticker_transfer(origin, auth_id: u64) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             let to_did =  match <identity::Module<T>>::current_did() {
                 Some(x) => x,
                 None => {
@@ -307,7 +307,7 @@ decl_module! {
         /// * `auth_id` Authorization ID of the token ownership transfer authorization
         pub fn accept_token_ownership_transfer(origin, auth_id: u64) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             let to_did =  match <identity::Module<T>>::current_did() {
                 Some(x) => x,
                 None => {
@@ -345,7 +345,7 @@ decl_module! {
             identifiers: Vec<(IdentifierType, Vec<u8>)>
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -431,7 +431,7 @@ decl_module! {
         /// * `ticker` - the ticker of the token
         pub fn freeze(origin, ticker: Ticker) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             ticker.canonize();
             ensure!(<Tokens<T>>::exists(&ticker), "token doesn't exist");
             let token = <Tokens<T>>::get(&ticker);
@@ -451,7 +451,7 @@ decl_module! {
         /// * `ticker` - the ticker of the frozen token
         pub fn unfreeze(origin, ticker: Ticker) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             ticker.canonize();
             ensure!(<Tokens<T>>::exists(&ticker), "token doesn't exist");
             let token = <Tokens<T>>::get(&ticker);
@@ -472,7 +472,7 @@ decl_module! {
         /// * `name` - the new name of the token
         pub fn rename_token(origin, ticker: Ticker, name: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             ticker.canonize();
             ensure!(<Tokens<T>>::exists(&ticker), "token doesn't exist");
             let token = <Tokens<T>>::get(&ticker);
@@ -493,7 +493,7 @@ decl_module! {
         /// * `value` Value that needs to transferred
         pub fn transfer(_origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, value: T::Balance) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -519,7 +519,7 @@ decl_module! {
         /// * `operator_data` It is a string which describes the reason of this control transfer call.
         pub fn controller_transfer(_origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key( Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey( AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -543,7 +543,7 @@ decl_module! {
         /// * `value` Amount of the tokens approved
         fn approve(_origin, did: IdentityId, ticker: Ticker, spender_did: IdentityId, value: T::Balance) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -568,7 +568,7 @@ decl_module! {
         /// * `to_did` DID to whom token is being transferred
         /// * `value` Amount of the token for transfer
         pub fn transfer_from(origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance) -> DispatchResult {
-            let spender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let spender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that spender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &spender), "sender must be a signing key for DID");
@@ -601,7 +601,7 @@ decl_module! {
         /// * `_ticker` Ticker of the token
         pub fn create_checkpoint(_origin, did: IdentityId, ticker: Ticker) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -621,7 +621,7 @@ decl_module! {
         /// * `value` Amount of tokens that get issued
         pub fn issue(origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -641,7 +641,7 @@ decl_module! {
         /// * `values` Array of the Amount of tokens that get issued
         pub fn batch_issue(origin, did: IdentityId, ticker: Ticker, investor_dids: Vec<IdentityId>, values: Vec<T::Balance>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -718,7 +718,7 @@ decl_module! {
         /// * `_data` An off chain data blob used to validate the redeem functionality.
         pub fn redeem(_origin, did: IdentityId, ticker: Ticker, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -771,7 +771,7 @@ decl_module! {
         /// * `_data` An off chain data blob used to validate the redeem functionality.
         pub fn redeem_from(_origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(_origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -830,7 +830,7 @@ decl_module! {
         /// * `operator_data` Any data blob that defines the reason behind the force redeem.
         pub fn controller_redeem(origin, did: IdentityId, ticker: Ticker, token_holder_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -874,7 +874,7 @@ decl_module! {
         /// * `ticker` Ticker of the token
         pub fn make_divisible(origin, did: IdentityId, ticker: Ticker) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -997,7 +997,7 @@ decl_module! {
         /// * `document_hash` Hash of the document to proof the incorruptibility of the document
         pub fn set_document(origin, did: IdentityId, ticker: Ticker, name: Vec<u8>, uri: Vec<u8>, document_hash: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -1017,7 +1017,7 @@ decl_module! {
         /// * `name` Name of the document
         pub fn remove_document(origin, did: IdentityId, ticker: Ticker, name: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -1043,7 +1043,7 @@ decl_module! {
         /// * `value` Allowance amount
         pub fn increase_custody_allowance(origin, ticker: Ticker, holder_did: IdentityId, custodian_did: IdentityId, value: T::Balance) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key( Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey( AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(
@@ -1091,13 +1091,13 @@ decl_module! {
             };
             // holder_account_id should be a part of the holder_did
             ensure!(signature.verify(&msg.encode()[..], &holder_account_id), "Invalid signature");
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             ensure!(
                 <identity::Module<T>>::is_signer_authorized(caller_did, &sender_signer),
                 "sender must be a signing key for DID"
             );
             // Validate the holder signing key
-            let holder_signer = Signer::Key(Key::try_from(holder_account_id.encode())?);
+            let holder_signer = Signer::AccountKey(AccountKey::try_from(holder_account_id.encode())?);
             ensure!(
                 <identity::Module<T>>::is_signer_authorized(holder_did, &holder_signer),
                 "holder signing key must be a signing key for holder DID"
@@ -1125,7 +1125,7 @@ decl_module! {
             value: T::Balance
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key( Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey( AccountKey::try_from(sender.encode())?);
             // Check that sender is allowed to act on behalf of `did`
             ensure!(
                 <identity::Module<T>>::is_signer_authorized(custodian_did, &sender_signer),
@@ -1160,7 +1160,7 @@ decl_module! {
         /// * `name` - the desired name of the current funding round.
         pub fn set_funding_round(origin, did: IdentityId, ticker: Ticker, name: Vec<u8>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer),
                     "sender must be a signing key for DID");
@@ -1186,7 +1186,7 @@ decl_module! {
             identifiers: Vec<(IdentifierType, Vec<u8>)>
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer),
                     "sender must be a signing key for DID");
             ticker.canonize();

--- a/runtime/src/committee.rs
+++ b/runtime/src/committee.rs
@@ -84,7 +84,7 @@ pub type Origin<T, I = DefaultInstance> = RawOrigin<<T as system::Trait>::Accoun
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
 /// Info for keeping track of a motion being voted on.
-pub struct Votes<IdentityId> {
+pub struct PolymeshVotes<IdentityId> {
     /// The proposal's unique index.
     index: ProposalIndex,
     /// The current set of commmittee members that approved it.
@@ -99,8 +99,8 @@ decl_storage! {
         pub Proposals get(fn proposals): Vec<T::Hash>;
         /// Actual proposal for a given hash.
         pub ProposalOf get(fn proposal_of): map T::Hash => Option<<T as Trait<I>>::Proposal>;
-        /// Votes on a given proposal, if it is ongoing.
-        pub Voting get(fn voting): map T::Hash => Option<Votes<IdentityId>>;
+        /// PolymeshVotes on a given proposal, if it is ongoing.
+        pub Voting get(fn voting): map T::Hash => Option<PolymeshVotes<IdentityId>>;
         /// Proposals so far.
         pub ProposalCount get(fn proposal_count): u32;
         /// The current members of the committee.
@@ -207,7 +207,7 @@ decl_module! {
             <Proposals<T, I>>::mutate(|proposals| proposals.push(proposal_hash));
             <ProposalOf<T, I>>::insert(proposal_hash, *proposal);
 
-            let votes = Votes { index, ayes: vec![did.clone()], nays: vec![] };
+            let votes = PolymeshVotes { index, ayes: vec![did.clone()], nays: vec![] };
             <Voting<T, I>>::insert(proposal_hash, votes);
 
             Self::deposit_event(RawEvent::Proposed(did, index, proposal_hash));
@@ -626,7 +626,7 @@ mod tests {
             assert_eq!(Committee::proposal_of(&hash), Some(proposal));
             assert_eq!(
                 Committee::voting(&hash),
-                Some(Votes {
+                Some(PolymeshVotes {
                     index: 0,
                     ayes: vec![alice_did],
                     nays: vec![]
@@ -730,7 +730,7 @@ mod tests {
             ));
             assert_eq!(
                 Committee::voting(&hash),
-                Some(Votes {
+                Some(PolymeshVotes {
                     index: 0,
                     ayes: vec![alice_did],
                     nays: vec![]
@@ -749,7 +749,7 @@ mod tests {
             ));
             assert_eq!(
                 Committee::voting(&hash),
-                Some(Votes {
+                Some(PolymeshVotes {
                     index: 0,
                     ayes: vec![],
                     nays: vec![alice_did]
@@ -794,7 +794,7 @@ mod tests {
             ));
             assert_eq!(
                 Committee::voting(&hash),
-                Some(Votes {
+                Some(PolymeshVotes {
                     index: 0,
                     ayes: vec![charlie_did],
                     nays: vec![bob_did]

--- a/runtime/src/committee.rs
+++ b/runtime/src/committee.rs
@@ -20,7 +20,7 @@
 //! - `vote` - Members vote on proposals which are automatically dispatched if they meet vote threshold
 //!
 use crate::identity;
-use primitives::{IdentityId, Key, Signer};
+use primitives::{AccountKey, IdentityId, Signer};
 use sp_runtime::traits::{EnsureOrigin, Hash};
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
@@ -190,7 +190,7 @@ decl_module! {
         #[weight = SimpleDispatchInfo::FixedOperational(5_000_000)]
         fn propose(origin, did: IdentityId, proposal: Box<<T as Trait<I>>::Proposal>) {
             let who = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(who.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(who.encode())?);
 
             // Ensure sender can sign for the given identity
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -223,7 +223,7 @@ decl_module! {
         #[weight = SimpleDispatchInfo::FixedOperational(200_000)]
         fn vote(origin, did: IdentityId, proposal: T::Hash, #[compact] index: ProposalIndex, approve: bool) {
             let who = ensure_signed(origin)?;
-            let signer = Signer::Key(Key::try_from(who.encode())?);
+            let signer = Signer::AccountKey(AccountKey::try_from(who.encode())?);
 
             // Ensure sender can sign for the given identity
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -601,7 +601,7 @@ mod tests {
     ) -> StdResult<(<Test as frame_system::Trait>::Origin, IdentityId), &'static str> {
         let signed_id = Origin::signed(account_id.clone());
         Identity::register_did(signed_id.clone(), vec![]);
-        let did = Identity::get_identity(&Key::try_from(account_id.encode())?).unwrap();
+        let did = Identity::get_identity(&AccountKey::try_from(account_id.encode())?).unwrap();
         Ok((signed_id, did))
     }
 

--- a/runtime/src/contracts_wrapper.rs
+++ b/runtime/src/contracts_wrapper.rs
@@ -14,7 +14,7 @@
 //!   - When code is instantiated enforce a POLY fee to the DID owning the code (i.e. that executed put_code)
 
 use crate::identity;
-use primitives::{IdentityId, Key, Signer};
+use primitives::{AccountKey, IdentityId, Signer};
 
 use codec::Encode;
 use frame_support::traits::Currency;
@@ -56,7 +56,7 @@ decl_module! {
             code: Vec<u8>
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signer::Key( Key::try_from(sender.encode())?);
+            let signer = Signer::AccountKey( AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");

--- a/runtime/src/dividend.rs
+++ b/runtime/src/dividend.rs
@@ -37,7 +37,7 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
 use frame_system::{self as system, ensure_signed};
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 use sp_runtime::traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use sp_std::{convert::TryFrom, prelude::*};
 
@@ -106,7 +106,7 @@ decl_module! {
             payout_ticker: Ticker,
             checkpoint_id: u64
         ) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
             ticker.canonize();
@@ -178,7 +178,7 @@ decl_module! {
 
         /// Lets the owner cancel a dividend before start/maturity date
         pub fn cancel(origin, did: IdentityId, ticker: Ticker, dividend_id: u32) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -219,7 +219,7 @@ decl_module! {
         /// Withdraws from a dividend the adequate share of the `amount` field. All dividend shares
         /// are rounded by truncation (down to first integer below)
         pub fn claim(origin, did: IdentityId, ticker: Ticker, dividend_id: u32) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -286,7 +286,7 @@ decl_module! {
 
         /// After a dividend had expired, collect the remaining amount to owner address
         pub fn claim_unclaimed(origin, did: IdentityId, ticker: Ticker, dividend_id: u32) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -707,7 +707,7 @@ mod tests {
         let signed_id = Origin::signed(account_id.clone());
         Balances::make_free_balance_be(&account_id, 1_000_000);
         Identity::register_did(signed_id.clone(), vec![]);
-        let did = Identity::get_identity(&Key::try_from(account_id.encode())?).unwrap();
+        let did = Identity::get_identity(&AccountKey::try_from(account_id.encode())?).unwrap();
         Ok((signed_id, did))
     }
 

--- a/runtime/src/exemption.rs
+++ b/runtime/src/exemption.rs
@@ -2,7 +2,7 @@ use crate::{
     asset::{self, AssetTrait},
     balances, identity, utils,
 };
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 
 use codec::Encode;
 use frame_support::{decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure};
@@ -34,7 +34,7 @@ decl_module! {
 
         fn modify_exemption_list(origin, did: IdentityId, ticker: Ticker, _tm: u16, asset_holder_did: IdentityId, exempted: bool) -> DispatchResult {
             ticker.canonize();
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");

--- a/runtime/src/general_tm.rs
+++ b/runtime/src/general_tm.rs
@@ -54,7 +54,7 @@ use core::result::Result as StdResult;
 use frame_support::{decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure};
 use frame_system::{self as system, ensure_signed};
 use identity::ClaimValue;
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 use sp_std::{convert::TryFrom, prelude::*};
 
 /// Type of operators that a rule can have
@@ -125,7 +125,7 @@ decl_module! {
 
         /// Adds an asset rule to active rules for a ticker
         pub fn add_active_rule(origin, did: IdentityId, ticker: Ticker, asset_rule: AssetRule) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -145,7 +145,7 @@ decl_module! {
 
         /// Removes a rule from active asset rules
         pub fn remove_active_rule(origin, did: IdentityId, ticker: Ticker, asset_rule: AssetRule) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from( ensure_signed(origin)?.encode())?);
 
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
             ticker.canonize();
@@ -166,7 +166,7 @@ decl_module! {
 
         /// Removes all active rules of a ticker
         pub fn reset_active_rules(origin, did: IdentityId, ticker: Ticker) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
             ticker.canonize();
@@ -524,7 +524,7 @@ mod tests {
         let signed_id = Origin::signed(account_id.clone());
         Balances::make_free_balance_be(&account_id, 1_000_000);
         Identity::register_did(signed_id.clone(), vec![]);
-        let did = Identity::get_identity(&Key::try_from(account_id.encode())?).unwrap();
+        let did = Identity::get_identity(&AccountKey::try_from(account_id.encode())?).unwrap();
         Ok((signed_id, did))
     }
 

--- a/runtime/src/identity.rs
+++ b/runtime/src/identity.rs
@@ -49,8 +49,9 @@ use crate::{
     BatchDispatchInfo,
 };
 use primitives::{
-    Authorization, AuthorizationData, AuthorizationError, Identity as DidRecord, IdentityId, Key,
-    Link, LinkData, Permission, PreAuthorizedKeyInfo, Signer, SignerType, SigningItem, Ticker,
+    AccountKey, Authorization, AuthorizationData, AuthorizationError, Identity as DidRecord,
+    IdentityId, Link, LinkData, Permission, PreAuthorizedKeyInfo, Signer, SignerType, SigningItem,
+    Ticker,
 };
 
 use codec::Encode;
@@ -204,7 +205,7 @@ decl_storage! {
         pub ClaimKeys get(fn claim_keys): map IdentityId => Vec<ClaimMetaData>;
 
         // Account => DID
-        pub KeyToIdentityIds get(fn key_to_identity_ids): map Key => Option<LinkedKeyInfo>;
+        pub KeyToIdentityIds get(fn key_to_identity_ids): map AccountKey => Option<LinkedKeyInfo>;
 
         /// How much does creating a DID cost
         pub DidCreationFee get(fn did_creation_fee) config(): T::Balance;
@@ -275,12 +276,12 @@ decl_module! {
         ///  - If any signing key is already linked to any identity, it will fail.
         ///  - If any signing key is already
         pub fn add_signing_items(origin, did: IdentityId, signing_items: Vec<SigningItem>) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             // Check constraint 1-to-1 in relation key-identity.
             for s_item in &signing_items{
-                if let Signer::Key(ref key) = s_item.signer {
+                if let Signer::AccountKey(ref key) = s_item.signer {
                     if !Self::can_key_be_linked_to_did( key, s_item.signer_type) {
                         return Err(Error::<T>::AlreadyLinked.into());
                     }
@@ -302,13 +303,13 @@ decl_module! {
         /// # Failure
         /// It can only called by master key owner.
         pub fn remove_signing_items(origin, did: IdentityId, signers_to_remove: Vec<Signer>) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             // Remove any Pre-Authentication & link
             signers_to_remove.iter().for_each( |signer| {
                 Self::remove_pre_join_identity( signer, did);
-                if let Signer::Key(ref key) = signer {
+                if let Signer::AccountKey(ref key) = signer {
                     Self::unlink_key_to_did(key, did);
                 }
             });
@@ -326,9 +327,9 @@ decl_module! {
         ///
         /// # Failure
         /// Only called by master key owner.
-        fn set_master_key(origin, did: IdentityId, new_key: Key) -> DispatchResult {
+        fn set_master_key(origin, did: IdentityId, new_key: AccountKey) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from( sender.encode())?;
+            let sender_key = AccountKey::try_from( sender.encode())?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             ensure!( Self::can_key_be_linked_to_did(&new_key, SignerType::External), "Master key can only belong to one DID");
@@ -351,7 +352,7 @@ decl_module! {
         /// * `kyc_auth_id` Authorization from a KYC service provider
         pub fn accept_master_key(origin, rotation_auth_id: u64, kyc_auth_id: u64) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             let signer = Signer::from(sender_key);
 
             // When both authorizations are present...
@@ -363,7 +364,7 @@ decl_module! {
             if let AuthorizationData::RotateMasterKey(rotation_for_did) = rotation_auth.authorization_data {
                 // Ensure the request was made by the owner of master key
                 match rotation_auth.authorized_by {
-                    Signer::Key(key) =>  {
+                    Signer::AccountKey(key) =>  {
                         let master_key = <DidRecords>::get(rotation_for_did).master_key;
                         ensure!(key == master_key, "Authorization to change key was not from the owner of master key");
                     },
@@ -375,7 +376,7 @@ decl_module! {
                 if let AuthorizationData::AttestMasterKeyRotation(attestation_for_did) = kyc_auth.authorization_data {
                     // Attestor must be a KYC service provider
                     let kyc_provider_did = match kyc_auth.authorized_by {
-                        Signer::Key(ref key) =>  Self::get_identity(key),
+                        Signer::AccountKey(ref key) =>  Self::get_identity(key),
                         Signer::Identity(id)  => Some(id),
                     };
 
@@ -425,10 +426,10 @@ decl_module! {
             ensure!(<DidRecords>::exists(did), "DID must already exist");
             ensure!(<DidRecords>::exists(did_issuer), "claim issuer DID must already exist");
 
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
 
             // Verify that sender key is one of did_issuer's signing keys
-            let sender_signer = Signer::Key(sender_key);
+            let sender_signer = Signer::AccountKey(sender_key);
             ensure!(Self::is_signer_authorized(did_issuer, &sender_signer), "Sender must hold a claim issuer's signing key");
 
             let claim_meta_data = ClaimMetaData {
@@ -467,9 +468,9 @@ decl_module! {
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             ensure!(<DidRecords>::exists(did_issuer), "claim issuer DID must already exist");
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             // Verify that sender key is one of did_issuer's signing keys
-            let sender_signer = Signer::Key(sender_key);
+            let sender_signer = Signer::AccountKey(sender_key);
             ensure!(Self::is_signer_authorized(did_issuer, &sender_signer),
                     "Sender must hold a claim issuer's signing key");
             // Claims that successfully passed all required checks. Unless all claims pass those
@@ -548,7 +549,7 @@ decl_module! {
 
         /// Marks the specified claim as revoked
         pub fn revoke_claim(origin, did: IdentityId, claim_key: Vec<u8>, did_issuer: IdentityId) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
 
             ensure!(<DidRecords>::exists(&did), "DID must already exist");
             ensure!(<DidRecords>::exists(&did_issuer), "claim issuer DID must already exist");
@@ -579,11 +580,11 @@ decl_module! {
         /// It sets permissions for an specific `target_key` key.
         /// Only the master key of an identity is able to set signing key permissions.
         pub fn set_permission_to_signer(origin, did: IdentityId, signer: Signer, permissions: Vec<Permission>) -> DispatchResult {
-            let sender_key = Key::try_from( ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
             let record = Self::grant_check_only_master_key( &sender_key, did)?;
 
             // You are trying to add a permission to did's master key. It is not needed.
-            if let Signer::Key(ref key) = signer {
+            if let Signer::AccountKey(ref key) = signer {
                 if record.master_key == *key {
                     return Ok(());
                 }
@@ -610,7 +611,7 @@ decl_module! {
         }
 
         pub fn get_my_did(origin) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             if let Some(did) = Self::get_identity(&sender_key) {
                 Self::deposit_event(RawEvent::DidQuery(sender_key, did));
                 sp_runtime::print(did);
@@ -628,7 +629,7 @@ decl_module! {
             authorization_data: AuthorizationData,
             expiry: Option<T::Moment>
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let from_did =  match Self::current_did() {
                 Some(x) => x,
                 None => {
@@ -653,7 +654,7 @@ decl_module! {
             authorization_data: AuthorizationData,
             expiry: Option<T::Moment>
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
 
             Self::add_auth(Signer::from(sender_key), target, authorization_data, expiry);
 
@@ -667,7 +668,7 @@ decl_module! {
             // Vec<(target_did, auth_data, expiry)>
             auths: Vec<(Signer, AuthorizationData, Option<T::Moment>)>
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let from_did =  match Self::current_did() {
                 Some(x) => x,
                 None => {
@@ -692,7 +693,7 @@ decl_module! {
             target: Signer,
             auth_id: u64
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let from_did =  match Self::current_did() {
                 Some(x) => x,
                 None => {
@@ -721,7 +722,7 @@ decl_module! {
             // Vec<(target_did, auth_id)>
             auth_identifiers: Vec<(Signer, u64)>
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let from_did =  match Self::current_did() {
                 Some(x) => x,
                 None => {
@@ -754,7 +755,7 @@ decl_module! {
             origin,
             auth_id: u64
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let signer = match Self::current_did() {
                 Some(x) => Signer::from(x),
                 None => {
@@ -781,7 +782,7 @@ decl_module! {
                         _ => return Err(Error::<T>::UnknownAuthorization.into())
                     }
                 },
-                Signer::Key(key) => {
+                Signer::AccountKey(key) => {
                     match auth.authorization_data {
                         AuthorizationData::AddMultiSigSigner =>
                             T::AddSignerMultiSigTarget::accept_multisig_signer(Signer::from(key), auth_id),
@@ -796,7 +797,7 @@ decl_module! {
             origin,
             auth_ids: Vec<u64>
         ) -> DispatchResult {
-            let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
             let signer = match Self::current_did() {
                 Some(x) => Signer::from(x),
                 None => {
@@ -828,7 +829,7 @@ decl_module! {
                         }
                     }
                 },
-                Signer::Key(key) => {
+                Signer::AccountKey(key) => {
                     for auth_id in auth_ids {
                         // NB: Even if an auth is invalid (due to any reason), this batch function does NOT return an error.
                         // It will just skip that particular authorization.
@@ -858,8 +859,8 @@ decl_module! {
         ///  - Key should be authorized previously to join to that target identity.
         ///  - Key is not linked to any other identity.
         pub fn authorize_join_to_identity(origin, target_id: IdentityId) -> DispatchResult {
-            let sender_key = Key::try_from( ensure_signed(origin)?.encode())?;
-            let signer_from_key = Signer::Key( sender_key.clone());
+            let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
+            let signer_from_key = Signer::AccountKey( sender_key.clone());
             let signer_id_found = Self::key_to_identity_ids(sender_key);
 
             // Double check that `origin` (its key or identity) has been pre-authorize.
@@ -892,7 +893,7 @@ decl_module! {
                         .find( |pre_auth_item| pre_auth_item.target_id == target_id) {
                     // Remove pre-auth, link key to identity and update identity record.
                     Self::remove_pre_join_identity(&signer, target_id);
-                    if let Signer::Key(key) = signer {
+                    if let Signer::AccountKey(key) = signer {
                         Self::link_key_to_did( &key, pre_auth.signing_item.signer_type, target_id);
                     }
                     <DidRecords>::mutate( target_id, |identity| {
@@ -912,13 +913,13 @@ decl_module! {
         /// It only affects the authorization: if key accepted it previously, then this transaction
         /// shall have no effect.
         pub fn unauthorized_join_to_identity(origin, signer: Signer, target_id: IdentityId) -> DispatchResult {
-            let sender_key = Key::try_from( ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
 
             let mut is_remove_allowed = Self::is_master_key( target_id, &sender_key);
 
             if !is_remove_allowed {
                 is_remove_allowed = match signer {
-                    Signer::Key(ref key) => sender_key == *key,
+                    Signer::AccountKey(ref key) => sender_key == *key,
                     Signer::Identity(id) => Self::is_master_key(id, &sender_key)
                 }
             }
@@ -949,7 +950,7 @@ decl_module! {
                 expires_at: T::Moment,
                 additional_keys: Vec<SigningItemWithAuth>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, id)?;
 
             // 0. Check expiration
@@ -968,7 +969,7 @@ decl_module! {
 
                 // Get account_id from signer
                 let account_id_found = match si.signer {
-                    Signer::Key(ref key) =>  Public::try_from(key.as_slice()).ok(),
+                    Signer::AccountKey(ref key) =>  Public::try_from(key.as_slice()).ok(),
                     Signer::Identity(ref id) if <DidRecords>::exists(id) => {
                         let master_key = <DidRecords>::get(id).master_key;
                         Public::try_from( master_key.as_slice()).ok()
@@ -977,7 +978,7 @@ decl_module! {
                 };
 
                 if let Some(account_id) = account_id_found {
-                    if let Signer::Key(ref key) = si.signer {
+                    if let Signer::AccountKey(ref key) = si.signer {
                         // 1.1. Constraint 1-to-1 account to DID
                         ensure!( Self::can_key_be_linked_to_did( key, si.signer_type),
                         "One signing key can only belong to one identity");
@@ -992,14 +993,14 @@ decl_module! {
                     ensure!( signature.verify( auth_encoded.as_slice(), &account_id),
                         "Invalid Authorization signature");
                 } else {
-                    return Err(Error::<T>::InvalidKey.into());
+                    return Err(Error::<T>::InvalidAccountKey.into());
                 }
             }
 
             // 2.1. Link keys to identity
             additional_keys.iter().for_each( |si_with_auth| {
                 let si = & si_with_auth.signing_item;
-                if let Signer::Key(ref key) = si.signer {
+                if let Signer::AccountKey(ref key) = si.signer {
                     Self::link_key_to_did( key, si.signer_type, id);
                 }
             });
@@ -1020,10 +1021,10 @@ decl_module! {
         /// It revokes the `auth` off-chain authorization of `signer`. It only takes effect if
         /// the authorized transaction is not yet executed.
         pub fn revoke_offchain_authorization(origin, signer: Signer, auth: TargetIdAuthorization<T::Moment>) -> DispatchResult {
-            let sender_key = Key::try_from( ensure_signed(origin)?.encode())?;
+            let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
 
             match signer {
-                Signer::Key(ref key) => ensure!( sender_key == *key, "This key is not allowed to revoke this off-chain authorization"),
+                Signer::AccountKey(ref key) => ensure!( sender_key == *key, "This key is not allowed to revoke this off-chain authorization"),
                 Signer::Identity(id) => ensure!( Self::is_master_key(id, &sender_key), "Only master key is allowed to revoke an Identity Signer off-chain authorization"),
             }
 
@@ -1038,7 +1039,7 @@ decl_module! {
         /// * `buffer_time` Buffer time corresponds to which kyc expiry need to check
         pub fn is_my_identity_has_valid_kyc(origin, buffer_time: u64) ->  DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_key = Key::try_from(sender.encode())?;
+            let sender_key = AccountKey::try_from(sender.encode())?;
             let my_did =  match Self::current_did() {
                 Some(x) => x,
                 None => {
@@ -1077,7 +1078,7 @@ decl_event!(
         SigningPermissionsUpdated(IdentityId, SigningItem, Vec<Permission>),
 
         /// DID, old master key account ID, new key
-        NewMasterKey(IdentityId, AccountId, Key),
+        NewMasterKey(IdentityId, AccountId, AccountKey),
 
         /// DID, claim issuer DID
         NewClaimIssuer(IdentityId, IdentityId),
@@ -1095,7 +1096,7 @@ decl_event!(
         NewIssuer(IdentityId),
 
         /// DID queried
-        DidQuery(Key, IdentityId),
+        DidQuery(AccountKey, IdentityId),
 
         /// To query the status of DID
         MyKycStatus(IdentityId, bool, Option<IdentityId>),
@@ -1111,9 +1112,9 @@ decl_event!(
 
         /// Authorization revoked or consumed. (auth_id, authorized_identity)
         AuthorizationRemoved(u64, Signer),
-        
+
         /// MasterKey changed (Requestor DID, New MasterKey)
-        MasterKeyChanged(IdentityId, Key),
+        MasterKeyChanged(IdentityId, AccountKey),
 
         /// New link added (link_id, associated identity or key, link_data, expiry)
         NewLink(
@@ -1146,7 +1147,7 @@ decl_error! {
         /// Given authorization is not pre-known
         UnknownAuthorization,
         /// Account Id cannot be extracted from signer
-        InvalidKey,
+        InvalidAccountKey,
     }
 }
 
@@ -1339,7 +1340,7 @@ impl<T: Trait> Module<T> {
 
         // Check master id or key
         match signer {
-            Signer::Key(ref signer_key) if record.master_key == *signer_key => true,
+            Signer::AccountKey(ref signer_key) if record.master_key == *signer_key => true,
             Signer::Identity(ref signer_id) if did == *signer_id => true,
             _ => {
                 // Check signing items if DID is not frozen.
@@ -1361,7 +1362,7 @@ impl<T: Trait> Module<T> {
         let record = <DidRecords>::get(did);
 
         match signer {
-            Signer::Key(ref signer_key) if record.master_key == *signer_key => true,
+            Signer::AccountKey(ref signer_key) if record.master_key == *signer_key => true,
             Signer::Identity(ref signer_id) if did == *signer_id => true,
             _ => {
                 if !Self::is_did_frozen(did) {
@@ -1382,7 +1383,7 @@ impl<T: Trait> Module<T> {
     }
 
     /// Use `did` as reference.
-    pub fn is_master_key(did: IdentityId, key: &Key) -> bool {
+    pub fn is_master_key(did: IdentityId, key: &AccountKey) -> bool {
         key == &<DidRecords>::get(did).master_key
     }
 
@@ -1452,7 +1453,7 @@ impl<T: Trait> Module<T> {
     /// # Return
     /// A result object containing the `DidRecord` of `did`.
     pub fn grant_check_only_master_key(
-        sender_key: &Key,
+        sender_key: &AccountKey,
         did: IdentityId,
     ) -> sp_std::result::Result<DidRecord, &'static str> {
         ensure!(<DidRecords>::exists(did), "DID does not exist");
@@ -1468,7 +1469,7 @@ impl<T: Trait> Module<T> {
     /// It checks if `key` is the master key or signing key of any did
     /// # Return
     /// An Option object containing the `did` that belongs to the key.
-    pub fn get_identity(key: &Key) -> Option<IdentityId> {
+    pub fn get_identity(key: &AccountKey) -> Option<IdentityId> {
         if let Some(linked_key_info) = <KeyToIdentityIds>::get(key) {
             if let LinkedKeyInfo::Unique(linked_id) = linked_key_info {
                 return Some(linked_id);
@@ -1486,7 +1487,7 @@ impl<T: Trait> Module<T> {
         did: IdentityId,
         freeze: bool,
     ) -> DispatchResult {
-        let sender_key = Key::try_from(ensure_signed(origin)?.encode())?;
+        let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
         let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
         if freeze {
@@ -1499,7 +1500,7 @@ impl<T: Trait> Module<T> {
 
     /// It checks that any sternal account can only be associated with at most one.
     /// Master keys are considered as external accounts.
-    pub fn can_key_be_linked_to_did(key: &Key, signer_type: SignerType) -> bool {
+    pub fn can_key_be_linked_to_did(key: &AccountKey, signer_type: SignerType) -> bool {
         if let Some(linked_key_info) = <KeyToIdentityIds>::get(key) {
             match linked_key_info {
                 LinkedKeyInfo::Unique(..) => false,
@@ -1514,7 +1515,7 @@ impl<T: Trait> Module<T> {
     /// # Errors
     /// This function can be used if `can_key_be_linked_to_did` returns true. Otherwise, it will do
     /// nothing.
-    fn link_key_to_did(key: &Key, key_type: SignerType, did: IdentityId) {
+    fn link_key_to_did(key: &AccountKey, key_type: SignerType, did: IdentityId) {
         if let Some(linked_key_info) = <KeyToIdentityIds>::get(key) {
             match linked_key_info {
                 LinkedKeyInfo::Group(mut dids) => {
@@ -1541,7 +1542,7 @@ impl<T: Trait> Module<T> {
 
     /// It unlinks the `key` key from `did`.
     /// If there is no more associated identities, its full entry is removed.
-    fn unlink_key_to_did(key: &Key, did: IdentityId) {
+    fn unlink_key_to_did(key: &AccountKey, did: IdentityId) {
         if let Some(linked_key_info) = <KeyToIdentityIds>::get(key) {
             match linked_key_info {
                 LinkedKeyInfo::Unique(..) => <KeyToIdentityIds>::remove(key),
@@ -1619,7 +1620,7 @@ impl<T: Trait> Module<T> {
         // Even if this transaction fails, nonce should be increased for added unpredictability of dids
         <MultiPurposeNonce>::put(&new_nonce);
 
-        let master_key = Key::try_from(sender.encode())?;
+        let master_key = AccountKey::try_from(sender.encode())?;
 
         // 1 Check constraints.
         // 1.1. Master key is not linked to any identity.
@@ -1642,7 +1643,7 @@ impl<T: Trait> Module<T> {
         ensure!(!<DidRecords>::exists(did), "DID must be unique");
         // 1.4. Signing keys can be linked to the new identity.
         for s_item in &signing_items {
-            if let Signer::Key(ref key) = s_item.signer {
+            if let Signer::AccountKey(ref key) = s_item.signer {
                 if !Self::can_key_be_linked_to_did(key, s_item.signer_type) {
                     return Err(Error::<T>::AlreadyLinked.into());
                 }
@@ -1672,18 +1673,18 @@ impl<T: Trait> Module<T> {
 }
 
 pub trait IdentityTrait<T> {
-    fn get_identity(key: &Key) -> Option<IdentityId>;
+    fn get_identity(key: &AccountKey) -> Option<IdentityId>;
     fn is_signer_authorized(did: IdentityId, signer: &Signer) -> bool;
     fn is_signer_authorized_with_permissions(
         did: IdentityId,
         signer: &Signer,
         permissions: Vec<Permission>,
     ) -> bool;
-    fn is_master_key(did: IdentityId, key: &Key) -> bool;
+    fn is_master_key(did: IdentityId, key: &AccountKey) -> bool;
 }
 
 impl<T: Trait> IdentityTrait<T::Balance> for Module<T> {
-    fn get_identity(key: &Key) -> Option<IdentityId> {
+    fn get_identity(key: &AccountKey) -> Option<IdentityId> {
         Self::get_identity(&key)
     }
 
@@ -1691,7 +1692,7 @@ impl<T: Trait> IdentityTrait<T::Balance> for Module<T> {
         Self::is_signer_authorized(did, signer)
     }
 
-    fn is_master_key(did: IdentityId, key: &Key) -> bool {
+    fn is_master_key(did: IdentityId, key: &AccountKey) -> bool {
         Self::is_master_key(did, &key)
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -48,7 +48,7 @@ pub mod config {
     pub type StakingConfig = pallet_staking::GenesisConfig<crate::Runtime>;
     pub type PolymeshCommitteeConfig =
         crate::committee::GenesisConfig<crate::Runtime, crate::committee::Instance1>;
-    pub type MIPSConfig = crate::mips::GenesisConfig<crate::Runtime>;
+    pub type MipsConfig = crate::mips::GenesisConfig<crate::Runtime>;
     pub type ContractsConfig = pallet_contracts::GenesisConfig<crate::Runtime>;
     pub type IndicesConfig = pallet_indices::GenesisConfig<crate::Runtime>;
     pub type SudoConfig = pallet_sudo::GenesisConfig<crate::Runtime>;

--- a/runtime/src/percentage_tm.rs
+++ b/runtime/src/percentage_tm.rs
@@ -24,7 +24,7 @@
 //! - `verify_restriction` - Checks if a transfer is a valid transfer and returns the result
 
 use crate::{asset::AssetTrait, balances, constants::*, exemption, identity, utils};
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 
 use codec::Encode;
 use core::result::Result as StdResult;
@@ -62,7 +62,7 @@ decl_module! {
 
         /// Set a maximum percentage that can be owned by a single investor
         fn toggle_maximum_percentage_restriction(origin, did: IdentityId, ticker: Ticker, max_percentage: u16) -> DispatchResult  {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -560,7 +560,7 @@ construct_runtime!(
         Treasury: pallet_treasury::{Module, Call, Storage, Event<T>},
         PolymeshCommittee: committee::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
         CommitteeMembership: group::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
-   		MIPS: mips::{Module, Call, Storage, Event<T>, Config<T>},
+   		Mips: mips::{Module, Call, Storage, Event<T>, Config<T>},
 
         //Polymesh
         Asset: asset::{Module, Call, Storage, Config<T>, Event<T>},
@@ -568,7 +568,7 @@ construct_runtime!(
         Identity: identity::{Module, Call, Storage, Event<T>, Config<T>},
         GeneralTM: general_tm::{Module, Call, Storage, Event},
         Voting: voting::{Module, Call, Storage, Event<T>},
-        STOCapped: sto_capped::{Module, Call, Storage, Event<T>},
+        StoCapped: sto_capped::{Module, Call, Storage, Event<T>},
         PercentageTM: percentage_tm::{Module, Call, Storage, Event<T>},
         Exemption: exemption::{Module, Call, Storage, Event},
         SimpleToken: simple_token::{Module, Call, Storage, Event<T>, Config<T>},

--- a/runtime/src/simple_token.rs
+++ b/runtime/src/simple_token.rs
@@ -32,7 +32,7 @@
 //! - `balance_of` - Returns the simple token balance associated with an identity
 
 use crate::{balances, identity, utils};
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 
 use codec::Encode;
 use sp_std::{convert::TryFrom, prelude::*};
@@ -76,7 +76,7 @@ decl_module! {
 
         /// Create a new token and mint a balance to the issuing identity
         pub fn create_token(origin, did: IdentityId, ticker: Ticker, total_supply: T::Balance) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -110,7 +110,7 @@ decl_module! {
 
         /// Approve another identity to transfer tokens on behalf of the caller
         fn approve(origin, did: IdentityId, ticker: Ticker, spender_did: IdentityId, value: T::Balance) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
             ticker.canonize();
             let ticker_did = (ticker, did.clone());
             ensure!(<BalanceOf<T>>::exists(&ticker_did), "Account does not own this token");
@@ -131,7 +131,7 @@ decl_module! {
         /// Transfer tokens to another identity
         pub fn transfer(origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, amount: T::Balance) -> DispatchResult {
             ticker.canonize();
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -141,7 +141,7 @@ decl_module! {
 
         /// Transfer tokens to another identity using the approval mechanic
         fn transfer_from(origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, amount: T::Balance) -> DispatchResult {
-            let spender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let spender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that spender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &spender), "spender must be a signing key for DID");

--- a/runtime/src/sto_capped.rs
+++ b/runtime/src/sto_capped.rs
@@ -33,7 +33,7 @@ use crate::{
     simple_token::{self, SimpleTokenTrait},
     utils,
 };
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 
 use codec::Encode;
 use frame_support::traits::Currency;
@@ -126,7 +126,7 @@ decl_module! {
             end_date: T::Moment,
             simple_token_ticker: Ticker
         ) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -179,7 +179,7 @@ decl_module! {
         /// * `value` Amount of POLY wants to invest in
         pub fn buy_tokens(origin, did: IdentityId, ticker: Ticker, sto_id: u32, value: T::Balance ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let sender_signer = Signer::Key(Key::try_from(sender.encode())?);
+            let sender_signer = Signer::AccountKey(AccountKey::try_from(sender.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -240,7 +240,7 @@ decl_module! {
         /// * `simple_token_ticker` Ticker of the stable coin
         /// * `modify_status` Boolean to know whether the provided simple token ticker will be used or not.
         pub fn modify_allowed_tokens(origin, did: IdentityId, ticker: Ticker, sto_id: u32, simple_token_ticker: Ticker, modify_status: bool) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             /// Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -290,7 +290,7 @@ decl_module! {
         /// * `value` Amount of POLY wants to invest in
         /// * `simple_token_ticker` Ticker of the simple token
         pub fn buy_tokens_by_simple_token(origin, did: IdentityId, ticker: Ticker, sto_id: u32, value: T::Balance, simple_token_ticker: Ticker) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -345,7 +345,7 @@ decl_module! {
         /// * `ticker` Ticker of the token
         /// * `sto_id` A unique identifier to know which STO needs to paused
         pub fn pause_sto(origin, did: IdentityId, ticker: Ticker, sto_id: u32) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");
@@ -372,7 +372,7 @@ decl_module! {
         /// * `ticker` Ticker of the token
         /// * `sto_id` A unique identifier to know which STO needs to un paused
         pub fn unpause_sto(origin, did: IdentityId, ticker: Ticker, sto_id: u32) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), "sender must be a signing key for DID");

--- a/runtime/src/sto_capped.rs
+++ b/runtime/src/sto_capped.rs
@@ -71,7 +71,7 @@ pub struct Investment<V, W> {
 }
 
 decl_storage! {
-    trait Store for Module<T: Trait> as STOCapped {
+    trait Store for Module<T: Trait> as StoCapped {
         /// Tokens can have multiple whitelists that (for now) check entries individually within each other
         /// (ticker, sto_id) -> STO
         StosByToken get(fn stos_by_token): map (Ticker, u32) => STO<T::Balance,T::Moment>;

--- a/runtime/src/test/identity_test.rs
+++ b/runtime/src/test/identity_test.rs
@@ -9,7 +9,7 @@ use crate::{
 use codec::Encode;
 use frame_support::{assert_err, assert_ok, traits::Currency};
 use primitives::{
-    AuthorizationData, Key, LinkData, Permission, Signer, SignerType, SigningItem, Ticker,
+    AccountKey, AuthorizationData, LinkData, Permission, Signer, SignerType, SigningItem, Ticker,
 };
 use rand::Rng;
 use sp_core::H512;
@@ -112,14 +112,14 @@ fn add_claims_batch() {
 fn only_master_or_signing_keys_can_authenticate_as_an_identity() {
     build_ext().execute_with(|| {
         let owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
-        let owner_signer = Signer::Key(Key::from(AccountKeyring::Alice.public().0));
+        let owner_signer = Signer::AccountKey(AccountKey::from(AccountKeyring::Alice.public().0));
 
         let a_did = register_keyring_account(AccountKeyring::Bob).unwrap();
         let a = Origin::signed(AccountKeyring::Bob.public());
         let b_did = register_keyring_account(AccountKeyring::Dave).unwrap();
 
-        let charlie_key = Key::from(AccountKeyring::Charlie.public().0);
-        let charlie_signer = Signer::Key(charlie_key);
+        let charlie_key = AccountKey::from(AccountKeyring::Charlie.public().0);
+        let charlie_signer = Signer::AccountKey(charlie_key);
         let charlie_signing_item =
             SigningItem::new(charlie_signer.clone(), vec![Permission::Admin]);
 
@@ -197,8 +197,8 @@ fn only_master_key_can_add_signing_key_permissions() {
 }
 
 fn only_master_key_can_add_signing_key_permissions_with_externalities() {
-    let bob_key = Key::from(AccountKeyring::Bob.public().0);
-    let charlie_key = Key::from(AccountKeyring::Charlie.public().0);
+    let bob_key = AccountKey::from(AccountKeyring::Bob.public().0);
+    let charlie_key = AccountKey::from(AccountKeyring::Charlie.public().0);
     let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
     let alice = Origin::signed(AccountKeyring::Alice.public());
     let bob = Origin::signed(AccountKeyring::Bob.public());
@@ -216,13 +216,13 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
         alice_did,
-        Signer::Key(bob_key),
+        Signer::AccountKey(bob_key),
         vec![Permission::Operator]
     ));
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
         alice_did,
-        Signer::Key(charlie_key),
+        Signer::AccountKey(charlie_key),
         vec![Permission::Admin, Permission::Operator]
     ));
 
@@ -231,7 +231,7 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
         Identity::set_permission_to_signer(
             bob.clone(),
             alice_did,
-            Signer::Key(bob_key),
+            Signer::AccountKey(bob_key),
             vec![Permission::Full]
         ),
         "Only master key of an identity is able to execute this operation"
@@ -239,7 +239,7 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
 
     // Bob tries to remove Charlie's permissions at `alice` Identity.
     assert_err!(
-        Identity::set_permission_to_signer(bob, alice_did, Signer::Key(charlie_key), vec![]),
+        Identity::set_permission_to_signer(bob, alice_did, Signer::AccountKey(charlie_key), vec![]),
         "Only master key of an identity is able to execute this operation"
     );
 
@@ -247,7 +247,7 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
     assert_ok!(Identity::set_permission_to_signer(
         alice,
         alice_did,
-        Signer::Key(bob_key),
+        Signer::AccountKey(bob_key),
         vec![]
     ));
 }
@@ -260,17 +260,17 @@ fn add_signing_keys_with_specific_type() {
 /// It tests that signing key can be added using non-default key type
 /// (`SignerType::External`).
 fn add_signing_keys_with_specific_type_with_externalities() {
-    let charlie_key = Key::from(AccountKeyring::Charlie.public().0);
-    let dave_key = Key::from(AccountKeyring::Dave.public().0);
+    let charlie_key = AccountKey::from(AccountKeyring::Charlie.public().0);
+    let dave_key = AccountKey::from(AccountKeyring::Dave.public().0);
 
     // Create keys using non-default type.
     let charlie_signing_key = SigningItem {
-        signer: Signer::Key(charlie_key),
+        signer: Signer::AccountKey(charlie_key),
         signer_type: SignerType::Relayer,
         permissions: vec![],
     };
     let dave_signing_key = SigningItem {
-        signer: Signer::Key(dave_key),
+        signer: Signer::AccountKey(dave_key),
         signer_type: SignerType::MultiSig,
         permissions: vec![],
     };
@@ -301,17 +301,17 @@ fn freeze_signing_keys_test() {
 
 fn freeze_signing_keys_with_externalities() {
     let (bob_key, charlie_key, dave_key) = (
-        Key::from(AccountKeyring::Bob.public().0),
-        Key::from(AccountKeyring::Charlie.public().0),
-        Key::from(AccountKeyring::Dave.public().0),
+        AccountKey::from(AccountKeyring::Bob.public().0),
+        AccountKey::from(AccountKeyring::Charlie.public().0),
+        AccountKey::from(AccountKeyring::Dave.public().0),
     );
     let bob = Origin::signed(AccountKeyring::Bob.public());
     let charlie = Origin::signed(AccountKeyring::Charlie.public());
     let dave = Origin::signed(AccountKeyring::Dave.public());
 
-    let bob_signing_key = SigningItem::new(Signer::Key(bob_key), vec![Permission::Admin]);
+    let bob_signing_key = SigningItem::new(Signer::AccountKey(bob_key), vec![Permission::Admin]);
     let charlie_signing_key =
-        SigningItem::new(Signer::Key(charlie_key), vec![Permission::Operator]);
+        SigningItem::new(Signer::AccountKey(charlie_key), vec![Permission::Operator]);
     let dave_signing_key = SigningItem::from(dave_key);
 
     // Add signing keys.
@@ -331,7 +331,7 @@ fn freeze_signing_keys_with_externalities() {
     ));
 
     assert_eq!(
-        Identity::is_signer_authorized(alice_did, &Signer::Key(bob_key)),
+        Identity::is_signer_authorized(alice_did, &Signer::AccountKey(bob_key)),
         true
     );
 
@@ -343,7 +343,7 @@ fn freeze_signing_keys_with_externalities() {
     assert_ok!(Identity::freeze_signing_keys(alice.clone(), alice_did));
 
     assert_eq!(
-        Identity::is_signer_authorized(alice_did, &Signer::Key(bob_key)),
+        Identity::is_signer_authorized(alice_did, &Signer::AccountKey(bob_key)),
         false
     );
 
@@ -356,7 +356,7 @@ fn freeze_signing_keys_with_externalities() {
     ));
     assert_ok!(Identity::authorize_join_to_identity(dave, alice_did));
     assert_eq!(
-        Identity::is_signer_authorized(alice_did, &Signer::Key(dave_key)),
+        Identity::is_signer_authorized(alice_did, &Signer::AccountKey(dave_key)),
         false
     );
 
@@ -364,7 +364,7 @@ fn freeze_signing_keys_with_externalities() {
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
         alice_did,
-        Signer::Key(bob_key),
+        Signer::AccountKey(bob_key),
         vec![Permission::Operator]
     ));
 
@@ -376,7 +376,7 @@ fn freeze_signing_keys_with_externalities() {
     assert_ok!(Identity::unfreeze_signing_keys(alice.clone(), alice_did));
 
     assert_eq!(
-        Identity::is_signer_authorized(alice_did, &Signer::Key(dave_key)),
+        Identity::is_signer_authorized(alice_did, &Signer::AccountKey(dave_key)),
         true
     );
 }
@@ -389,13 +389,13 @@ fn remove_frozen_signing_keys_test() {
 
 fn remove_frozen_signing_keys_with_externalities() {
     let (bob_key, charlie_key) = (
-        Key::from(AccountKeyring::Bob.public().0),
-        Key::from(AccountKeyring::Charlie.public().0),
+        AccountKey::from(AccountKeyring::Bob.public().0),
+        AccountKey::from(AccountKeyring::Charlie.public().0),
     );
 
-    let bob_signing_key = SigningItem::new(Signer::Key(bob_key), vec![Permission::Admin]);
+    let bob_signing_key = SigningItem::new(Signer::AccountKey(bob_key), vec![Permission::Admin]);
     let charlie_signing_key =
-        SigningItem::new(Signer::Key(charlie_key), vec![Permission::Operator]);
+        SigningItem::new(Signer::AccountKey(charlie_key), vec![Permission::Operator]);
 
     // Add signing keys.
     let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
@@ -423,7 +423,7 @@ fn remove_frozen_signing_keys_with_externalities() {
     assert_ok!(Identity::remove_signing_items(
         alice.clone(),
         alice_did,
-        vec![Signer::Key(bob_key)]
+        vec![Signer::AccountKey(bob_key)]
     ));
     // Check DidRecord.
     let did_rec = Identity::did_records(alice_did);
@@ -443,8 +443,8 @@ fn enforce_uniqueness_keys_in_identity() {
     let bob = Origin::signed(AccountKeyring::Bob.public());
 
     // Check external signed key uniqueness.
-    let charlie_key = Key::from(AccountKeyring::Charlie.public().0);
-    let charlie_sk = SigningItem::new(Signer::Key(charlie_key), vec![Permission::Operator]);
+    let charlie_key = AccountKey::from(AccountKeyring::Charlie.public().0);
+    let charlie_sk = SigningItem::new(Signer::AccountKey(charlie_key), vec![Permission::Operator]);
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
         alice_id,
@@ -461,9 +461,9 @@ fn enforce_uniqueness_keys_in_identity() {
     );
 
     // Check non-external signed key non-uniqueness.
-    let dave_key = Key::from(AccountKeyring::Dave.public().0);
+    let dave_key = AccountKey::from(AccountKeyring::Dave.public().0);
     let dave_sk = SigningItem {
-        signer: Signer::Key(dave_key),
+        signer: Signer::AccountKey(dave_key),
         signer_type: SignerType::MultiSig,
         permissions: vec![Permission::Operator],
     };
@@ -479,9 +479,9 @@ fn enforce_uniqueness_keys_in_identity() {
     ));
 
     // Check that master key acts like external signed key.
-    let bob_key = Key::from(AccountKeyring::Bob.public().0);
+    let bob_key = AccountKey::from(AccountKeyring::Bob.public().0);
     let bob_sk_as_mutisig = SigningItem {
-        signer: Signer::Key(bob_key),
+        signer: Signer::AccountKey(bob_key),
         signer_type: SignerType::MultiSig,
         permissions: vec![Permission::Operator],
     };
@@ -490,7 +490,7 @@ fn enforce_uniqueness_keys_in_identity() {
         Error::<TestStorage>::AlreadyLinked
     );
 
-    let bob_sk = SigningItem::new(Signer::Key(bob_key), vec![Permission::Admin]);
+    let bob_sk = SigningItem::new(Signer::AccountKey(bob_key), vec![Permission::Admin]);
     assert_err!(
         Identity::add_signing_items(alice.clone(), alice_id, vec![bob_sk]),
         Error::<TestStorage>::AlreadyLinked
@@ -556,15 +556,15 @@ fn two_step_join_id_with_ext() {
     let bob = Origin::signed(AccountKeyring::Bob.public());
 
     let c_sk = SigningItem::new(
-        Signer::Key(Key::from(AccountKeyring::Charlie.public().0)),
+        Signer::AccountKey(AccountKey::from(AccountKeyring::Charlie.public().0)),
         vec![Permission::Operator],
     );
     let d_sk = SigningItem::new(
-        Signer::Key(Key::from(AccountKeyring::Dave.public().0)),
+        Signer::AccountKey(AccountKey::from(AccountKeyring::Dave.public().0)),
         vec![Permission::Full],
     );
     let e_sk = SigningItem::new(
-        Signer::Key(Key::from(AccountKeyring::Eve.public().0)),
+        Signer::AccountKey(AccountKey::from(AccountKeyring::Eve.public().0)),
         vec![Permission::Full],
     );
 
@@ -974,7 +974,7 @@ fn changing_master_key() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
 
         let target_did = register_keyring_account(AccountKeyring::Bob).unwrap();
-        let new_key = Key::from(AccountKeyring::Bob.public().0);
+        let new_key = AccountKey::from(AccountKeyring::Bob.public().0);
         let new_key_origin = Origin::signed(AccountKeyring::Bob.public());
 
         let kyc_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
@@ -983,28 +983,28 @@ fn changing_master_key() {
         // Master key matches Alice's key
         assert_eq!(
             Identity::did_records(alice_did).master_key,
-            Key::from(AccountKeyring::Alice.public().0)
+            AccountKey::from(AccountKeyring::Alice.public().0)
         );
 
         // Alice triggers change of master key
         assert_ok!(Identity::add_authorization_as_key(
             alice.clone(),
-            Signer::Key(new_key),
+            Signer::AccountKey(new_key),
             AuthorizationData::RotateMasterKey(alice_did),
             None,
         ));
 
-        let owner_auth_id = Identity::last_authorization(Signer::Key(new_key));
+        let owner_auth_id = Identity::last_authorization(Signer::AccountKey(new_key));
 
         // Charlie a KYC provider approves the change
         assert_ok!(Identity::add_authorization(
             kyc.clone(),
-            Signer::Key(new_key),
+            Signer::AccountKey(new_key),
             AuthorizationData::AttestMasterKeyRotation(alice_did),
             None,
         ));
 
-        let kyc_auth_id = Identity::last_authorization(Signer::Key(new_key));
+        let kyc_auth_id = Identity::last_authorization(Signer::AccountKey(new_key));
 
         // Accept the authorization with the new key
         assert_ok!(Identity::accept_master_key(
@@ -1016,7 +1016,7 @@ fn changing_master_key() {
         // Alice's master key is now Bob's
         assert_eq!(
             Identity::did_records(alice_did).master_key,
-            Key::from(AccountKeyring::Bob.public().0)
+            AccountKey::from(AccountKeyring::Bob.public().0)
         );
     });
 }

--- a/runtime/src/test/multisig.rs
+++ b/runtime/src/test/multisig.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use codec::Encode;
 use frame_support::{assert_err, assert_ok};
-use primitives::{Key, Signer};
+use primitives::{AccountKey, Signer};
 use std::convert::TryFrom;
 use test_client::AccountKeyring;
 
@@ -63,7 +63,7 @@ fn join_multisig() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob = Origin::signed(AccountKeyring::Bob.public());
         let bob_signer =
-            Signer::from(Key::try_from(AccountKeyring::Bob.public().encode()).unwrap());
+            Signer::from(AccountKey::try_from(AccountKeyring::Bob.public().encode()).unwrap());
 
         let musig_address = MultiSig::get_next_multisig_address(AccountKeyring::Alice.public());
 
@@ -112,7 +112,7 @@ fn change_multisig_sigs_required() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob = Origin::signed(AccountKeyring::Bob.public());
         let bob_signer =
-            Signer::from(Key::try_from(AccountKeyring::Bob.public().encode()).unwrap());
+            Signer::from(AccountKey::try_from(AccountKeyring::Bob.public().encode()).unwrap());
 
         let musig_address = MultiSig::get_next_multisig_address(AccountKeyring::Alice.public());
 
@@ -170,7 +170,7 @@ fn remove_multisig_signer() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob = Origin::signed(AccountKeyring::Bob.public());
         let bob_signer =
-            Signer::from(Key::try_from(AccountKeyring::Bob.public().encode()).unwrap());
+            Signer::from(AccountKey::try_from(AccountKeyring::Bob.public().encode()).unwrap());
 
         let musig_address = MultiSig::get_next_multisig_address(AccountKeyring::Alice.public());
 
@@ -230,7 +230,7 @@ fn add_multisig_signer() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob = Origin::signed(AccountKeyring::Bob.public());
         let bob_signer =
-            Signer::from(Key::try_from(AccountKeyring::Bob.public().encode()).unwrap());
+            Signer::from(AccountKey::try_from(AccountKeyring::Bob.public().encode()).unwrap());
 
         let musig_address = MultiSig::get_next_multisig_address(AccountKeyring::Alice.public());
 

--- a/runtime/src/test/storage.rs
+++ b/runtime/src/test/storage.rs
@@ -8,7 +8,7 @@ use frame_support::{
     traits::Currency,
 };
 use frame_system::{self as system, EnsureSignedBy};
-use primitives::{IdentityId, Key, Signer};
+use primitives::{AccountKey, IdentityId, Signer};
 use sp_core::{
     crypto::{key_types, Pair as PairTrait},
     sr25519::Pair,
@@ -288,7 +288,7 @@ pub fn make_account_with_balance(
     Balances::make_free_balance_be(&id, balance);
 
     Identity::register_did(signed_id.clone(), vec![]).map_err(|_| "Register DID failed")?;
-    let did = Identity::get_identity(&Key::try_from(id.encode())?).unwrap();
+    let did = Identity::get_identity(&AccountKey::try_from(id.encode())?).unwrap();
 
     Ok((signed_id, did))
 }
@@ -307,7 +307,7 @@ pub fn register_keyring_account_with_balance(
     Identity::register_did(Origin::signed(acc_pub.clone()), vec![])
         .map_err(|_| "Register DID failed")?;
 
-    let acc_key = Key::from(acc_pub.0);
+    let acc_key = AccountKey::from(acc_pub.0);
     let did =
         Identity::get_identity(&acc_key).ok_or_else(|| "Key cannot be generated from account")?;
 

--- a/runtime/src/update_did_signed_extension.rs
+++ b/runtime/src/update_did_signed_extension.rs
@@ -1,5 +1,5 @@
 use crate::{identity, identity::LinkedKeyInfo, runtime, Runtime};
-use primitives::{IdentityId, Key, TransactionError};
+use primitives::{AccountKey, IdentityId, TransactionError};
 
 use sp_runtime::{
     traits::SignedExtension,
@@ -28,7 +28,7 @@ impl<T: frame_system::Trait + Send + Sync> UpdateDid<T> {
 
     /// It extracts the `IdentityId` associated with `who` account.
     fn identity_from_key(who: &T::AccountId) -> Option<IdentityId> {
-        if let Ok(who_key) = Key::try_from(who.encode()) {
+        if let Ok(who_key) = AccountKey::try_from(who.encode()) {
             if let Some(linked_key_info) = Identity::key_to_identity_ids(&who_key) {
                 if let LinkedKeyInfo::Unique(id) = linked_key_info {
                     return Some(id);

--- a/runtime/src/voting.rs
+++ b/runtime/src/voting.rs
@@ -39,7 +39,7 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
 use frame_system::{self as system, ensure_signed};
-use primitives::{IdentityId, Key, Signer, Ticker};
+use primitives::{AccountKey, IdentityId, Signer, Ticker};
 use sp_std::{convert::TryFrom, prelude::*};
 
 /// The module's configuration trait.
@@ -119,7 +119,7 @@ decl_module! {
         /// * `ballot_name` - Name of the ballot
         /// * `ballot_details` - Other details of the ballot
         pub fn add_ballot(origin, did: IdentityId, ticker: Ticker, ballot_name: Vec<u8>, ballot_details: Ballot<T::Moment>) -> DispatchResult {
-            let sender = Signer::Key(Key::try_from(ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), Error::<T>::InvalidSigner);
@@ -172,7 +172,7 @@ decl_module! {
         /// * `ballot_name` - Name of the ballot
         /// * `votes` - The actual vote to be cast
         pub fn vote(origin, did: IdentityId, ticker: Ticker, ballot_name: Vec<u8>, votes: Vec<T::Balance>) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), Error::<T>::InvalidSigner);
@@ -242,7 +242,7 @@ decl_module! {
         /// * `ticker` - Ticker of the token for which ballot is to be cancelled
         /// * `ballot_name` - Name of the ballot
         pub fn cancel_ballot(origin, did: IdentityId, ticker: Ticker, ballot_name: Vec<u8>) -> DispatchResult {
-            let sender = Signer::Key( Key::try_from( ensure_signed(origin)?.encode())?);
+            let sender = Signer::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender), Error::<T>::InvalidSigner);
@@ -588,7 +588,7 @@ mod tests {
         let signed_id = Origin::signed(account_id.clone());
         Balances::make_free_balance_be(&account_id, 1_000_000);
         Identity::register_did(signed_id.clone(), vec![]);
-        let did = Identity::get_identity(&Key::try_from(account_id.encode())?).unwrap();
+        let did = Identity::get_identity(&AccountKey::try_from(account_id.encode())?).unwrap();
         Ok((signed_id, did))
     }
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -9,7 +9,7 @@ use polymesh_runtime::constants::{currency::MILLICENTS, currency::POLY};
 use polymesh_runtime::{
     config::{
         AssetConfig, BalancesConfig, ContractsConfig, GenesisConfig, IdentityConfig, IndicesConfig,
-        MIPSConfig, SessionConfig, SimpleTokenConfig, StakingConfig, SudoConfig, SystemConfig,
+        MipsConfig, SessionConfig, SimpleTokenConfig, StakingConfig, SudoConfig, SystemConfig,
     },
     runtime::CommitteeMembershipConfig,
     runtime::KYCServiceProvidersConfig,
@@ -275,7 +275,7 @@ fn testnet_genesis(
             slash_reward_fraction: Perbill::from_percent(10),
             ..Default::default()
         }),
-        mips: Some(MIPSConfig {
+        mips: Some(MipsConfig {
             min_proposal_deposit: 5000,
             quorum_threshold: 100000,
             proposal_duration: 50,


### PR DESCRIPTION
`STOCapped`, `MIPS`, `ReferendumInfo`, `Key` and `Votes` renamed