### PR TITLE
Refactored authorizations and links

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -130,16 +130,10 @@ decl_storage! {
         pub RevokeOffChainAuthorization get(fn is_offchain_authorization_revoked): map (Signatory, TargetIdAuthorization<T::Moment>) => bool;
 
         /// All authorizations that an identity has
-        pub Authorizations get(fn authorizations): map(Signatory, u64) => Authorization<T::Moment>;
-
-        /// Auth id of the latest auth of an identity. Used to allow iterating over auths
-        pub LastAuthorization get(fn last_authorization): map Signatory => u64;
+        pub Authorizations: double_map hasher(blake2_256) Signatory, blake2_256(u64) => Authorization<T::Moment>;
 
         /// All links that an identity/key has
-        pub Links get(fn links): map(Signatory, u64) => Link<T::Moment>;
-
-        /// Link id of the latest auth of an identity/key. Used to allow iterating over links
-        pub LastLink get(fn last_link): map Signatory => u64;
+        pub Links: double_map hasher(blake2_256) Signatory, blake2_256(u64) => Link<T::Moment>;
     }
 }
 
@@ -260,11 +254,11 @@ decl_module! {
             let signer = Signatory::from(sender_key);
 
             // When both authorizations are present...
-            ensure!(<Authorizations<T>>::exists((signer, rotation_auth_id)), "Invalid authorization from owner");
-            ensure!(<Authorizations<T>>::exists((signer, kyc_auth_id)), "Invalid authorization from KYC service provider");
+            ensure!(<Authorizations<T>>::exists(signer, rotation_auth_id), "Invalid authorization from owner");
+            ensure!(<Authorizations<T>>::exists(signer, kyc_auth_id), "Invalid authorization from KYC service provider");
 
             // Accept authorization from the owner
-            let rotation_auth = Self::authorizations((signer, rotation_auth_id));
+            let rotation_auth = <Authorizations<T>>::get(signer, rotation_auth_id);
             if let AuthorizationData::RotateMasterKey(rotation_for_did) = rotation_auth.authorization_data {
                 // Ensure the request was made by the owner of master key
                 match rotation_auth.authorized_by {
@@ -276,7 +270,7 @@ decl_module! {
                 };
 
                 // Aceept authorization from KYC service provider
-                let kyc_auth = Self::authorizations((signer, kyc_auth_id));
+                let kyc_auth = <Authorizations<T>>::get(signer, kyc_auth_id);
                 if let AuthorizationData::AttestMasterKeyRotation(attestation_for_did) = kyc_auth.authorization_data {
                     // Attestor must be a KYC service provider
                     let kyc_provider_did = match kyc_auth.authorized_by {
@@ -617,13 +611,13 @@ decl_module! {
                 }
             };
 
-            ensure!(<Authorizations<T>>::exists((target, auth_id)), "Invalid auth");
+            ensure!(<Authorizations<T>>::exists(target, auth_id), "Invalid auth");
 
-            let auth = Self::authorizations((target, auth_id));
+            let auth = <Authorizations<T>>::get(target, auth_id);
 
             ensure!(auth.authorized_by.eq_either(&from_did, &sender_key) || target.eq_either(&from_did, &sender_key) , "Unauthorized");
 
-            Self::remove_auth(target, auth_id, auth.next_authorization, auth.previous_authorization);
+            Self::remove_auth(target, auth_id);
 
             Ok(())
         }
@@ -647,16 +641,14 @@ decl_module! {
             };
 
             for auth_identifier in &auth_identifiers {
-                ensure!(<Authorizations<T>>::exists(auth_identifier), "Invalid auth");
+                ensure!(<Authorizations<T>>::exists(&auth_identifier.0, &auth_identifier.1), "Invalid auth");
 
-                let auth = Self::authorizations(auth_identifier);
+                let auth = <Authorizations<T>>::get(&auth_identifier.0, &auth_identifier.1);
                 ensure!(auth.authorized_by.eq_either(&from_did, &sender_key) || auth_identifier.0.eq_either(&from_did, &sender_key) , "Unauthorized");
             }
 
             for auth_identifier in auth_identifiers {
-                let auth = Self::authorizations(&auth_identifier);
-
-                Self::remove_auth(auth_identifier.0, auth_identifier.1, auth.next_authorization, auth.previous_authorization);
+                Self::remove_auth(auth_identifier.0, auth_identifier.1);
             }
 
             Ok(())
@@ -679,8 +671,8 @@ decl_module! {
                 }
             };
 
-            ensure!(<Authorizations<T>>::exists((signer, auth_id)), "Invalid auth");
-            let auth = Self::authorizations((signer, auth_id));
+            ensure!(<Authorizations<T>>::exists(signer, auth_id), "Invalid auth");
+            let auth = <Authorizations<T>>::get(signer, auth_id);
 
             match signer {
                 Signatory::Identity(did) => {
@@ -726,8 +718,8 @@ decl_module! {
                     for auth_id in auth_ids {
                         // NB: Even if an auth is invalid (due to any reason), this batch function does NOT return an error.
                         // It will just skip that particular authorization.
-                        if <Authorizations<T>>::exists((signer, auth_id)) {
-                            let auth = Self::authorizations((signer, auth_id));
+                        if <Authorizations<T>>::exists(signer, auth_id) {
+                            let auth = <Authorizations<T>>::get(signer, auth_id);
                             // NB: Result is not handled, invalid auths are just ignored to let the batch function continue.
                             let _result = match auth.authorization_data {
                                 AuthorizationData::TransferTicker(_) =>
@@ -745,8 +737,8 @@ decl_module! {
                     for auth_id in auth_ids {
                         // NB: Even if an auth is invalid (due to any reason), this batch function does NOT return an error.
                         // It will just skip that particular authorization.
-                        if <Authorizations<T>>::exists((signer, auth_id)) {
-                            let auth = Self::authorizations((signer, auth_id));
+                        if <Authorizations<T>>::exists(signer, auth_id) {
+                            let auth = <Authorizations<T>>::get(signer, auth_id);
                             //NB: Result is not handled, invalid auths are just ignored to let the batch function continue.
                             let _result = match auth.authorization_data {
                                 AuthorizationData::AddMultiSigSigner =>
@@ -994,30 +986,18 @@ impl<T: Trait> Module<T> {
         target: Signatory,
         authorization_data: AuthorizationData,
         expiry: Option<T::Moment>,
-    ) {
+    ) -> u64 {
         let new_nonce = Self::multi_purpose_nonce() + 1u64;
         <MultiPurposeNonce>::put(&new_nonce);
-
-        let last_auth = Self::last_authorization(&target);
-
-        if last_auth > 0 {
-            //0 means no previous auth. 0 is the default value.
-            // Changing the last auth to point to new auth as next auth.
-            <Authorizations<T>>::mutate((target, last_auth), |last_authorization| {
-                last_authorization.next_authorization = new_nonce
-            });
-        }
 
         let auth = Authorization {
             authorization_data: authorization_data.clone(),
             authorized_by: from,
             expiry: expiry,
-            next_authorization: 0,
-            previous_authorization: last_auth,
+            auth_id: new_nonce,
         };
 
-        <LastAuthorization>::insert(&target, new_nonce);
-        <Authorizations<T>>::insert((target, new_nonce), auth);
+        <Authorizations<T>>::insert(target, new_nonce, auth);
 
         Self::deposit_event(RawEvent::NewAuthorization(
             new_nonce,
@@ -1026,38 +1006,24 @@ impl<T: Trait> Module<T> {
             authorization_data,
             expiry,
         ));
+        new_nonce
     }
 
     /// Remove any authorization. No questions asked.
     /// NB: Please do all the required checks before calling this function.
-    pub fn remove_auth(target: Signatory, auth_id: u64, next_auth: u64, previous_auth: u64) {
-        if next_auth != 0 {
-            // update next auth's previous auth to point to previous auth of this auth
-            <Authorizations<T>>::mutate((target, next_auth), |next_auth| {
-                next_auth.previous_authorization = previous_auth
-            });
-        } else {
-            // this was the last auth. update last auth to be previous auth.
-            <LastAuthorization>::insert(&target, previous_auth);
-        }
-        if previous_auth != 0 {
-            // update previous auth's next auth to point to next auth of this auth
-            <Authorizations<T>>::mutate((target, previous_auth), |prev_auth| {
-                prev_auth.next_authorization = next_auth
-            });
-        }
-        <Authorizations<T>>::remove((target, auth_id));
+    pub fn remove_auth(target: Signatory, auth_id: u64) {
+        <Authorizations<T>>::remove(target, auth_id);
         Self::deposit_event(RawEvent::AuthorizationRemoved(auth_id, target));
     }
 
     /// Consumes an authorization.
     /// Checks if the auth has not expired and the caller is authorized to consume this auth.
     pub fn consume_auth(from: Signatory, target: Signatory, auth_id: u64) -> DispatchResult {
-        if !<Authorizations<T>>::exists((target, auth_id)) {
+        if !<Authorizations<T>>::exists(target, auth_id) {
             // Auth does not exist
             return Err(AuthorizationError::Invalid.into());
         }
-        let auth = Self::authorizations((target, auth_id));
+        let auth = <Authorizations<T>>::get(target, auth_id);
         if auth.authorized_by != from {
             // Not authorized to revoke this authorization
             return Err(AuthorizationError::Unauthorized.into());
@@ -1070,11 +1036,17 @@ impl<T: Trait> Module<T> {
         }
         Self::remove_auth(
             target,
-            auth_id,
-            auth.next_authorization,
-            auth.previous_authorization,
+            auth_id
         );
         Ok(())
+    }
+
+    pub fn get_authorization(target: Signatory, auth_id: u64) -> Authorization<T::Moment> {
+        <Authorizations<T>>::get(target, auth_id)
+    }
+
+    pub fn get_link(target: Signatory, link_id: u64) -> Link<T::Moment> {
+        <Links<T>>::get(target, link_id)
     }
 
     /// Adds a link to a key or an identity
@@ -1083,25 +1055,13 @@ impl<T: Trait> Module<T> {
         let new_nonce = Self::multi_purpose_nonce() + 1u64;
         <MultiPurposeNonce>::put(&new_nonce);
 
-        let last_link = Self::last_link(&target);
-
-        if last_link > 0 {
-            // 0 means no previous link. 0 is the default value.
-            // Changing the last link to point to new link as next link.
-            <Links<T>>::mutate((target, last_link), |last_link| {
-                last_link.next_link = new_nonce
-            });
-        }
-
         let link = Link {
             link_data: link_data.clone(),
             expiry: expiry,
-            next_link: 0,
-            previous_link: last_link,
+            link_id: new_nonce,
         };
 
-        <LastLink>::insert(&target, new_nonce);
-        <Links<T>>::insert((target, new_nonce), link);
+        <Links<T>>::insert(target, new_nonce, link);
 
         Self::deposit_event(RawEvent::NewLink(new_nonce, target, link_data, expiry));
         new_nonce
@@ -1110,24 +1070,8 @@ impl<T: Trait> Module<T> {
     /// Remove a link (if it exists) from a key or identity
     /// NB: Please do all the required checks before calling this function.
     pub fn remove_link(target: Signatory, link_id: u64) {
-        if <Links<T>>::exists((target, link_id)) {
-            let link = Self::links((target, link_id));
-            if link.next_link != 0 {
-                // update next link's previous link to point to previous link of this link
-                <Links<T>>::mutate((target, link.next_link), |next_link| {
-                    next_link.previous_link = link.previous_link
-                });
-            } else {
-                // this was the last link. update last link to be previous link.
-                <LastLink>::insert(&target, link.previous_link);
-            }
-            if link.previous_link != 0 {
-                // update previous link's next link to point to next link of this link
-                <Links<T>>::mutate((target, link.previous_link), |prev_link| {
-                    prev_link.next_link = link.next_link
-                });
-            }
-            <Links<T>>::remove((target, link_id));
+        if <Links<T>>::exists(target, link_id) {
+            <Links<T>>::remove(target, link_id);
             Self::deposit_event(RawEvent::LinkRemoved(link_id, target));
         }
     }
@@ -1135,8 +1079,8 @@ impl<T: Trait> Module<T> {
     /// Update link data (if it exists) from a key or identity
     /// NB: Please do all the required checks before calling this function.
     pub fn update_link(target: Signatory, link_id: u64, link_data: LinkData) {
-        if <Links<T>>::exists((target, link_id)) {
-            <Links<T>>::mutate((target, link_id), |link| link.link_data = link_data);
+        if <Links<T>>::exists(target, link_id) {
+            <Links<T>>::mutate(target, link_id, |link| link.link_data = link_data);
 
             Self::deposit_event(RawEvent::LinkUpdated(link_id, target));
         }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1034,10 +1034,7 @@ impl<T: Trait> Module<T> {
                 return Err(AuthorizationError::Expired.into());
             }
         }
-        Self::remove_auth(
-            target,
-            auth_id
-        );
+        Self::remove_auth(target, auth_id);
         Ok(())
     }
 

--- a/pallets/runtime/src/asset.rs
+++ b/pallets/runtime/src/asset.rs
@@ -1907,11 +1907,11 @@ impl<T: Trait> Module<T> {
     /// Accept and process a ticker transfer
     pub fn _accept_ticker_transfer(to_did: IdentityId, auth_id: u64) -> DispatchResult {
         ensure!(
-            <identity::Authorizations<T>>::exists((Signatory::from(to_did), auth_id)),
+            <identity::Authorizations<T>>::exists(Signatory::from(to_did), auth_id),
             AuthorizationError::from(AuthorizationError::Invalid)
         );
 
-        let auth = <identity::Module<T>>::authorizations((Signatory::from(to_did), auth_id));
+        let auth = <identity::Authorizations<T>>::get(Signatory::from(to_did), auth_id);
 
         let ticker = match auth.authorization_data {
             AuthorizationData::TransferTicker(ticker) => {
@@ -1958,11 +1958,11 @@ impl<T: Trait> Module<T> {
     /// Accept and process a token ownership transfer
     pub fn _accept_token_ownership_transfer(to_did: IdentityId, auth_id: u64) -> DispatchResult {
         ensure!(
-            <identity::Authorizations<T>>::exists((Signatory::from(to_did), auth_id)),
+            <identity::Authorizations<T>>::exists(Signatory::from(to_did), auth_id),
             AuthorizationError::from(AuthorizationError::Invalid)
         );
 
-        let auth = <identity::Module<T>>::authorizations((Signatory::from(to_did), auth_id));
+        let auth = <identity::Authorizations<T>>::get(Signatory::from(to_did), auth_id);
 
         let ticker = match auth.authorization_data {
             AuthorizationData::TransferTokenOwnership(ticker) => {

--- a/pallets/runtime/src/multisig.rs
+++ b/pallets/runtime/src/multisig.rs
@@ -366,11 +366,11 @@ impl<T: Trait> Module<T> {
     /// Accept and process addition of a signer to a multisig
     pub fn _accept_multisig_signer(signer: Signatory, auth_id: u64) -> DispatchResult {
         ensure!(
-            <identity::Authorizations<T>>::exists((signer, auth_id)),
+            <identity::Authorizations<T>>::exists(signer, auth_id),
             AuthorizationError::Invalid
         );
 
-        let auth = <identity::Module<T>>::authorizations((signer, auth_id));
+        let auth = <identity::Authorizations<T>>::get(signer, auth_id);
 
         ensure!(
             auth.authorization_data == AuthorizationData::AddMultiSigSigner,

--- a/pallets/runtime/src/test/asset_test.rs
+++ b/pallets/runtime/src/test/asset_test.rs
@@ -15,13 +15,15 @@ use polymesh_runtime_balances as balances;
 use polymesh_runtime_identity as identity;
 
 use codec::Encode;
-use frame_support::{assert_err, assert_noop, assert_ok, traits::Currency, StorageMap};
+use frame_support::{
+    assert_err, assert_noop, assert_ok, traits::Currency, StorageDoubleMap, StorageMap,
+};
 use sp_runtime::AnySignature;
 use test_client::AccountKeyring;
 
 use chrono::prelude::Utc;
 use rand::Rng;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, mem};
 
 type Identity = identity::Module<TestStorage>;
 type Balances = balances::Module<TestStorage>;
@@ -80,17 +82,17 @@ fn issuers_can_create_and_rename_tokens() {
             Some(funding_round_name.clone())
         ));
 
-        let token_link = Identity::links((
+        let token_link = Identity::get_link(
             Signatory::from(owner_did),
             Asset::token_details(ticker).link_id,
-        ));
+        );
         assert_eq!(token_link.link_data, LinkData::TokenOwned(ticker));
         assert_eq!(token_link.expiry, None);
 
-        let ticker_link = Identity::links((
+        let ticker_link = Identity::get_link(
             Signatory::from(owner_did),
             Asset::ticker_registration(ticker).link_id,
-        ));
+        );
         assert_eq!(ticker_link.link_data, LinkData::TickerOwned(ticker));
         assert_eq!(ticker_link.expiry, None);
 
@@ -111,7 +113,7 @@ fn issuers_can_create_and_rename_tokens() {
         // The token should remain unchanged in storage.
         assert_eq!(Asset::token_details(ticker), token);
         // Rename the token and check storage has been updated.
-        let mut renamed_token = SecurityToken {
+        let renamed_token = SecurityToken {
             name: vec![0x42],
             owner_did: token.owner_did,
             total_supply: token.total_supply,
@@ -779,10 +781,10 @@ fn register_ticker() {
 
         assert_ok!(Asset::register_ticker(owner_signed.clone(), ticker));
 
-        let ticker_link = Identity::links((
+        let ticker_link = Identity::get_link(
             Signatory::from(owner_did),
             Asset::ticker_registration(ticker).link_id,
-        ));
+        );
         assert_eq!(ticker_link.link_data, LinkData::TickerOwned(ticker));
 
         let (alice_signed, _) = make_account(AccountKeyring::Alice.public()).unwrap();
@@ -817,14 +819,14 @@ fn transfer_ticker() {
         assert_eq!(Asset::is_ticker_available(&ticker), true);
         assert_ok!(Asset::register_ticker(owner_signed.clone(), ticker));
 
-        Identity::add_auth(
+        let auth_id_alice = Identity::add_auth(
             Signatory::from(owner_did),
             Signatory::from(alice_did),
             AuthorizationData::TransferTicker(ticker),
             None,
         );
 
-        Identity::add_auth(
+        let auth_id_bob = Identity::add_auth(
             Signatory::from(owner_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTicker(ticker),
@@ -835,68 +837,65 @@ fn transfer_ticker() {
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, alice_did), false);
         assert_eq!(Asset::is_ticker_available(&ticker), false);
 
-        let mut auth_id = Identity::last_authorization(Signatory::from(alice_did));
-
         assert_err!(
-            Asset::accept_ticker_transfer(alice_signed.clone(), auth_id + 1),
+            Asset::accept_ticker_transfer(alice_signed.clone(), auth_id_alice + 1),
             "Authorization does not exist"
         );
 
         let old_ticker = Asset::ticker_registration(ticker);
         let old_ticker_link =
-            Identity::links((Signatory::from(old_ticker.owner), old_ticker.link_id));
+            Identity::get_link(Signatory::from(old_ticker.owner), old_ticker.link_id);
         assert_eq!(old_ticker_link.link_data, LinkData::TickerOwned(ticker));
 
-        assert_ok!(Asset::accept_ticker_transfer(alice_signed.clone(), auth_id));
+        assert_ok!(Asset::accept_ticker_transfer(
+            alice_signed.clone(),
+            auth_id_alice
+        ));
 
-        assert!(!<identity::Links<TestStorage>>::exists((
+        assert!(!<identity::Links<TestStorage>>::exists(
             Signatory::from(old_ticker.owner),
             old_ticker.link_id
-        )));
+        ));
 
-        let ticker_link = Identity::links((
+        let ticker_link = Identity::get_link(
             Signatory::from(alice_did),
             Asset::ticker_registration(ticker).link_id,
-        ));
+        );
         assert_eq!(ticker_link.link_data, LinkData::TickerOwned(ticker));
 
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
-            Asset::accept_ticker_transfer(bob_signed.clone(), auth_id),
+            Asset::accept_ticker_transfer(bob_signed.clone(), auth_id_bob),
             "Illegal use of Authorization"
         );
 
-        Identity::add_auth(
+        let mut auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTicker(ticker),
             Some(now.timestamp() as u64 - 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
             Asset::accept_ticker_transfer(bob_signed.clone(), auth_id),
             "Authorization expired"
         );
 
-        Identity::add_auth(
+        auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::Custom(ticker),
             Some(now.timestamp() as u64 + 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
             Asset::accept_ticker_transfer(bob_signed.clone(), auth_id),
             AssetError::NoTickerTransferAuth
         );
 
-        Identity::add_auth(
+        auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTicker(ticker),
             Some(now.timestamp() as u64 + 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_ok!(Asset::accept_ticker_transfer(bob_signed.clone(), auth_id));
 
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner_did), false);
@@ -930,14 +929,14 @@ fn transfer_token_ownership() {
             None
         ));
 
-        Identity::add_auth(
+        let auth_id_alice = Identity::add_auth(
             Signatory::from(owner_did),
             Signatory::from(alice_did),
             AuthorizationData::TransferTokenOwnership(ticker),
             None,
         );
 
-        Identity::add_auth(
+        let auth_id_bob = Identity::add_auth(
             Signatory::from(owner_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTokenOwnership(ticker),
@@ -946,97 +945,90 @@ fn transfer_token_ownership() {
 
         assert_eq!(Asset::token_details(&ticker).owner_did, owner_did);
 
-        let mut auth_id = Identity::last_authorization(Signatory::from(alice_did));
-
         assert_err!(
-            Asset::accept_token_ownership_transfer(alice_signed.clone(), auth_id + 1),
+            Asset::accept_token_ownership_transfer(alice_signed.clone(), auth_id_alice + 1),
             "Authorization does not exist"
         );
 
         let old_ticker = Asset::ticker_registration(ticker);
         let old_ticker_link =
-            Identity::links((Signatory::from(old_ticker.owner), old_ticker.link_id));
+            Identity::get_link(Signatory::from(old_ticker.owner), old_ticker.link_id);
         assert_eq!(old_ticker_link.link_data, LinkData::TickerOwned(ticker));
 
         let old_token = Asset::token_details(ticker);
         let old_token_link =
-            Identity::links((Signatory::from(old_token.owner_did), old_token.link_id));
+            Identity::get_link(Signatory::from(old_token.owner_did), old_token.link_id);
         assert_eq!(old_token_link.link_data, LinkData::TokenOwned(ticker));
 
         assert_ok!(Asset::accept_token_ownership_transfer(
             alice_signed.clone(),
-            auth_id
+            auth_id_alice
         ));
         assert_eq!(Asset::token_details(&ticker).owner_did, alice_did);
-        assert!(!<identity::Links<TestStorage>>::exists((
+        assert!(!<identity::Links<TestStorage>>::exists(
             Signatory::from(old_ticker.owner),
             old_ticker.link_id
-        )));
-        assert!(!<identity::Links<TestStorage>>::exists((
+        ));
+        assert!(!<identity::Links<TestStorage>>::exists(
             Signatory::from(old_token.owner_did),
             old_token.link_id
-        )));
+        ));
 
-        let ticker_link = Identity::links((
+        let ticker_link = Identity::get_link(
             Signatory::from(alice_did),
             Asset::ticker_registration(ticker).link_id,
-        ));
+        );
         assert_eq!(ticker_link.link_data, LinkData::TickerOwned(ticker));
-        let token_link = Identity::links((
+        let token_link = Identity::get_link(
             Signatory::from(alice_did),
             Asset::token_details(ticker).link_id,
-        ));
+        );
         assert_eq!(token_link.link_data, LinkData::TokenOwned(ticker));
 
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
-            Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id),
+            Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id_bob),
             "Illegal use of Authorization"
         );
 
-        Identity::add_auth(
+        let mut auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTokenOwnership(ticker),
             Some(now.timestamp() as u64 - 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
             Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id),
             "Authorization expired"
         );
 
-        Identity::add_auth(
+        auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::Custom(ticker),
             Some(now.timestamp() as u64 + 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
             Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id),
             AssetError::NotTickerOwnershipTransferAuth
         );
 
-        Identity::add_auth(
+        auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTokenOwnership(Ticker::from_slice(&[0x50])),
             Some(now.timestamp() as u64 + 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_err!(
             Asset::accept_token_ownership_transfer(bob_signed.clone(), auth_id),
             "Token does not exist"
         );
 
-        Identity::add_auth(
+        auth_id = Identity::add_auth(
             Signatory::from(alice_did),
             Signatory::from(bob_did),
             AuthorizationData::TransferTokenOwnership(ticker),
             Some(now.timestamp() as u64 + 100),
         );
-        auth_id = Identity::last_authorization(Signatory::from(bob_did));
         assert_ok!(Asset::accept_token_ownership_transfer(
             bob_signed.clone(),
             auth_id
@@ -1158,21 +1150,32 @@ fn adding_removing_documents() {
             documents
         ));
 
-        let last_id = Identity::last_link(Signatory::from(ticker_did));
-        let last_doc = Identity::links((Signatory::from(ticker_did), last_id));
+        let mut docs = <identity::Links<TestStorage>>::iter_prefix(Signatory::from(ticker_did));
+        let mut doc1 = docs.next().unwrap();
+        let mut doc2 = docs.next().unwrap();
+        if doc1.link_id > doc2.link_id {
+            mem::swap(&mut doc1, &mut doc2);
+        }
 
         assert_eq!(
-            last_doc.link_data,
+            doc1.link_data,
+            LinkData::DocumentOwned(Document {
+                name: b"A".to_vec(),
+                uri: b"www.a.com".to_vec(),
+                hash: b"0x1".to_vec(),
+            })
+        );
+        assert_eq!(doc1.expiry, None);
+
+        assert_eq!(
+            doc2.link_data,
             LinkData::DocumentOwned(Document {
                 name: b"B".to_vec(),
                 uri: b"www.b.com".to_vec(),
                 hash: b"0x2".to_vec()
             })
         );
-        assert_eq!(last_doc.next_link, 0);
-        assert_eq!(last_doc.expiry, None);
-
-        let doc_ids = vec![last_id, last_doc.previous_link];
+        assert_eq!(doc2.expiry, None);
 
         assert_ok!(Asset::update_documents(
             owner_signed.clone(),
@@ -1180,7 +1183,7 @@ fn adding_removing_documents() {
             ticker,
             vec![
                 (
-                    doc_ids[0],
+                    doc1.link_id,
                     Document {
                         name: b"C".to_vec(),
                         uri: b"www.c.com".to_vec(),
@@ -1188,7 +1191,7 @@ fn adding_removing_documents() {
                     }
                 ),
                 (
-                    doc_ids[1],
+                    doc2.link_id,
                     Document {
                         name: b"D".to_vec(),
                         uri: b"www.d.com".to_vec(),
@@ -1198,26 +1201,32 @@ fn adding_removing_documents() {
             ]
         ));
 
-        let last_id = Identity::last_link(Signatory::from(ticker_did));
-        let last_doc = Identity::links((Signatory::from(ticker_did), last_id));
+        docs = <identity::Links<TestStorage>>::iter_prefix(Signatory::from(ticker_did));
+        doc1 = docs.next().unwrap();
+        doc2 = docs.next().unwrap();
+        if doc1.link_id > doc2.link_id {
+            mem::swap(&mut doc1, &mut doc2);
+        }
 
         assert_eq!(
-            last_doc.link_data,
+            doc1.link_data,
             LinkData::DocumentOwned(Document {
                 name: b"C".to_vec(),
                 uri: b"www.c.com".to_vec(),
                 hash: b"0x3".to_vec(),
             })
         );
+        assert_eq!(doc1.expiry, None);
 
-        assert_ok!(Asset::remove_documents(
-            owner_signed.clone(),
-            owner_did,
-            ticker,
-            doc_ids
-        ));
-
-        assert_eq!(Identity::last_link(Signatory::from(ticker_did)), 0);
+        assert_eq!(
+            doc2.link_data,
+            LinkData::DocumentOwned(Document {
+                name: b"D".to_vec(),
+                uri: b"www.d.com".to_vec(),
+                hash: b"0x4".to_vec(),
+            })
+        );
+        assert_eq!(doc2.expiry, None);
     });
 }
 
@@ -1778,27 +1787,26 @@ fn freeze_unfreeze_asset() {
             Asset::freeze(alice_signed.clone(), ticker),
             "asset must not already be frozen"
         );
-        // Attempt to transfer token ownership.
-        Identity::add_auth(
-            Signatory::from(alice_did),
-            Signatory::from(bob_did),
-            AuthorizationData::TransferTokenOwnership(ticker),
-            None,
-        );
-        let auth_id = Identity::last_authorization(Signatory::from(bob_did));
         // Attempt to mint tokens.
         assert_err!(
             Asset::issue(alice_signed.clone(), alice_did, ticker, bob_did, 1, vec![]),
             "asset is frozen"
         );
-        assert_ok!(Asset::accept_token_ownership_transfer(
-            bob_signed.clone(),
-            auth_id
-        ));
         assert_err!(
             Asset::transfer(alice_signed.clone(), alice_did, ticker, bob_did, 1),
             "asset is frozen"
         );
+        // Attempt to transfer token ownership.
+        let auth_id = Identity::add_auth(
+            Signatory::from(alice_did),
+            Signatory::from(bob_did),
+            AuthorizationData::TransferTokenOwnership(ticker),
+            None,
+        );
+        assert_ok!(Asset::accept_token_ownership_transfer(
+            bob_signed.clone(),
+            auth_id
+        ));
         // `batch_issue` fails when the vector of recipients is not empty.
         assert_err!(
             Asset::batch_issue(bob_signed.clone(), bob_did, ticker, vec![bob_did], vec![1]),

--- a/pallets/runtime/src/test/identity_test.rs
+++ b/pallets/runtime/src/test/identity_test.rs
@@ -15,7 +15,7 @@ use polymesh_runtime_common::traits::identity::{
 use polymesh_runtime_identity::{self as identity, Error};
 
 use codec::Encode;
-use frame_support::{assert_err, assert_ok, traits::Currency};
+use frame_support::{assert_err, assert_ok, traits::Currency, StorageDoubleMap};
 
 use sp_core::H512;
 use test_client::AccountKeyring;
@@ -805,6 +805,10 @@ fn adding_authorizations() {
             AuthorizationData::TransferTicker(ticker50),
             None,
         );
+        assert_eq!(
+            <identity::AuthorizationsGiven>::get(alice_did, auth_id),
+            bob_did
+        );
         let mut auth = Identity::get_authorization(bob_did, auth_id);
         assert_eq!(auth.authorized_by, alice_did);
         assert_eq!(auth.expiry, None);
@@ -817,6 +821,10 @@ fn adding_authorizations() {
             bob_did,
             AuthorizationData::TransferTicker(ticker50),
             Some(100),
+        );
+        assert_eq!(
+            <identity::AuthorizationsGiven>::get(alice_did, auth_id),
+            bob_did
         );
         auth = Identity::get_authorization(bob_did, auth_id);
         assert_eq!(auth.authorized_by, alice_did);
@@ -841,6 +849,10 @@ fn removing_authorizations() {
             AuthorizationData::TransferTicker(ticker50),
             None,
         );
+        assert_eq!(
+            <identity::AuthorizationsGiven>::get(alice_did, auth_id),
+            bob_did
+        );
         let auth = Identity::get_authorization(bob_did, auth_id);
         assert_eq!(
             auth.authorization_data,
@@ -851,8 +863,10 @@ fn removing_authorizations() {
             bob_did,
             auth_id
         ));
-        let removed_auth = Identity::get_authorization(bob_did, auth_id);
-        assert_eq!(removed_auth.authorization_data, AuthorizationData::NoData);
+        assert!(!<identity::AuthorizationsGiven>::exists(alice_did, auth_id));
+        assert!(!<identity::Authorizations<TestStorage>>::exists(
+            bob_did, auth_id
+        ));
     });
 }
 

--- a/pallets/runtime/src/test/identity_test.rs
+++ b/pallets/runtime/src/test/identity_test.rs
@@ -799,82 +799,20 @@ fn adding_authorizations() {
         let alice_did = Signatory::from(register_keyring_account(AccountKeyring::Alice).unwrap());
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob_did = Signatory::from(register_keyring_account(AccountKeyring::Bob).unwrap());
-        let charlie_did =
-            Signatory::from(register_keyring_account(AccountKeyring::Charlie).unwrap());
-        let charlie = Origin::signed(AccountKeyring::Charlie.public());
         let ticker50 = Ticker::from_slice(&[0x50]);
-        let ticker51 = Ticker::from_slice(&[0x51]);
-        let mut auth_ids_bob = Vec::new();
-        auth_ids_bob.push(0); // signifies that there are no more auths left
-        assert_ok!(Identity::add_authorization(
+        let auth_id = Identity::add_auth(
             alice.clone(),
             bob_did,
             AuthorizationData::TransferTicker(ticker50),
             None,
-        ));
-        auth_ids_bob.push(Identity::last_authorization(bob_did));
-        assert_ok!(Identity::add_authorization(
-            alice.clone(),
-            bob_did,
-            AuthorizationData::TransferTicker(ticker51),
-            None,
-        ));
-        auth_ids_bob.push(Identity::last_authorization(bob_did));
-        assert_ok!(Identity::add_authorization(
-            alice,
-            bob_did,
-            AuthorizationData::TransferTicker(ticker50),
-            Some(100),
-        ));
-        auth_ids_bob.push(Identity::last_authorization(bob_did));
-        assert_ok!(Identity::add_authorization(
-            charlie,
-            bob_did,
-            AuthorizationData::TransferTicker(ticker50),
-            Some(100),
-        ));
-        auth_ids_bob.push(Identity::last_authorization(bob_did));
-        auth_ids_bob.push(0); // signifies that there are no more auths left
-        for i in 1..(auth_ids_bob.len() - 1) {
-            let auth = Identity::authorizations((bob_did, auth_ids_bob[i]));
-            assert_eq!(auth.previous_authorization, auth_ids_bob[i - 1]);
-            assert_eq!(auth.next_authorization, auth_ids_bob[i + 1]);
-            match i {
-                1 => {
-                    assert_eq!(auth.authorized_by, alice_did);
-                    assert_eq!(auth.expiry, None);
-                    assert_eq!(
-                        auth.authorization_data,
-                        AuthorizationData::TransferTicker(ticker50)
-                    );
-                }
-                2 => {
-                    assert_eq!(auth.authorized_by, alice_did);
-                    assert_eq!(auth.expiry, None);
-                    assert_eq!(
-                        auth.authorization_data,
-                        AuthorizationData::TransferTicker(ticker51)
-                    );
-                }
-                3 => {
-                    assert_eq!(auth.authorized_by, alice_did);
-                    assert_eq!(auth.expiry, Some(100));
-                    assert_eq!(
-                        auth.authorization_data,
-                        AuthorizationData::TransferTicker(ticker50)
-                    );
-                }
-                4 => {
-                    assert_eq!(auth.authorized_by, charlie_did);
-                    assert_eq!(auth.expiry, Some(100));
-                    assert_eq!(
-                        auth.authorization_data,
-                        AuthorizationData::TransferTicker(ticker50)
-                    );
-                }
-                _ => {}
-            }
-        }
+        );
+        let auth = Identity::get_authorization(bob_did, auth_id);
+        assert_eq!(auth.authorized_by, alice_did);
+        assert_eq!(auth.expiry, None);
+        assert_eq!(
+            auth.authorization_data,
+            AuthorizationData::TransferTicker(ticker50)
+        );
     });
 }
 
@@ -885,45 +823,24 @@ fn removing_authorizations() {
         let alice = Origin::signed(AccountKeyring::Alice.public());
         let bob_did = Signatory::from(register_keyring_account(AccountKeyring::Bob).unwrap());
         let ticker50 = Ticker::from_slice(&[0x50]);
-        let mut auth_ids_bob = Vec::new();
-        auth_ids_bob.push(0); // signifies that there are no more auths left
-        for _ in 0..10 {
-            assert_ok!(Identity::add_authorization(
-                alice.clone(),
-                bob_did,
-                AuthorizationData::TransferTicker(ticker50),
-                None,
-            ));
-            auth_ids_bob.push(Identity::last_authorization(bob_did));
-        }
-        auth_ids_bob.push(0); // signifies that there are no more auths left
-        let mut rng = rand::thread_rng();
-        for _ in 0..10 {
-            let auth_to_remove = rng.gen_range(1, auth_ids_bob.len() - 1);
-            let auth = Identity::authorizations((bob_did, auth_ids_bob[auth_to_remove]));
-            assert_eq!(
-                auth.authorization_data,
-                AuthorizationData::TransferTicker(ticker50)
-            );
-            assert_eq!(
-                auth.previous_authorization,
-                auth_ids_bob[auth_to_remove - 1]
-            );
-            assert_eq!(auth.next_authorization, auth_ids_bob[auth_to_remove + 1]);
-            assert_ok!(Identity::remove_authorization(
-                alice.clone(),
-                bob_did,
-                auth_ids_bob[auth_to_remove]
-            ));
-            let removed_auth = Identity::authorizations((bob_did, auth_ids_bob[auth_to_remove]));
-            assert_eq!(removed_auth.authorization_data, AuthorizationData::NoData);
-            auth_ids_bob.remove(auth_to_remove);
-            for i in 1..(auth_ids_bob.len() - 1) {
-                let auth = Identity::authorizations((bob_did, auth_ids_bob[i]));
-                assert_eq!(auth.previous_authorization, auth_ids_bob[i - 1]);
-                assert_eq!(auth.next_authorization, auth_ids_bob[i + 1]);
-            }
-        }
+        let auth_id = Identity::add_auth(
+            alice.clone(),
+            bob_did,
+            AuthorizationData::TransferTicker(ticker50),
+            None,
+        );
+        let auth = Identity::get_authorization(bob_did, auth_id);
+        assert_eq!(
+            auth.authorization_data,
+            AuthorizationData::TransferTicker(ticker50)
+        );
+        assert_ok!(Identity::remove_authorization(
+            alice.clone(),
+            bob_did,
+            auth_id
+        ));
+        let removed_auth = Identity::get_authorization(bob_did, auth_id);
+        assert_eq!(removed_auth.authorization_data, AuthorizationData::NoData);
     });
 }
 
@@ -932,42 +849,22 @@ fn adding_links() {
     ExtBuilder::default().build().execute_with(|| {
         let bob_did = Signatory::from(register_keyring_account(AccountKeyring::Bob).unwrap());
         let ticker50 = Ticker::from_slice(&[0x50]);
-        let ticker51 = Ticker::from_slice(&[0x51]);
-        let mut link_ids_bob = Vec::new();
-        link_ids_bob.push(0); // signifies that there are no more links left
-        Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), None);
-        link_ids_bob.push(Identity::last_link(bob_did));
-        Identity::add_link(bob_did, LinkData::TickerOwned(ticker51), None);
-        link_ids_bob.push(Identity::last_link(bob_did));
-        Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), Some(100));
-        link_ids_bob.push(Identity::last_link(bob_did));
-        Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), Some(100));
-        link_ids_bob.push(Identity::last_link(bob_did));
-        link_ids_bob.push(0); // signifies that there are no more links left
-        for i in 1..(link_ids_bob.len() - 1) {
-            let link = Identity::links((bob_did, link_ids_bob[i]));
-            assert_eq!(link.previous_link, link_ids_bob[i - 1]);
-            assert_eq!(link.next_link, link_ids_bob[i + 1]);
-            match i {
-                1 => {
-                    assert_eq!(link.expiry, None);
-                    assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
-                }
-                2 => {
-                    assert_eq!(link.expiry, None);
-                    assert_eq!(link.link_data, LinkData::TickerOwned(ticker51));
-                }
-                3 => {
-                    assert_eq!(link.expiry, Some(100));
-                    assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
-                }
-                4 => {
-                    assert_eq!(link.expiry, Some(100));
-                    assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
-                }
-                _ => {}
-            }
-        }
+        let mut link_id = Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), None);
+        let mut link = Identity::get_link(bob_did, link_id);
+        assert_eq!(link.expiry, None);
+        assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
+        link_id = Identity::add_link(bob_did, LinkData::TickerOwned(ticker51), None);
+        link = Identity::get_link(bob_did, link_id);
+        assert_eq!(link.expiry, None);
+        assert_eq!(link.link_data, LinkData::TickerOwned(ticker51));
+        link_id = Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), Some(100));
+        link = Identity::get_link(bob_did, link_id);
+        assert_eq!(link.expiry, Some(100));
+        assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
+        link_id = Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), Some(100));
+        link = Identity::get_link(bob_did, link_id);
+        assert_eq!(link.expiry, Some(100));
+        assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
     });
 }
 
@@ -976,30 +873,12 @@ fn removing_links() {
     ExtBuilder::default().build().execute_with(|| {
         let bob_did = Signatory::from(register_keyring_account(AccountKeyring::Bob).unwrap());
         let ticker50 = Ticker::from_slice(&[0x50]);
-        let mut link_ids_bob = Vec::new();
-        link_ids_bob.push(0); // signifies that there are no more links left
-        for _ in 0..10 {
-            Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), None);
-            link_ids_bob.push(Identity::last_link(bob_did));
-        }
-        link_ids_bob.push(0); // signifies that there are no more links left
-        let mut rng = rand::thread_rng();
-        for _ in 0..10 {
-            let link_to_remove = rng.gen_range(1, link_ids_bob.len() - 1);
-            let link = Identity::links((bob_did, link_ids_bob[link_to_remove]));
-            assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
-            assert_eq!(link.previous_link, link_ids_bob[link_to_remove - 1]);
-            assert_eq!(link.next_link, link_ids_bob[link_to_remove + 1]);
-            Identity::remove_link(bob_did, link_ids_bob[link_to_remove]);
-            let removed_link = Identity::links((bob_did, link_ids_bob[link_to_remove]));
-            assert_eq!(removed_link.link_data, LinkData::NoData);
-            link_ids_bob.remove(link_to_remove);
-            for i in 1..(link_ids_bob.len() - 1) {
-                let link = Identity::links((bob_did, link_ids_bob[i]));
-                assert_eq!(link.previous_link, link_ids_bob[i - 1]);
-                assert_eq!(link.next_link, link_ids_bob[i + 1]);
-            }
-        }
+        let link_id = Identity::add_link(bob_did, LinkData::TickerOwned(ticker50), None);
+        let link = Identity::get_link(bob_did, link_id);
+        assert_eq!(link.link_data, LinkData::TickerOwned(ticker50));
+        Identity::remove_link(bob_did, link_id);
+        let removed_link = Identity::get_link(bob_did, link_id);
+        assert_eq!(removed_link.link_data, LinkData::NoData);
     });
 }
 

--- a/pallets/runtime/src/test/multisig.rs
+++ b/pallets/runtime/src/test/multisig.rs
@@ -9,7 +9,7 @@ use polymesh_primitives::{AccountKey, Signatory};
 use polymesh_runtime_identity as identity;
 
 use codec::Encode;
-use frame_support::{assert_err, assert_ok};
+use frame_support::{assert_err, assert_ok, StorageDoubleMap};
 use std::convert::TryFrom;
 use test_client::AccountKeyring;
 
@@ -88,14 +88,25 @@ fn join_multisig() {
             false
         );
 
+        let alice_auth_id =
+            <identity::Authorizations<TestStorage>>::iter_prefix(Signatory::from(alice_did))
+                .next()
+                .unwrap()
+                .auth_id;
+
         assert_ok!(MultiSig::accept_multisig_signer_as_identity(
             alice.clone(),
-            Identity::last_authorization(Signatory::from(alice_did))
+            alice_auth_id
         ));
+
+        let bob_auth_id = <identity::Authorizations<TestStorage>>::iter_prefix(bob_signer)
+            .next()
+            .unwrap()
+            .auth_id;
 
         assert_ok!(MultiSig::accept_multisig_signer_as_key(
             bob.clone(),
-            Identity::last_authorization(bob_signer)
+            bob_auth_id
         ));
 
         assert_eq!(
@@ -127,14 +138,25 @@ fn change_multisig_sigs_required() {
             2,
         ));
 
+        let alice_auth_id =
+            <identity::Authorizations<TestStorage>>::iter_prefix(Signatory::from(alice_did))
+                .next()
+                .unwrap()
+                .auth_id;
+
         assert_ok!(MultiSig::accept_multisig_signer_as_identity(
             alice.clone(),
-            Identity::last_authorization(Signatory::from(alice_did))
+            alice_auth_id
         ));
+
+        let bob_auth_id = <identity::Authorizations<TestStorage>>::iter_prefix(bob_signer)
+            .next()
+            .unwrap()
+            .auth_id;
 
         assert_ok!(MultiSig::accept_multisig_signer_as_key(
             bob.clone(),
-            Identity::last_authorization(bob_signer)
+            bob_auth_id
         ));
 
         assert_eq!(
@@ -185,14 +207,25 @@ fn remove_multisig_signer() {
             1,
         ));
 
+        let alice_auth_id =
+            <identity::Authorizations<TestStorage>>::iter_prefix(Signatory::from(alice_did))
+                .next()
+                .unwrap()
+                .auth_id;
+
         assert_ok!(MultiSig::accept_multisig_signer_as_identity(
             alice.clone(),
-            Identity::last_authorization(Signatory::from(alice_did))
+            alice_auth_id
         ));
+
+        let bob_auth_id = <identity::Authorizations<TestStorage>>::iter_prefix(bob_signer)
+            .next()
+            .unwrap()
+            .auth_id;
 
         assert_ok!(MultiSig::accept_multisig_signer_as_key(
             bob.clone(),
-            Identity::last_authorization(bob_signer)
+            bob_auth_id
         ));
 
         assert_eq!(
@@ -245,9 +278,15 @@ fn add_multisig_signer() {
             1,
         ));
 
+        let alice_auth_id =
+            <identity::Authorizations<TestStorage>>::iter_prefix(Signatory::from(alice_did))
+                .next()
+                .unwrap()
+                .auth_id;
+
         assert_ok!(MultiSig::accept_multisig_signer_as_identity(
             alice.clone(),
-            Identity::last_authorization(Signatory::from(alice_did))
+            alice_auth_id
         ));
 
         assert_eq!(
@@ -279,9 +318,14 @@ fn add_multisig_signer() {
             false
         );
 
+        let bob_auth_id = <identity::Authorizations<TestStorage>>::iter_prefix(bob_signer)
+            .next()
+            .unwrap()
+            .auth_id;
+
         assert_ok!(MultiSig::accept_multisig_signer_as_key(
             bob.clone(),
-            Identity::last_authorization(bob_signer)
+            bob_auth_id
         ));
 
         assert_eq!(

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -48,8 +48,7 @@
     "Link": {
         "link_data": "LinkData",
         "expiry": "Option<Moment>",
-        "next_link": "u64",
-        "previous_link": "u64"
+        "link_id": "u64",
     },
     "LinkData": {
        "_enum": {
@@ -254,8 +253,7 @@
         "authorization_data": "AuthorizationData",
         "authorized_by": "IdentityId",
         "expiry": "Option<Moment>",
-        "next_authorization": "u64",
-        "previous_authorization": "u64"
+        "auth_id": "u64",
     },
     "AuthorizationData": {
         "_enum": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -48,7 +48,7 @@
     "Link": {
         "link_data": "LinkData",
         "expiry": "Option<Moment>",
-        "link_id": "u64",
+        "link_id": "u64"
     },
     "LinkData": {
        "_enum": {
@@ -251,9 +251,9 @@
     },
     "Authorization": {
         "authorization_data": "AuthorizationData",
-        "authorized_by": "IdentityId",
+        "authorized_by": "Signatory",
         "expiry": "Option<Moment>",
-        "auth_id": "u64",
+        "auth_id": "u64"
     },
     "AuthorizationData": {
         "_enum": {
@@ -265,6 +265,10 @@
             "Custom": "Vec<u8>",
             "NoData": ""
         }
+    },
+    "AuthIdentifier": {
+        "signatory": "Signatory",
+        "auth_id": "u64"
     },
     "Compliance": {
         "_enum": [

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -65,11 +65,6 @@ pub struct Authorization<U> {
     /// time when this authorization expires. optional.
     pub expiry: Option<U>,
 
-    // Extra data to allow iterating over the authorizations.
-    /// Authorization number of the next Authorization.
-    /// Authorization number starts with 1.
-    pub next_authorization: u64,
-    /// Authorization number of the previous Authorization.
-    /// Authorization number starts with 1.
-    pub previous_authorization: u64,
+    /// Authorization id of this authorization
+    pub auth_id: u64,
 }

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -68,3 +68,7 @@ pub struct Authorization<U> {
     /// Authorization id of this authorization
     pub auth_id: u64,
 }
+
+/// Data required to fetch and authorization
+#[derive(Encode, Decode, Clone, Default, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub struct AuthIdentifier(pub Signatory, pub u64);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -87,6 +87,7 @@ pub use pre_authorized_key_info::PreAuthorizedKeyInfo;
 pub mod authorization;
 /// Pub Traits
 pub mod traits;
+pub use authorization::AuthIdentifier;
 pub use authorization::Authorization;
 pub use authorization::AuthorizationData;
 pub use authorization::AuthorizationError;

--- a/primitives/src/link.rs
+++ b/primitives/src/link.rs
@@ -30,11 +30,6 @@ pub struct Link<U> {
     /// time when this Link expires. optional.
     pub expiry: Option<U>,
 
-    // Extra data to allow iterating over the Links.
-    /// Link number of the next Link.
-    /// Link number starts with 1.
-    pub next_link: u64,
-    /// Link number of the previous Link.
-    /// Link number starts with 1.
-    pub previous_link: u64,
+    /// Link id of this link
+    pub link_id: u64,
 }


### PR DESCRIPTION
Authorizations and links now use double_map. That allows us to not store next and previous links and still be able to iterate over them.

In polkadot.js, `entries` function will fetch all auths/links
Example: `api.query.identity.authorizations.entries(alice)` will fetch all authorizations that alice has.

Also added ability to fetch auths given by a particular user.