### PR TITLE
Improve circleci caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - run:
           name: Check formatting
           command: ./scripts/rustfmt.sh
-          working_directory: .
   build:
     docker:
       - image: maxsam4/rust
@@ -18,19 +17,37 @@ jobs:
       VERBOSE: "1"
     steps:
       - checkout
+      - run:
+        name: Build concatenated lock file for caching
+        command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
+      - run:
+        name: Store rust version in a file for backup caching
+        command: rustc --version > rust.version
       - restore_cache:
           keys:
-            - build-cache-{{ checksum "./Cargo.lock" }}
-      - run:
-          name: Build rocksdb
-          command: cargo build -p rocksdb -j 1 --release
-          working_directory: .
+            - release-cache-{{ checksum "./concatenated.lock" }}
+            - release-cache-{{ checksum "./Cargo.lock" }}
+            - release-cache-{{ checksum "./rust.version" }}
       - run:
           name: Build release
           command: cargo build -j 1 --release
-          working_directory: .
+          no_output_timeout: 4h
       - save_cache:
-          key: build-cache-{{ checksum "./Cargo.lock" }}
+          key: release-cache-{{ checksum "./concatenated.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+            - "./pallets/runtime/target"
+            - "./pallets/runtime/wasm/target"
+      - save_cache:
+          key: release-cache-{{ checksum "./Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+            - "./pallets/runtime/target"
+            - "./pallets/runtime/wasm/target"
+      - save_cache:
+          key: release-cache-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
@@ -43,15 +60,38 @@ jobs:
       VERBOSE: "1"
     steps:
       - checkout
+      - run:
+        name: Build concatenated lock file for caching
+        command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
+      - run:
+        name: Store rust version in a file for backup caching
+        command: rustc --version > rust.version
       - restore_cache:
           keys:
+            - debug-cache-{{ checksum "./concatenated.lock" }}
             - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}
+            - debug-cache-{{ checksum "./rust.version" }}
       - run:
           name: runtime tests
-          command: cd pallets/runtime && cargo test && cd ../..
-          working_directory: .
+          command: cargo test
+          working_directory: ./pallets/runtime
+          no_output_timeout: 60m
       - save_cache:
-          key: debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}
+          key: debug-cache-{{ checksum "./concatenated.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+            - "./pallets/runtime/target"
+            - "./pallets/runtime/wasm/target"
+      - save_cache:
+          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+            - "./pallets/runtime/target"
+            - "./pallets/runtime/wasm/target"
+      - save_cache:
+          key: debug-cache-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - restore_cache:
           keys:
             - release-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
-            - release-cache-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
+            - release-cache2-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
             - release-cache-{{ checksum "./rust.version" }}
       - run:
           name: Build release
@@ -40,7 +40,7 @@ jobs:
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
+          key: release-cache2-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
@@ -84,7 +84,7 @@ jobs:
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
+          key: debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,32 +22,32 @@ jobs:
           command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
           name: Store rust version in an environment var for cache key
-          command: export RUST_VERISON=$(rustc --version) && echo $RUST_VERISON
+          command: rustc --version > rust.version
       - restore_cache:
           keys:
-            - release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
-            - release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
-            - release-cache-{{ .Environment.RUST_VERISON }}
+            - release-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
+            - release-cache-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
+            - release-cache-{{ checksum "./rust.version" }}
       - run:
           name: Build release
           command: cargo build -j 1 --release
           no_output_timeout: 4h
       - save_cache:
-          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
+          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
+          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ .Environment.RUST_VERISON }}
+          key: release-cache-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
@@ -64,34 +64,34 @@ jobs:
           name: Build concatenated lock file for caching
           command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
-          name: Store rust version in an environment var for cache key
-          command: export RUST_VERISON=$(rustc --version) && echo $RUST_VERISON
+          name: Store rust version in a file for cache key
+          command: rustc --version > rust.version
       - restore_cache:
           keys:
-            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
-            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
-            - debug-cache-{{ .Environment.RUST_VERISON }}
+            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
+            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
+            - debug-cache-{{ checksum "./rust.version" }}
       - run:
           name: runtime tests
           command: cargo test
           working_directory: ./pallets/runtime
           no_output_timeout: 60m
       - save_cache:
-          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
+          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
+          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: debug-cache-{{ .Environment.RUST_VERISON }}
+          key: debug-cache-{{ checksum "./rust.version" }}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,29 +25,16 @@ jobs:
           command: rustc --version > rust.version
       - restore_cache:
           keys:
-            - release-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
-            - release-cache2-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
+            - release-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./concatenated.lock" }}
+            - release-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}
             - release-cache-{{ checksum "./rust.version" }}
+            - release-cache
       - run:
           name: Build release
           command: cargo build -j 1 --release
           no_output_timeout: 4h
       - save_cache:
-          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
-          paths:
-            - "~/.cargo"
-            - "./target"
-            - "./pallets/runtime/target"
-            - "./pallets/runtime/wasm/target"
-      - save_cache:
-          key: release-cache2-{{ checksum "./Cargo.lock" }}-{{ checksum "./rust.version" }}
-          paths:
-            - "~/.cargo"
-            - "./target"
-            - "./pallets/runtime/target"
-            - "./pallets/runtime/wasm/target"
-      - save_cache:
-          key: release-cache-{{ checksum "./rust.version" }}
+          key: release-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./concatenated.lock" }}
           paths:
             - "~/.cargo"
             - "./target"
@@ -68,30 +55,17 @@ jobs:
           command: rustc --version > rust.version
       - restore_cache:
           keys:
-            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
-            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
+            - debug-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./concatenated.lock" }}
+            - debug-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}
             - debug-cache-{{ checksum "./rust.version" }}
