### PR TITLE
MESH-973: avoid 0-value transfers

### DIFF
--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -705,6 +705,9 @@ where
 impl<T: Trait> BlockRewardsReserveCurrency<T::Balance, NegativeImbalance<T>> for Module<T> {
     // Polymesh modified code. Drop behavious modified to reduce BRR balance instead of inflating total supply.
     fn drop_positive_imbalance(mut amount: T::Balance) {
+        if amount.is_zero() {
+            return;
+        }
         let brr = <BlockRewardsReserve<T>>::get();
         let _ = Self::try_mutate_account(&brr, |account| -> DispatchResult {
             if account.free > Zero::zero() {
@@ -727,6 +730,9 @@ impl<T: Trait> BlockRewardsReserveCurrency<T::Balance, NegativeImbalance<T>> for
     // Polymesh modified code. Instead of minting new tokens, this function tries to transfer tokens from BRR to the beneficiary.
     // If BRR does not have enough free funds, new tokens are issued.
     fn issue_using_block_rewards_reserve(mut amount: T::Balance) -> NegativeImbalance<T> {
+        if amount.is_zero() {
+            return NegativeImbalance::zero();
+        }
         let brr = <BlockRewardsReserve<T>>::get();
         Self::try_mutate_account(&brr, |account| -> Result<NegativeImbalance<T>, ()> {
             let amount_to_mint = if account.free > Zero::zero() {

--- a/pallets/runtime/common/tests/all/balances_test.rs
+++ b/pallets/runtime/common/tests/all/balances_test.rs
@@ -379,10 +379,11 @@ fn transfer_with_memo_we() {
     ];
     // Ignoring `frame_system` events
     let system_events = System::events();
+    let num_events = system_events.len();
     let emitted_events = vec![
-        system_events[13].clone(),
-        system_events[14].clone(),
-        system_events[15].clone(),
+        system_events[num_events - 3].clone(),
+        system_events[num_events - 2].clone(),
+        system_events[num_events - 1].clone(),
     ];
     assert_eq!(emitted_events, expected_events);
 }


### PR DESCRIPTION
This fixes the problem with 0-value transfer event spam but not the fact that only the treasury gets their share (80%) and the block author (the "5C" address) doesn't get anything. In other words, it was sent 0 amounts, which was causing the events to be sent.

I'm not sure at the moment why the author is neither of the stash block author accounts but rather some other fixed account.