### PR TITLE
Staking fixes

### DIFF
--- a/pallets/runtime/develop/src/constants.rs
+++ b/pallets/runtime/develop/src/constants.rs
@@ -9,7 +9,7 @@ pub mod time {
     // mainnet
     // pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 4 * HOURS;
     // Testnet
-    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 30 * MINUTES;
+    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 5 * MINUTES;
 
     // These time units are defined in number of blocks.
     pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -297,7 +297,7 @@ parameter_types! {
     // Six sessions in an era (24 hours).
     pub const SessionsPerEra: sp_staking::SessionIndex = 6;
     // 28 eras for unbonding (28 days).
-    pub const BondingDuration: pallet_staking::EraIndex = 28;
+    pub const BondingDuration: pallet_staking::EraIndex = 7;
     pub const SlashDeferDuration: pallet_staking::EraIndex = 24 * 7; // 1/4 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 64;

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -823,7 +823,7 @@ pub fn bond_validator(acc: u64, val: u128) {
         RewardDestination::Controller
     ));
     create_did_and_add_claim(stash);
-    assert_ok!(Staking::add_potential_validator(
+    assert_ok!(Staking::add_permissioned_validator(
         Origin::system(frame_system::RawOrigin::Root),
         stash
     ));

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -387,7 +387,7 @@ fn staking_should_work() {
             ));
             let current_era_at_bond = Staking::current_era();
             // Add validator in the potential validator list
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 account_from(3)
             ));
@@ -2110,7 +2110,7 @@ fn switching_roles() {
             // create identity and add cdd claim
             create_did_and_add_claim(account_from(5));
             // add in to potential validator list
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 account_from(5)
             ));
@@ -2130,7 +2130,7 @@ fn switching_roles() {
 
             // 2 decides to be a validator. Consequences:
             // add in to potential validator list
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 account_from(1)
             ));
@@ -2235,7 +2235,7 @@ fn bond_with_little_staked_value_bounded() {
             // create identity and add provide valid claim
             create_did_and_add_claim(account_from(1));
             // add validator in potential validator list
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 account_from(1)
             ));
@@ -4128,7 +4128,7 @@ fn should_initialize_stakers_and_validators() {
 }
 
 #[test]
