### PR TITLE
Remove unused `Subtrait`

### DIFF
--- a/pallets/common/src/traits/balances.rs
+++ b/pallets/common/src/traits/balances.rs
@@ -7,58 +7,6 @@ use frame_support::{
 };
 use frame_system::{self as system, OnNewAccount};
 
-/// Tag a type as an instance of a module.
-///
-/// Defines storage prefixes, they must be unique.
-#[allow(non_upper_case_globals)]
-pub trait Instance: 'static {
-    /// The prefix used by any storage entry of an instance.
-    const PREFIX: &'static str;
-    const PREFIX_FOR_TotalIssuance: &'static str;
-    const PREFIX_FOR_Vesting: &'static str;
-    const PREFIX_FOR_FreeBalance: &'static str;
-    const PREFIX_FOR_ReservedBalance: &'static str;
-    const PREFIX_FOR_Locks: &'static str;
-    const PREFIX_FOR_IdentityBalance: &'static str;
-    const PREFIX_FOR_ChargeDid: &'static str;
-}
-
-pub struct DefaultInstance;
-
-#[allow(non_upper_case_globals)]
-impl Instance for DefaultInstance {
-    const PREFIX: &'static str = "Balances";
-    const PREFIX_FOR_TotalIssuance: &'static str = "Balances TotalIssuance";
-    const PREFIX_FOR_Vesting: &'static str = "Balances Vesting";
-    const PREFIX_FOR_FreeBalance: &'static str = "Balances FreeBalance";
-    const PREFIX_FOR_ReservedBalance: &'static str = "Balances ReservedBalance";
-    const PREFIX_FOR_Locks: &'static str = "Balances Locks";
-    const PREFIX_FOR_IdentityBalance: &'static str = "Balances IdentityBalance";
-    const PREFIX_FOR_ChargeDid: &'static str = "Balances ChargeDid";
-}
-
-pub trait Subtrait<I: Instance = DefaultInstance>: CommonTrait {
-    /// This type is no longer needed but kept for compatibility reasons.
-    /// A function that is invoked when the free-balance has fallen below the existential deposit and
-    /// has been reduced to zero.
-    ///
-    /// Gives a chance to clean up resources associated with the given account.
-    type OnFreeBalanceZero: OnFreeBalanceZero<Self::AccountId>;
-
-    /// Handler for when a new account is created.
-    type OnNewAccount: OnNewAccount<Self::AccountId>;
-
-    /// This type is no longer needed but kept for compatibility reasons.
-    /// The minimum amount required to keep an account open.
-    type ExistentialDeposit: Get<Self::Balance>;
-
-    /// The fee required to make a transfer.
-    type TransferFee: Get<Self::Balance>;
-
-    /// Used to charge fee to identity rather than user directly
-    type Identity: IdentityTrait;
-}
-
 decl_event!(
     pub enum Event<T> where
     <T as system::Trait>::AccountId,
@@ -101,14 +49,6 @@ pub trait Trait: CommonTrait {
 
     /// Used to charge fee to identity rather than user directly
     type Identity: IdentityTrait;
-}
-
-impl<T: Trait, I: Instance> Subtrait<I> for T {
-    type OnFreeBalanceZero = T::OnFreeBalanceZero;
-    type OnNewAccount = T::OnNewAccount;
-    type ExistentialDeposit = T::ExistentialDeposit;
-    type TransferFee = T::TransferFee;
-    type Identity = T::Identity;
 }
 
 pub trait BalancesTrait<A, B, NI> {

--- a/pallets/runtime/src/simple_token.rs
+++ b/pallets/runtime/src/simple_token.rs
@@ -260,10 +260,8 @@ mod tests {
     use polymesh_runtime_identity as identity;
 
     use frame_support::{
-        assert_err, assert_ok, dispatch::DispatchResult, impl_outer_dispatch, impl_outer_origin,
-        parameter_types,
+        assert_err, assert_ok, dispatch::DispatchResult, impl_outer_origin, parameter_types,
     };
-    use frame_system::EnsureSignedBy;
     use sp_core::{crypto::key_types, H256};
     use sp_runtime::{
         testing::{Header, UintAuthorityId},
@@ -295,7 +293,7 @@ mod tests {
     impl frame_system::Trait for Test {
         type Origin = Origin;
         type Index = u64;
-        type BlockNumber = u64;
+        type BlockNumber = BlockNumber;
         type Call = ();
         type Hash = H256;
         type Hashing = BlakeTwo256;
@@ -441,12 +439,10 @@ mod tests {
     }
 
     type Identity = identity::Module<Test>;
-    type System = system::Module<Test>;
-    type Balances = balances::Module<Test>;
     type SimpleToken = Module<Test>;
 
     fn new_test_ext() -> sp_io::TestExternalities {
-        let mut t = system::GenesisConfig::default()
+        let t = system::GenesisConfig::default()
             .build_storage::<Test>()
             .unwrap();
         t.into()

--- a/pallets/runtime/src/test/asset_test.rs
+++ b/pallets/runtime/src/test/asset_test.rs
@@ -111,7 +111,7 @@ fn issuers_can_create_and_rename_tokens() {
         // The token should remain unchanged in storage.
         assert_eq!(Asset::token_details(ticker), token);
         // Rename the token and check storage has been updated.
-        let mut renamed_token = SecurityToken {
+        let renamed_token = SecurityToken {
             name: vec![0x42],
             owner_did: token.owner_did,
             total_supply: token.total_supply,

--- a/pallets/runtime/src/test/balances_test.rs
+++ b/pallets/runtime/src/test/balances_test.rs
@@ -154,7 +154,7 @@ fn issue_must_work() {
         let brr = Balances::block_reward_reserve();
         assert_eq!(Balances::free_balance(&brr), 0);
         let mut ti = Balances::total_issuance();
-        let alice = AccountKeyring::Alice.public();
+        let _alice = AccountKeyring::Alice.public();
 
         // When there is no balance in BRR, issuance should increase total supply
         // NOTE: dropping negative imbalance is equivalent to burning. It will decrease total supply.


### PR DESCRIPTION
It just removes `Subtrait` in Balances.
It is not needed because we previously removed the `ElevateTrait` trick.