+            - debug-cache
       - run:
           name: runtime tests
           command: cargo test
           working_directory: ./pallets/runtime
           no_output_timeout: 60m
       - save_cache:
-          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ checksum "./rust.version" }}
-          paths:
-            - "~/.cargo"
-            - "./target"
-            - "./pallets/runtime/target"
-            - "./pallets/runtime/wasm/target"
-      - save_cache:
-          key: debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./rust.version" }}
-          paths:
-            - "~/.cargo"
-            - "./target"
-            - "./pallets/runtime/target"
-            - "./pallets/runtime/wasm/target"
-      - save_cache:
-          key: debug-cache-{{ checksum "./rust.version" }}
+          key: debug-cache-{{ checksum "./rust.version" }}-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ checksum "./concatenated.lock" }}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,36 +18,36 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Build concatenated lock file for caching
-        command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
+          name: Build concatenated lock file for caching
+          command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
-        name: Store rust version in a file for backup caching
-        command: rustc --version > rust.version
+          name: Store rust version in an environment var for cache key
+          command: export RUST_VERISON=$(rustc --version) && echo RUST_VERISON
       - restore_cache:
           keys:
-            - release-cache-{{ checksum "./concatenated.lock" }}
-            - release-cache-{{ checksum "./Cargo.lock" }}
-            - release-cache-{{ checksum "./rust.version" }}
+            - release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
+            - release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
+            - release-cache-{{ checksum "./rust.version" }}-{{ .Environment.RUST_VERISON}}
       - run:
           name: Build release
           command: cargo build -j 1 --release
           no_output_timeout: 4h
       - save_cache:
-          key: release-cache-{{ checksum "./concatenated.lock" }}
+          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./Cargo.lock" }}
+          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./rust.version" }}
+          key: release-cache-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"
@@ -61,37 +61,37 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Build concatenated lock file for caching
-        command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
+          name: Build concatenated lock file for caching
+          command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
-        name: Store rust version in a file for backup caching
-        command: rustc --version > rust.version
+          name: Store rust version in an environment var for cache key
+          command: export RUST_VERISON=$(rustc --version) && echo RUST_VERISON
       - restore_cache:
           keys:
-            - debug-cache-{{ checksum "./concatenated.lock" }}
-            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}
-            - debug-cache-{{ checksum "./rust.version" }}
+            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
+            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
+            - debug-cache-{{ .Environment.RUST_VERISON}}
       - run:
           name: runtime tests
           command: cargo test
           working_directory: ./pallets/runtime
           no_output_timeout: 60m
       - save_cache:
-          key: debug-cache-{{ checksum "./concatenated.lock" }}
+          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}
+          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: debug-cache-{{ checksum "./rust.version" }}
+          key: debug-cache-{{ .Environment.RUST_VERISON}}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,32 +22,32 @@ jobs:
           command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
           name: Store rust version in an environment var for cache key
-          command: export RUST_VERISON=$(rustc --version) && echo RUST_VERISON
+          command: export RUST_VERISON=$(rustc --version) && echo $RUST_VERISON
       - restore_cache:
           keys:
-            - release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
-            - release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
-            - release-cache-{{ checksum "./rust.version" }}-{{ .Environment.RUST_VERISON}}
+            - release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
+            - release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
+            - release-cache-{{ .Environment.RUST_VERISON }}
       - run:
           name: Build release
           command: cargo build -j 1 --release
           no_output_timeout: 4h
       - save_cache:
-          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
+          key: release-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
+          key: release-cache-{{ checksum "./Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ .Environment.RUST_VERISON}}
+          key: release-cache-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"
@@ -65,33 +65,33 @@ jobs:
           command: find . -name "Cargo.lock" -not -path "*/target/*" | xargs cat > concatenated.lock
       - run:
           name: Store rust version in an environment var for cache key
-          command: export RUST_VERISON=$(rustc --version) && echo RUST_VERISON
+          command: export RUST_VERISON=$(rustc --version) && echo $RUST_VERISON
       - restore_cache:
           keys:
-            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
-            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
-            - debug-cache-{{ .Environment.RUST_VERISON}}
+            - debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
+            - debug-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
+            - debug-cache-{{ .Environment.RUST_VERISON }}
       - run:
           name: runtime tests
           command: cargo test
           working_directory: ./pallets/runtime
           no_output_timeout: 60m
       - save_cache:
-          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON}}
+          key: debug-cache-{{ checksum "./concatenated.lock" }}-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON}}
+          key: release-cache-{{ checksum "./pallets/runtime/Cargo.lock" }}-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"
             - "./pallets/runtime/target"
             - "./pallets/runtime/wasm/target"
       - save_cache:
-          key: debug-cache-{{ .Environment.RUST_VERISON}}
+          key: debug-cache-{{ .Environment.RUST_VERISON }}
           paths:
             - "~/.cargo"
             - "./target"


### PR DESCRIPTION
To reduce cache misses, I've changed our CircleCI logic to:
1) Try and restore cache created against exactly the same lock files of all our packages
2) If that's not available (let's say we changed just the identity module), then rather than not restoring any cache, we restore the cache created for the exact lock file for the main package.
3) If that's not available, restore the cache created for the current rust version. This way, at least we won't have to rebuild the third party dependencies that haven't changed.

Other changes:
- The Rust version is also stored in the cache keys. This way, we won't be trying to restore cross rust version caches and wasting time.
- minor improvements and bug fixes :)