### PR TITLE
Mesh 598/remove did parameter

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -179,8 +179,9 @@ decl_module! {
         ///  - It can only called by master key owner.
         ///  - If any signing key is already linked to any identity, it will fail.
         ///  - If any signing key is already
-        pub fn add_signing_items(origin, did: IdentityId, signing_items: Vec<SigningItem>) -> DispatchResult {
+        pub fn add_signing_items(origin, signing_items: Vec<SigningItem>) -> DispatchResult {
             let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             // Check constraint 1-to-1 in relation key-identity.
@@ -206,8 +207,9 @@ decl_module! {
         ///
         /// # Failure
         /// It can only called by master key owner.
-        pub fn remove_signing_items(origin, did: IdentityId, signers_to_remove: Vec<Signatory>) -> DispatchResult {
+        pub fn remove_signing_items(origin, signers_to_remove: Vec<Signatory>) -> DispatchResult {
             let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             // Remove any Pre-Authentication & link
@@ -231,9 +233,10 @@ decl_module! {
         ///
         /// # Failure
         /// Only called by master key owner.
-        fn set_master_key(origin, did: IdentityId, new_key: AccountKey) -> DispatchResult {
+        fn set_master_key(origin, new_key: AccountKey) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let sender_key = AccountKey::try_from( sender.encode())?;
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
             ensure!( Self::can_key_be_linked_to_did(&new_key, SignatoryType::External), "Master key can only belong to one DID");
@@ -452,12 +455,12 @@ decl_module! {
         }
 
         /// Marks the specified claim as revoked
-        pub fn revoke_claim(origin, did: IdentityId, claim_key: Vec<u8>, did_issuer: IdentityId) -> DispatchResult {
-            let sender = Signatory::AccountKey( AccountKey::try_from( ensure_signed(origin)?.encode())?);
+        pub fn revoke_claim(origin, claim_key: Vec<u8>, did_issuer: IdentityId) -> DispatchResult {
+            let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
+            let sender = Signatory::AccountKey(sender_key);
 
-            ensure!(<DidRecords>::exists(&did), "DID must already exist");
             ensure!(<DidRecords>::exists(&did_issuer), "claim issuer DID must already exist");
-
             // Verify that sender key is one of did_issuer's signing keys
             ensure!(Self::is_signer_authorized(did_issuer, &sender), "Sender must hold a claim issuer's signing key");
 
@@ -483,8 +486,9 @@ decl_module! {
 
         /// It sets permissions for an specific `target_key` key.
         /// Only the master key of an identity is able to set signing key permissions.
-        pub fn set_permission_to_signer(origin, did: IdentityId, signer: Signatory, permissions: Vec<Permission>) -> DispatchResult {
+        pub fn set_permission_to_signer(origin, signer: Signatory, permissions: Vec<Permission>) -> DispatchResult {
             let sender_key = AccountKey::try_from( ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
             let record = Self::grant_check_only_master_key( &sender_key, did)?;
 
             // You are trying to add a permission to did's master key. It is not needed.
@@ -506,23 +510,20 @@ decl_module! {
         ///
         /// # Errors
         ///
-        pub fn freeze_signing_keys(origin, did: IdentityId) -> DispatchResult {
-            Self::set_frozen_signing_key_flags( origin, did, true)
+        pub fn freeze_signing_keys(origin) -> DispatchResult {
+            Self::set_frozen_signing_key_flags( origin, true)
         }
 
-        pub fn unfreeze_signing_keys(origin, did: IdentityId) -> DispatchResult {
-            Self::set_frozen_signing_key_flags( origin, did, false)
+        pub fn unfreeze_signing_keys(origin) -> DispatchResult {
+            Self::set_frozen_signing_key_flags( origin, false)
         }
 
         pub fn get_my_did(origin) -> DispatchResult {
             let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
-            if let Some(did) = Self::get_identity(&sender_key) {
-                Self::deposit_event(RawEvent::DidQuery(sender_key, did));
-                sp_runtime::print(did);
-                Ok(())
-            } else {
-                Err(Error::<T>::NoDIDFound.into())
-            }
+            let did = Context::current_identity_or::<Self>(&sender_key)?;
+
+            Self::deposit_event(RawEvent::DidQuery(sender_key, did));
+            Ok(())
         }
 
         pub fn get_asset_did(origin, ticker: Ticker) -> DispatchResult {
@@ -811,11 +812,11 @@ decl_module! {
         ///     - It can only called by master key owner.
         ///     - Keys should be able to linked to any identity.
         pub fn add_signing_items_with_authorization( origin,
-                id: IdentityId,
                 expires_at: T::Moment,
                 additional_keys: Vec<SigningItemWithAuth>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let sender_key = AccountKey::try_from(sender.encode())?;
+            let id = Context::current_identity_or::<Self>(&sender_key)?;
             let _grants_checked = Self::grant_check_only_master_key(&sender_key, id)?;
 
             // 0. Check expiration
@@ -1271,12 +1272,9 @@ impl<T: Trait> Module<T> {
     ///
     /// # Errors
     /// Only master key can freeze/unfreeze an identity.
-    fn set_frozen_signing_key_flags(
-        origin: T::Origin,
-        did: IdentityId,
-        freeze: bool,
-    ) -> DispatchResult {
+    fn set_frozen_signing_key_flags(origin: T::Origin, freeze: bool) -> DispatchResult {
         let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+        let did = Context::current_identity_or::<Self>(&sender_key)?;
         let _grants_checked = Self::grant_check_only_master_key(&sender_key, did)?;
 
         if freeze {

--- a/pallets/runtime/src/asset.rs
+++ b/pallets/runtime/src/asset.rs
@@ -240,6 +240,8 @@ decl_storage! {
     }
 }
 
+type Identity<T> = identity::Module<T>;
+
 // public interface for this runtime module
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
@@ -259,7 +261,7 @@ decl_module! {
             let sender = ensure_signed(origin)?;
             let sender_key = AccountKey::try_from(sender.encode())?;
             let signer = Signatory::AccountKey(sender_key.clone());
-            let to_did = Context::current_identity_or::<identity::Module<T>>(&sender_key)?;
+            let to_did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
 
             ticker.canonize();
             ensure!(<identity::Module<T>>::is_signer_authorized(to_did, &signer), "sender must be a signing key for DID");
@@ -293,7 +295,7 @@ decl_module! {
         pub fn accept_ticker_transfer(origin, auth_id: u64) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let sender_key = AccountKey::try_from(sender.encode())?;
-            let to_did = Context::current_identity_or::<identity::Module<T>>(&sender_key)?;
+            let to_did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
 
             Self::_accept_ticker_transfer(to_did, auth_id)
         }
@@ -307,7 +309,7 @@ decl_module! {
         pub fn accept_token_ownership_transfer(origin, auth_id: u64) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let sender_key = AccountKey::try_from(sender.encode())?;
-            let to_did = Context::current_identity_or::<identity::Module<T>>(&sender_key)?;
+            let to_did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
 
             Self::_accept_token_ownership_transfer(to_did, auth_id)
         }
@@ -318,7 +320,6 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` - contains the signing key of the caller (i.e who signed the transaction to execute this function).
-        /// * `did` - the DID of the creator of the token or the owner of the token.
         /// * `name` - the name of the token.
         /// * `ticker` - the ticker symbol of the token.
         /// * `total_supply` - the total supply of the token.
@@ -328,7 +329,6 @@ decl_module! {
         /// * `funding_round` - name of the funding round
         pub fn create_token(
             origin,
-            did: IdentityId,
             name: Vec<u8>,
             ticker: Ticker,
             total_supply: T::Balance,
@@ -338,7 +338,9 @@ decl_module! {
             funding_round: Option<Vec<u8>>
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+            let sender_key = AccountKey::try_from(sender.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -487,13 +489,13 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` signing key of the sender
-        /// * `did` DID of the `from` token holder, from whom tokens needs to transferred
         /// * `ticker` Ticker of the token
         /// * `to_did` DID of the `to` token holder, to whom token needs to transferred
         /// * `value` Value that needs to transferred
-        pub fn transfer(_origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, value: T::Balance) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn transfer(origin, ticker: Ticker, to_did: IdentityId, value: T::Balance) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -510,16 +512,16 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` signing key of the token owner DID.
-        /// * `did` Token owner DID.
         /// * `ticker` symbol of the token
         /// * `from_did` DID of the token holder from whom balance token will be transferred.
         /// * `to_did` DID of token holder to whom token balance will be transferred.
         /// * `value` Amount of tokens.
         /// * `data` Some off chain data to validate the restriction.
         /// * `operator_data` It is a string which describes the reason of this control transfer call.
-        pub fn controller_transfer(_origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey( AccountKey::try_from(sender.encode())?);
+        pub fn controller_transfer(origin, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -538,12 +540,12 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` Signing key of the token owner (i.e sender)
-        /// * `did` DID of the sender
         /// * `spender_did` DID of the spender
         /// * `value` Amount of the tokens approved
-        fn approve(_origin, did: IdentityId, ticker: Ticker, spender_did: IdentityId, value: T::Balance) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        fn approve(origin, ticker: Ticker, spender_did: IdentityId, value: T::Balance) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -562,13 +564,14 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` Signing key of spender
-        /// * `did` DID of the spender
         /// * `_ticker` Ticker of the token
         /// * `from_did` DID from whom token is being transferred
         /// * `to_did` DID to whom token is being transferred
         /// * `value` Amount of the token for transfer
-        pub fn transfer_from(origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance) -> DispatchResult {
-            let spender = Signatory::AccountKey(AccountKey::try_from(ensure_signed(origin)?.encode())?);
+        pub fn transfer_from(origin, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let spender = Signatory::AccountKey(sender_key);
 
             // Check that spender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &spender), "sender must be a signing key for DID");
@@ -596,12 +599,12 @@ decl_module! {
         /// Function used to create the checkpoint
         ///
         /// # Arguments
-        /// * `_origin` Signing key of the token owner. (Only token owner can call this function).
-        /// * `did` DID of the token owner
+        /// * `origin` Signing key of the token owner. (Only token owner can call this function).
         /// * `_ticker` Ticker of the token
-        pub fn create_checkpoint(_origin, did: IdentityId, ticker: Ticker) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn create_checkpoint(origin, ticker: Ticker) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -615,13 +618,13 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of token owner
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
         /// * `to_did` DID of the token holder to whom new tokens get issued.
         /// * `value` Amount of tokens that get issued
-        pub fn issue(origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn issue(origin, ticker: Ticker, to_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -635,13 +638,13 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of token owner
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
         /// * `investor_dids` Array of the DID of the token holders to whom new tokens get issued.
         /// * `values` Array of the Amount of tokens that get issued
-        pub fn batch_issue(origin, did: IdentityId, ticker: Ticker, investor_dids: Vec<IdentityId>, values: Vec<T::Balance>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn batch_issue(origin, ticker: Ticker, investor_dids: Vec<IdentityId>, values: Vec<T::Balance>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -712,13 +715,13 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` Signing key of the token holder who wants to redeem the tokens
-        /// * `did` DID of the token holder
         /// * `ticker` Ticker of the token
         /// * `value` Amount of the tokens needs to redeem
         /// * `_data` An off chain data blob used to validate the redeem functionality.
-        pub fn redeem(_origin, did: IdentityId, ticker: Ticker, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn redeem(origin, ticker: Ticker, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -764,14 +767,14 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` Signing key of the spender who has valid approval to redeem the tokens
-        /// * `did` DID of the spender
         /// * `ticker` Ticker of the token
         /// * `from_did` DID from whom balance get reduced
         /// * `value` Amount of the tokens needs to redeem
         /// * `_data` An off chain data blob used to validate the redeem functionality.
-        pub fn redeem_from(_origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(_origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn redeem_from(origin, ticker: Ticker, from_did: IdentityId, value: T::Balance, _data: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -822,15 +825,15 @@ decl_module! {
         ///
         /// # Arguments
         /// * `_origin` Signing key of the token owner
-        /// * `did` DID of the token holder
         /// * `ticker` Ticker of the token
         /// * `token_holder_did` DID from whom balance get reduced
         /// * `value` Amount of the tokens needs to redeem
         /// * `data` An off chain data blob used to validate the redeem functionality.
         /// * `operator_data` Any data blob that defines the reason behind the force redeem.
-        pub fn controller_redeem(origin, did: IdentityId, ticker: Ticker, token_holder_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn controller_redeem(origin, ticker: Ticker, token_holder_did: IdentityId, value: T::Balance, data: Vec<u8>, operator_data: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer), "sender must be a signing key for DID");
@@ -870,11 +873,11 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the token owner.
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
-        pub fn make_divisible(origin, did: IdentityId, ticker: Ticker) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let sender_signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn make_divisible(origin, ticker: Ticker) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let sender_signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -932,14 +935,18 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the sender
-        /// * `did` DID from whom tokens will be transferred
         /// * `ticker` Ticker of the token
         /// * `to_did` DID to whom tokens will be transferred
         /// * `value` Amount of the tokens
         /// * `data` Off chain data blob to validate the transfer.
-        pub fn transfer_with_data(origin, did: IdentityId, ticker: Ticker, to_did: IdentityId, value: T::Balance, data: Vec<u8>) -> DispatchResult {
+        pub fn transfer_with_data(origin, ticker: Ticker, to_did: IdentityId, value: T::Balance, data: Vec<u8>) -> DispatchResult {
+
+            let sender_key = AccountKey::try_from(ensure_signed(origin.clone())?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+
             ticker.canonize();
-            Self::transfer(origin, did, ticker, to_did, value)?;
+            Self::transfer(origin, ticker, to_did, value)?;
+
             Self::deposit_event(RawEvent::TransferWithData(ticker, did, to_did, value, data));
             Ok(())
         }
@@ -950,15 +957,15 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the spender
-        /// * `did` DID of spender
         /// * `ticker` Ticker of the token
         /// * `from_did` DID from whom tokens will be transferred
         /// * `to_did` DID to whom tokens will be transferred
         /// * `value` Amount of the tokens
         /// * `data` Off chain data blob to validate the transfer.
-        pub fn transfer_from_with_data(origin, did: IdentityId, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance, data: Vec<u8>) -> DispatchResult {
+        pub fn transfer_from_with_data(origin, ticker: Ticker, from_did: IdentityId, to_did: IdentityId, value: T::Balance, data: Vec<u8>) -> DispatchResult {
             ticker.canonize();
-            Self::transfer_from(origin, did, ticker, from_did,  to_did, value)?;
+            Self::transfer_from(origin, ticker, from_did,  to_did, value)?;
+
             Self::deposit_event(RawEvent::TransferWithData(ticker, from_did, to_did, value, data));
             Ok(())
         }
@@ -977,12 +984,12 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the token owner
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
         /// * `documents` Documents to be attached to `ticker`
-        pub fn add_documents(origin, did: IdentityId, ticker: Ticker, documents: Vec<Document>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let sender_signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn add_documents(origin, ticker: Ticker, documents: Vec<Document>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let sender_signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -1002,12 +1009,12 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the token owner
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
         /// * `doc_ids` Documents to be removed from `ticker`
-        pub fn remove_documents(origin, did: IdentityId, ticker: Ticker, doc_ids: Vec<u64>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let sender_signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn remove_documents(origin, ticker: Ticker, doc_ids: Vec<u64>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let sender_signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -1027,12 +1034,12 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` Signing key of the token owner
-        /// * `did` DID of the token owner
         /// * `ticker` Ticker of the token
         /// * `docs` Vector of tuples (Document to be updated, Contents of new document)
-        pub fn update_documents(origin, did: IdentityId, ticker: Ticker, docs: Vec<(u64, Document)>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let sender_signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn update_documents(origin, ticker: Ticker, docs: Vec<(u64, Document)>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let sender_signer = Signatory::AccountKey(sender_key);
 
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer), "sender must be a signing key for DID");
@@ -1175,12 +1182,12 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` - the signing key of the token owner DID.
-        /// * `did` - the token owner DID.
         /// * `ticker` - the ticker of the token.
         /// * `name` - the desired name of the current funding round.
-        pub fn set_funding_round(origin, did: IdentityId, ticker: Ticker, name: Vec<u8>) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+        pub fn set_funding_round(origin, ticker: Ticker, name: Vec<u8>) -> DispatchResult {
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let signer = Signatory::AccountKey(sender_key);
             // Check that sender is allowed to act on behalf of `did`
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &signer),
                     "sender must be a signing key for DID");
@@ -1195,18 +1202,17 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` - the signing key of the token owner
-        /// * `did` - the DID of the token owner
         /// * `ticker` - the ticker of the token
         /// * `identifiers` - the asset identifiers to be updated in the form of a vector of pairs
         ///    of `IdentifierType` and `Vec<u8>` value.
         pub fn update_identifiers(
             origin,
-            did: IdentityId,
             ticker: Ticker,
             identifiers: Vec<(IdentifierType, Vec<u8>)>
         ) -> DispatchResult {
-            let sender = ensure_signed(origin)?;
-            let sender_signer = Signatory::AccountKey(AccountKey::try_from(sender.encode())?);
+            let sender_key = AccountKey::try_from(ensure_signed(origin)?.encode())?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender_key)?;
+            let sender_signer = Signatory::AccountKey(sender_key);
             ensure!(<identity::Module<T>>::is_signer_authorized(did, &sender_signer),
                     "sender must be a signing key for DID");
             ticker.canonize();

--- a/pallets/runtime/src/test/asset_test.rs
+++ b/pallets/runtime/src/test/asset_test.rs
@@ -55,7 +55,6 @@ fn issuers_can_create_and_rename_tokens() {
         assert_err!(
             Asset::create_token(
                 owner_signed.clone(),
-                owner_did,
                 token.name.clone(),
                 ticker,
                 1_000_000_000_000_000_000_000_000, // Total supply over the limit
@@ -70,7 +69,6 @@ fn issuers_can_create_and_rename_tokens() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -180,7 +178,6 @@ fn valid_transfers_pass() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -198,14 +195,12 @@ fn valid_transfers_pass() {
         // Allow all transfers
         assert_ok!(GeneralTM::add_active_rule(
             owner_signed.clone(),
-            owner_did,
             ticker,
             asset_rule
         ));
 
         assert_ok!(Asset::transfer(
             owner_signed.clone(),
-            owner_did,
             ticker,
             alice_did,
             500
@@ -240,7 +235,6 @@ fn valid_custodian_allowance() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -263,14 +257,12 @@ fn valid_custodian_allowance() {
         // Allow all transfers
         assert_ok!(GeneralTM::add_active_rule(
             owner_signed.clone(),
-            owner_did,
             ticker,
             asset_rule
         ));
         let funding_round1 = b"Round One".to_vec();
         assert_ok!(Asset::set_funding_round(
             owner_signed.clone(),
-            owner_did,
             ticker,
             funding_round1.clone()
         ));
@@ -278,7 +270,6 @@ fn valid_custodian_allowance() {
         let num_tokens1: u128 = 2_000_000;
         assert_ok!(Asset::issue(
             owner_signed.clone(),
-            owner_did,
             ticker,
             investor1_did,
             num_tokens1,
@@ -343,7 +334,6 @@ fn valid_custodian_allowance() {
         // Transfer the token upto the limit
         assert_ok!(Asset::transfer(
             investor1_signed.clone(),
-            investor1_did,
             ticker,
             investor2_did,
             140_00_00 as u128
@@ -358,7 +348,6 @@ fn valid_custodian_allowance() {
         assert_noop!(
             Asset::transfer(
                 investor1_signed.clone(),
-                investor1_did,
                 ticker,
                 investor2_did,
                 50_00_00 as u128
@@ -431,7 +420,6 @@ fn valid_custodian_allowance_of() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -454,7 +442,6 @@ fn valid_custodian_allowance_of() {
         // Allow all transfers
         assert_ok!(GeneralTM::add_active_rule(
             owner_signed.clone(),
-            owner_did,
             ticker,
             asset_rule
         ));
@@ -462,7 +449,6 @@ fn valid_custodian_allowance_of() {
         // Mint some tokens to investor1
         assert_ok!(Asset::issue(
             owner_signed.clone(),
-            owner_did,
             ticker,
             investor1_did,
             200_00_00 as u128,
@@ -542,7 +528,6 @@ fn valid_custodian_allowance_of() {
         // Transfer the token upto the limit
         assert_ok!(Asset::transfer(
             investor1_signed.clone(),
-            investor1_did,
             ticker,
             investor2_did,
             140_00_00 as u128
@@ -557,7 +542,6 @@ fn valid_custodian_allowance_of() {
         assert_noop!(
             Asset::transfer(
                 investor1_signed.clone(),
-                investor1_did,
                 ticker,
                 investor2_did,
                 50_00_00 as u128
@@ -629,7 +613,6 @@ fn checkpoints_fuzz_test() {
             // Issuance is successful
             assert_ok!(Asset::create_token(
                 owner_signed.clone(),
-                owner_did,
                 token.name.clone(),
                 ticker,
                 token.total_supply,
@@ -647,7 +630,6 @@ fn checkpoints_fuzz_test() {
             // Allow all transfers
             assert_ok!(GeneralTM::add_active_rule(
                 owner_signed.clone(),
-                owner_did,
                 ticker,
                 asset_rule
             ));
@@ -666,19 +648,9 @@ fn checkpoints_fuzz_test() {
                     }
                     owner_balance[j] -= 1;
                     bob_balance[j] += 1;
-                    assert_ok!(Asset::transfer(
-                        owner_signed.clone(),
-                        owner_did,
-                        ticker,
-                        bob_did,
-                        1
-                    ));
+                    assert_ok!(Asset::transfer(owner_signed.clone(), ticker, bob_did, 1));
                 }
-                assert_ok!(Asset::create_checkpoint(
-                    owner_signed.clone(),
-                    owner_did,
-                    ticker,
-                ));
+                assert_ok!(Asset::create_checkpoint(owner_signed.clone(), ticker,));
                 let x: u64 = u64::try_from(j).unwrap();
                 assert_eq!(
                     Asset::get_balance_at(ticker, owner_did, 0),
@@ -742,7 +714,6 @@ fn register_ticker() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -920,7 +891,6 @@ fn transfer_token_ownership() {
         let ticker = Ticker::from_slice(token_name.as_slice());
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token_name.clone(),
             ticker,
             1_000_000,
@@ -1067,7 +1037,6 @@ fn update_identifiers() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1091,7 +1060,6 @@ fn update_identifiers() {
         ];
         assert_ok!(Asset::update_identifiers(
             owner_signed.clone(),
-            owner_did,
             ticker,
             updated_identifiers.clone(),
         ));
@@ -1128,7 +1096,6 @@ fn adding_removing_documents() {
         // Issuance is successful
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1153,7 +1120,6 @@ fn adding_removing_documents() {
 
         assert_ok!(Asset::add_documents(
             owner_signed.clone(),
-            owner_did,
             ticker,
             documents
         ));
@@ -1176,7 +1142,6 @@ fn adding_removing_documents() {
 
         assert_ok!(Asset::update_documents(
             owner_signed.clone(),
-            owner_did,
             ticker,
             vec![
                 (
@@ -1212,7 +1177,6 @@ fn adding_removing_documents() {
 
         assert_ok!(Asset::remove_documents(
             owner_signed.clone(),
-            owner_did,
             ticker,
             doc_ids
         ));
@@ -1224,12 +1188,11 @@ fn adding_removing_documents() {
 #[test]
 fn add_extension_successfully() {
     ExtBuilder::default().build().execute_with(|| {
-        let (owner_signed, owner_did) = make_account(AccountKeyring::Dave.public()).unwrap();
+        let (owner_signed, _) = make_account(AccountKeyring::Dave.public()).unwrap();
 
         // Expected token entry
         let token = SecurityToken {
             name: b"TEST".to_vec(),
-            owner_did,
             total_supply: 1_000_000,
             divisible: true,
             asset_type: AssetType::default(),
@@ -1244,7 +1207,6 @@ fn add_extension_successfully() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1310,7 +1272,6 @@ fn add_same_extension_should_fail() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1381,7 +1342,6 @@ fn should_successfully_archive_extension() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1457,7 +1417,6 @@ fn should_fail_to_archive_an_already_archived_extension() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1538,7 +1497,6 @@ fn should_fail_to_archive_a_non_existent_extension() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1580,7 +1538,6 @@ fn should_successfuly_unarchive_an_extension() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1666,7 +1623,6 @@ fn should_fail_to_unarchive_an_already_unarchived_extension() {
         let identifiers = vec![(IdentifierType::Cusip, identifier_value1.to_vec())];
         assert_ok!(Asset::create_token(
             owner_signed.clone(),
-            owner_did,
             token.name.clone(),
             ticker,
             token.total_supply,
@@ -1745,7 +1701,6 @@ fn freeze_unfreeze_asset() {
         let ticker = Ticker::from_slice(token_name);
         assert_ok!(Asset::create_token(
             alice_signed.clone(),
-            alice_did,
             token_name.to_vec(),
             ticker,
             1_000_000,
@@ -1761,7 +1716,6 @@ fn freeze_unfreeze_asset() {
         };
         assert_ok!(GeneralTM::add_active_rule(
             alice_signed.clone(),
-            alice_did,
             ticker,
             asset_rule
         ));
@@ -1788,7 +1742,7 @@ fn freeze_unfreeze_asset() {
         let auth_id = Identity::last_authorization(Signatory::from(bob_did));
         // Attempt to mint tokens.
         assert_err!(
-            Asset::issue(alice_signed.clone(), alice_did, ticker, bob_did, 1, vec![]),
+            Asset::issue(alice_signed.clone(), ticker, bob_did, 1, vec![]),
             "asset is frozen"
         );
         assert_ok!(Asset::accept_token_ownership_transfer(
@@ -1796,17 +1750,17 @@ fn freeze_unfreeze_asset() {
             auth_id
         ));
         assert_err!(
-            Asset::transfer(alice_signed.clone(), alice_did, ticker, bob_did, 1),
+            Asset::transfer(alice_signed.clone(), ticker, bob_did, 1),
             "asset is frozen"
         );
         // `batch_issue` fails when the vector of recipients is not empty.
         assert_err!(
-            Asset::batch_issue(bob_signed.clone(), bob_did, ticker, vec![bob_did], vec![1]),
+            Asset::batch_issue(bob_signed.clone(), ticker, vec![bob_did], vec![1]),
             "asset is frozen"
         );
         // `batch_issue` fails with the empty vector of investors with a different error message.
         assert_err!(
-            Asset::batch_issue(bob_signed.clone(), bob_did, ticker, vec![], vec![]),
+            Asset::batch_issue(bob_signed.clone(), ticker, vec![], vec![]),
             "list of investors is empty"
         );
         assert_ok!(Asset::unfreeze(bob_signed.clone(), ticker));
@@ -1815,13 +1769,7 @@ fn freeze_unfreeze_asset() {
             "asset must be frozen"
         );
         // Transfer some balance.
-        assert_ok!(Asset::transfer(
-            alice_signed.clone(),
-            alice_did,
-            ticker,
-            bob_did,
-            1
-        ));
+        assert_ok!(Asset::transfer(alice_signed.clone(), ticker, bob_did, 1));
     });
 }
 

--- a/pallets/runtime/src/test/identity_test.rs
+++ b/pallets/runtime/src/test/identity_test.rs
@@ -132,7 +132,6 @@ fn only_master_or_signing_keys_can_authenticate_as_an_identity() {
 
         assert_ok!(Identity::add_signing_items(
             a.clone(),
-            a_did,
             vec![charlie_signing_item]
         ));
         assert_ok!(Identity::authorize_join_to_identity(
@@ -149,7 +148,6 @@ fn only_master_or_signing_keys_can_authenticate_as_an_identity() {
         // ... and remove that key.
         assert_ok!(Identity::remove_signing_items(
             a.clone(),
-            a_did.clone(),
             vec![charlie_signer.clone()]
         ));
         assert!(Identity::is_signer_authorized(a_did, &charlie_signer) == false);
@@ -159,8 +157,8 @@ fn only_master_or_signing_keys_can_authenticate_as_an_identity() {
 #[test]
 fn revoking_claims() {
     ExtBuilder::default().build().execute_with(|| {
-        let owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
-        let issuer_did = register_keyring_account(AccountKeyring::Bob).unwrap();
+        let _owner_did = register_keyring_account(AccountKeyring::Alice).unwrap();
+        let _issuer_did = register_keyring_account(AccountKeyring::Bob).unwrap();
         let issuer = Origin::signed(AccountKeyring::Bob.public());
         let claim_issuer_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
         let claim_issuer = Origin::signed(AccountKeyring::Charlie.public());
@@ -182,7 +180,6 @@ fn revoking_claims() {
         assert_err!(
             Identity::revoke_claim(
                 issuer.clone(),
-                issuer_did,
                 "some_key".as_bytes().to_vec(),
                 claim_issuer_did
             ),
@@ -191,7 +188,6 @@ fn revoking_claims() {
 
         assert_ok!(Identity::revoke_claim(
             claim_issuer.clone(),
-            owner_did,
             "some_key".as_bytes().to_vec(),
             claim_issuer_did
         ));
@@ -215,7 +211,6 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
 
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_did,
         vec![SigningItem::from(bob_key), SigningItem::from(charlie_key)]
     ));
     assert_ok!(Identity::authorize_join_to_identity(bob.clone(), alice_did));
@@ -224,13 +219,11 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
     // Only `alice` is able to update `bob`'s permissions and `charlie`'s permissions.
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
-        alice_did,
         Signatory::AccountKey(bob_key),
         vec![Permission::Operator]
     ));
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
-        alice_did,
         Signatory::AccountKey(charlie_key),
         vec![Permission::Admin, Permission::Operator]
     ));
@@ -239,7 +232,6 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
     assert_err!(
         Identity::set_permission_to_signer(
             bob.clone(),
-            alice_did,
             Signatory::AccountKey(bob_key),
             vec![Permission::Full]
         ),
@@ -248,19 +240,13 @@ fn only_master_key_can_add_signing_key_permissions_with_externalities() {
 
     // Bob tries to remove Charlie's permissions at `alice` Identity.
     assert_err!(
-        Identity::set_permission_to_signer(
-            bob,
-            alice_did,
-            Signatory::AccountKey(charlie_key),
-            vec![]
-        ),
+        Identity::set_permission_to_signer(bob, Signatory::AccountKey(charlie_key), vec![]),
         "Only master key of an identity is able to execute this operation"
     );
 
     // Alice over-write some permissions.
     assert_ok!(Identity::set_permission_to_signer(
         alice,
-        alice_did,
         Signatory::AccountKey(bob_key),
         vec![]
     ));
@@ -292,11 +278,10 @@ fn add_signing_keys_with_specific_type_with_externalities() {
     };
 
     // Add signing keys with non-default type.
-    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
+    let _alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
     let alice = Origin::signed(AccountKeyring::Alice.public());
     assert_ok!(Identity::add_signing_items(
         alice,
-        alice_did,
         vec![charlie_signing_key, dave_signing_key.clone()]
     ));
 
@@ -341,7 +326,6 @@ fn freeze_signing_keys_with_externalities() {
     let signing_keys_v1 = vec![bob_signing_key.clone(), charlie_signing_key];
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_did,
         signing_keys_v1.clone()
     ));
     assert_ok!(Identity::authorize_join_to_identity(bob.clone(), alice_did));
@@ -357,10 +341,10 @@ fn freeze_signing_keys_with_externalities() {
 
     // Freeze signing keys: bob & charlie.
     assert_err!(
-        Identity::freeze_signing_keys(bob.clone(), alice_did),
+        Identity::freeze_signing_keys(bob.clone()),
         "Only master key of an identity is able to execute this operation"
     );
-    assert_ok!(Identity::freeze_signing_keys(alice.clone(), alice_did));
+    assert_ok!(Identity::freeze_signing_keys(alice.clone()));
 
     assert_eq!(
         Identity::is_signer_authorized(alice_did, &Signatory::AccountKey(bob_key)),
@@ -371,7 +355,6 @@ fn freeze_signing_keys_with_externalities() {
     let signing_keys_v2 = vec![dave_signing_key.clone()];
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_did,
         signing_keys_v2.clone()
     ));
     assert_ok!(Identity::authorize_join_to_identity(dave, alice_did));
@@ -383,17 +366,16 @@ fn freeze_signing_keys_with_externalities() {
     // update permission of frozen keys.
     assert_ok!(Identity::set_permission_to_signer(
         alice.clone(),
-        alice_did,
         Signatory::AccountKey(bob_key),
         vec![Permission::Operator]
     ));
 
     // unfreeze all
     assert_err!(
-        Identity::unfreeze_signing_keys(bob.clone(), alice_did),
+        Identity::unfreeze_signing_keys(bob.clone()),
         "Only master key of an identity is able to execute this operation"
     );
-    assert_ok!(Identity::unfreeze_signing_keys(alice.clone(), alice_did));
+    assert_ok!(Identity::unfreeze_signing_keys(alice.clone()));
 
     assert_eq!(
         Identity::is_signer_authorized(alice_did, &Signatory::AccountKey(dave_key)),
@@ -428,7 +410,6 @@ fn remove_frozen_signing_keys_with_externalities() {
     let signing_keys_v1 = vec![bob_signing_key, charlie_signing_key.clone()];
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_did,
         signing_keys_v1.clone()
     ));
     assert_ok!(Identity::authorize_join_to_identity(
@@ -441,12 +422,11 @@ fn remove_frozen_signing_keys_with_externalities() {
     ));
 
     // Freeze all signing keys
-    assert_ok!(Identity::freeze_signing_keys(alice.clone(), alice_did));
+    assert_ok!(Identity::freeze_signing_keys(alice.clone()));
 
     // Remove Bob's key.
     assert_ok!(Identity::remove_signing_items(
         alice.clone(),
-        alice_did,
         vec![Signatory::AccountKey(bob_key)]
     ));
     // Check DidRecord.
@@ -465,7 +445,7 @@ fn enforce_uniqueness_keys_in_identity() {
     // Register identities
     let alice_id = register_keyring_account(AccountKeyring::Alice).unwrap();
     let alice = Origin::signed(AccountKeyring::Alice.public());
-    let bob_id = register_keyring_account(AccountKeyring::Bob).unwrap();
+    let _bob_id = register_keyring_account(AccountKeyring::Bob).unwrap();
     let bob = Origin::signed(AccountKeyring::Bob.public());
 
     // Check external signed key uniqueness.
@@ -476,7 +456,6 @@ fn enforce_uniqueness_keys_in_identity() {
     );
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_id,
         vec![charlie_sk.clone()]
     ));
     assert_ok!(Identity::authorize_join_to_identity(
@@ -485,7 +464,7 @@ fn enforce_uniqueness_keys_in_identity() {
     ));
 
     assert_err!(
-        Identity::add_signing_items(bob.clone(), bob_id, vec![charlie_sk]),
+        Identity::add_signing_items(bob.clone(), vec![charlie_sk]),
         Error::<TestStorage>::AlreadyLinked
     );
 
@@ -498,14 +477,9 @@ fn enforce_uniqueness_keys_in_identity() {
     };
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_id,
         vec![dave_sk.clone()]
     ));
-    assert_ok!(Identity::add_signing_items(
-        bob.clone(),
-        bob_id,
-        vec![dave_sk]
-    ));
+    assert_ok!(Identity::add_signing_items(bob.clone(), vec![dave_sk]));
 
     // Check that master key acts like external signed key.
     let bob_key = AccountKey::from(AccountKeyring::Bob.public().0);
@@ -515,13 +489,13 @@ fn enforce_uniqueness_keys_in_identity() {
         permissions: vec![Permission::Operator],
     };
     assert_err!(
-        Identity::add_signing_items(alice.clone(), alice_id, vec![bob_sk_as_mutisig]),
+        Identity::add_signing_items(alice.clone(), vec![bob_sk_as_mutisig]),
         Error::<TestStorage>::AlreadyLinked
     );
 
     let bob_sk = SigningItem::new(Signatory::AccountKey(bob_key), vec![Permission::Admin]);
     assert_err!(
-        Identity::add_signing_items(alice.clone(), alice_id, vec![bob_sk]),
+        Identity::add_signing_items(alice.clone(), vec![bob_sk]),
         Error::<TestStorage>::AlreadyLinked
     );
 }
@@ -545,7 +519,6 @@ fn add_remove_signing_identities_with_externalities() {
 
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_id,
         vec![SigningItem::from(bob_id), SigningItem::from(charlie_id)]
     ));
     assert_ok!(Identity::authorize_join_to_identity(bob, alice_id));
@@ -557,7 +530,6 @@ fn add_remove_signing_identities_with_externalities() {
 
     assert_ok!(Identity::remove_signing_items(
         alice.clone(),
-        alice_id,
         vec![Signatory::Identity(bob_id), Signatory::Identity(dave_id)]
     ));
 
@@ -605,14 +577,9 @@ fn two_step_join_id_with_ext() {
     let signing_keys = vec![c_sk.clone(), d_sk.clone(), e_sk.clone()];
     assert_ok!(Identity::add_signing_items(
         alice.clone(),
-        alice_id,
         signing_keys.clone()
     ));
-    assert_ok!(Identity::add_signing_items(
-        bob.clone(),
-        bob_id,
-        signing_keys
-    ));
+    assert_ok!(Identity::add_signing_items(bob.clone(), signing_keys));
     assert_eq!(
         Identity::is_signer_authorized(alice_id, &c_sk.signer),
         false
@@ -637,7 +604,6 @@ fn two_step_join_id_with_ext() {
     assert_eq!(Identity::is_signer_authorized(alice_id, &d_sk.signer), true);
     assert_ok!(Identity::remove_signing_items(
         alice.clone(),
-        alice_id,
         vec![d_sk.signer.clone()]
     ));
     assert_eq!(
@@ -713,7 +679,6 @@ fn one_step_join_id_with_ext() {
 
     assert_ok!(Identity::add_signing_items_with_authorization(
         a.clone(),
-        a_id,
         expires_at,
         signing_items_with_auth[..2].to_owned()
     ));
@@ -729,7 +694,6 @@ fn one_step_join_id_with_ext() {
     assert_err!(
         Identity::add_signing_items_with_authorization(
             a.clone(),
-            a_id,
             expires_at,
             signing_items_with_auth[2..].to_owned()
         ),
@@ -759,7 +723,6 @@ fn one_step_join_id_with_ext() {
     assert_err!(
         Identity::add_signing_items_with_authorization(
             a,
-            a_id.clone(),
             expires_at,
             vec![eve_signing_item_with_auth]
         ),
@@ -785,7 +748,6 @@ fn one_step_join_id_with_ext() {
     assert_err!(
         Identity::add_signing_items_with_authorization(
             f,
-            f_id,
             expires_at,
             vec![ferdie_signing_item_with_auth]
         ),

--- a/pallets/runtime/src/test/statistics_test.rs
+++ b/pallets/runtime/src/test/statistics_test.rs
@@ -43,7 +43,6 @@ fn investor_count_per_asset_with_ext() {
     let ticker = Ticker::from_slice(token.name.as_slice());
     assert_ok!(Asset::create_token(
         alice_signed.clone(),
-        alice_did,
         token.name.clone(),
         ticker,
         1_000_000, // Total supply over the limit
@@ -62,38 +61,19 @@ fn investor_count_per_asset_with_ext() {
     let ticker = Ticker::from_slice(token.name.as_slice());
     assert_ok!(GeneralTM::add_active_rule(
         alice_signed.clone(),
-        alice_did,
         ticker,
         asset_rule
     ));
 
     // Alice sends some tokens to Bob. Token has only one investor.
-    assert_ok!(Asset::transfer(
-        alice_signed.clone(),
-        alice_did,
-        ticker,
-        bob_did,
-        500
-    ));
+    assert_ok!(Asset::transfer(alice_signed.clone(), ticker, bob_did, 500));
     assert_eq!(Statistic::investor_count_per_asset(&ticker), 1);
 
     // Alice sends some tokens to Charlie. Token has now two investors.
-    assert_ok!(Asset::transfer(
-        alice_signed,
-        alice_did,
-        ticker,
-        charlie_did,
-        5000
-    ));
+    assert_ok!(Asset::transfer(alice_signed, ticker, charlie_did, 5000));
     assert_eq!(Statistic::investor_count_per_asset(&ticker), 2);
 
     // Bob sends all his tokens to Charlie, so now we have one investor again.
-    assert_ok!(Asset::transfer(
-        bob_signed,
-        bob_did,
-        ticker,
-        charlie_did,
-        500
-    ));
+    assert_ok!(Asset::transfer(bob_signed, ticker, charlie_did, 500));
     assert_eq!(Statistic::investor_count_per_asset(&ticker), 1);
 }

--- a/pallets/runtime/src/update_did_signed_extension.rs
+++ b/pallets/runtime/src/update_did_signed_extension.rs
@@ -168,7 +168,7 @@ mod tests {
 
         // `Identity::add_signing_items` needs DID. `validate` updates `current_did` and
         // `post_dispatch` clears it.
-        let add_signing_items_1 = Call::Identity(IdentityCall::add_signing_items(alice_id, vec![]));
+        let add_signing_items_1 = Call::Identity(IdentityCall::add_signing_items(vec![]));
         assert_eq!(
             update_did_se.validate(&alice_signed, &add_signing_items_1, dispatch_info, 0),
             valid_transaction_ok
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(Context::current_identity::<Identity>(), None);
 
         // `Identity::freeze_signing_keys` fails because `c_acc` account has not a DID.
-        let freeze_call1 = Call::Identity(IdentityCall::freeze_signing_keys(alice_id));
+        let freeze_call1 = Call::Identity(IdentityCall::freeze_signing_keys());
         assert_eq!(
             update_did_se.validate(&charlie_signed, &freeze_call1, dispatch_info, 0usize),
             Err(InvalidTransaction::Custom(TransactionError::MissingIdentity as u8).into())


### PR DESCRIPTION
**Description**
In this PR we are replacing `did: IdentityId` parameter in each module function by the new call `current_identity_or` (from MESH-542).