-fn should_add_potential_validators() {
+fn should_add_permissioned_validators() {
     ExtBuilder::default()
         .minimum_validator_count(2)
         .validator_count(2)
@@ -4140,22 +4140,17 @@ fn should_add_potential_validators() {
             let acc_10 = account_from(10);
             let acc_20 = account_from(20);
 
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 acc_10.clone()
             ));
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
-                acc_20.clone()
-            ));
-
-            assert_ok!(Staking::compliance_failed(
-                Origin::signed(account_from(3000)),
                 acc_20.clone()
             ));
             assert_eq!(
                 Staking::permissioned_validators(acc_10).unwrap().compliance,
-                Compliance::Active
+                Compliance::Pending
             );
             assert_eq!(
                 Staking::permissioned_validators(acc_20).unwrap().compliance,
@@ -4165,7 +4160,7 @@ fn should_add_potential_validators() {
 }
 
 #[test]
-fn should_remove_validators() {
+fn should_remove_permissioned_validators() {
     ExtBuilder::default()
         .minimum_validator_count(2)
         .validator_count(2)
@@ -4178,21 +4173,16 @@ fn should_remove_validators() {
             let acc_20 = account_from(20);
             let acc_30 = account_from(30);
 
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 acc_10.clone()
             ));
-            assert_ok!(Staking::add_potential_validator(
+            assert_ok!(Staking::add_permissioned_validator(
                 Origin::system(frame_system::RawOrigin::Root),
                 acc_20.clone()
             ));
 
-            assert_ok!(Staking::compliance_failed(
-                Origin::signed(account_from(3000)),
-                acc_20.clone()
-            ));
-
-            assert_ok!(Staking::remove_validator(
+            assert_ok!(Staking::remove_permissioned_validator(
                 Origin::signed(account_from(2000)),
                 acc_20.clone()
             ));
@@ -4200,7 +4190,7 @@ fn should_remove_validators() {
             assert_eq!(
                 Staking::permissioned_validators(&acc_10),
                 Some(PermissionedValidator {
-                    compliance: Compliance::Active
+                    compliance: Compliance::Pending
                 })
             );
             assert_eq!(Staking::permissioned_validators(&acc_20), None);

--- a/scripts/cli/environment.config.js
+++ b/scripts/cli/environment.config.js
@@ -5,7 +5,7 @@ module.exports = {
       name: "pmesh-primary-node",
       script:
         "../../target/release/polymesh",
-      args: "-d /tmp/pmesh-primary-node --pool-limit 100000 --ws-port 9944 --alice --validator --chain live --force-authoring",
+      args: "-d /tmp/pmesh-primary-node --pool-limit 100000 --ws-port 9944 --alice --validator --chain local --force-authoring",
       env: {
         RUST_BACKTRACE: "1",
       }
@@ -14,7 +14,7 @@ module.exports = {
       name: "pmesh-peer-node-1",
       script:
         "../../target/release/polymesh",
-      args: "-d /tmp/pmesh-peer-node-1 --ws-port 9945 --bob --validator --chain live --force-authoring",
+      args: "-d /tmp/pmesh-peer-node-1 --ws-port 9945 --bob --validator --chain local --force-authoring",
       env: {
         RUST_BACKTRACE: "1"
       }
@@ -23,7 +23,7 @@ module.exports = {
       name: "pmesh-peer-node-2",
       script:
         "../../target/release/polymesh",
-      args: "-d /tmp/pmesh-peer-node-2 --ws-port 9946 --charlie --validator --chain live --force-authoring",
+      args: "-d /tmp/pmesh-peer-node-2 --ws-port 9946 --charlie --validator --chain local --force-authoring",
       env: {
         RUST_BACKTRACE: "1"
       }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -262,6 +262,9 @@ fn general_testnet_genesis(
         pallet_staking: Some(V1Config::StakingConfig {
             minimum_validator_count: 1,
             validator_count: 2,
+            validator_commission: v1::Commission::Global(PerThing::from_rational_approximation(
+                1u64, 4u64,
+            )),
             stakers: initial_authorities
                 .iter()
                 .map(|x| {
@@ -275,9 +278,6 @@ fn general_testnet_genesis(
                 .collect(),
             invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
             slash_reward_fraction: general::Perbill::from_percent(10),
-            validator_commission: general::Commission::Global(
-                PerThing::from_rational_approximation(1u64, 4u64),
-            ),
             min_bond_threshold: 5_000_000_000_000,
             ..Default::default()
         }),
@@ -614,13 +614,13 @@ fn v1_live_testnet_genesis() -> GenesisConfig {
         pallet_staking: Some(V1Config::StakingConfig {
             minimum_validator_count: 1,
             validator_count: 8,
+            validator_commission: v1::Commission::Global(PerThing::zero()),
             stakers: initial_authorities
                 .iter()
                 .map(|x| (x.0.clone(), x.1.clone(), STASH, v1::StakerStatus::Validator))
                 .collect(),
             invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
             slash_reward_fraction: v1::Perbill::from_percent(10),
-            validator_commission: v1::Commission::Global(PerThing::zero()),
             min_bond_threshold: 5_000_000_000_000,
             ..Default::default()
         }),
@@ -915,15 +915,13 @@ fn v1_testnet_genesis(
         pallet_staking: Some(V1Config::StakingConfig {
             minimum_validator_count: 1,
             validator_count: 2,
+            validator_commission: v1::Commission::Global(PerThing::zero()),
             stakers: initial_authorities
                 .iter()
                 .map(|x| (x.0.clone(), x.1.clone(), STASH, v1::StakerStatus::Validator))
                 .collect(),
             invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
             slash_reward_fraction: v1::Perbill::from_percent(10),
-            validator_commission: v1::Commission::Global(PerThing::from_rational_approximation(
-                1u64, 4u64,
-            )),
             min_bond_threshold: 5_000_000_000_000,
             ..Default::default()
         }),


### PR DESCRIPTION
- ensure that validators are removed if they lose their CDD status
- correctly set validator preferences on genesis and fail on errors
- remove GC functions to set compliance, and instead refresh each era
- use local rather than live for cli setup