### PR TITLE
Strong Typing added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler32"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "dc98824304f5513bb8f862f9e5985219003de4d730689e59d8f28818283a6fe4"
 
 [[package]]
 name = "app_dirs"
@@ -166,8 +175,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -249,24 +258,15 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "a5393cb2f40a6fae0014c9af00018e95846f3b241b331a6b7733c326d3e58108"
 dependencies = [
- "backtrace-sys",
+ "addr2line",
  "cfg-if",
  "libc",
+ "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -306,8 +306,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
  "regex",
  "rustc-hash",
  "shlex",
@@ -765,9 +765,9 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -893,9 +893,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "synstructure",
 ]
 
@@ -1044,9 +1044,9 @@ version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1056,9 +1056,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1066,9 +1066,9 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1233,9 +1233,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1358,6 +1358,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "glob"
@@ -1698,9 +1704,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1836,9 +1842,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -1978,9 +1984,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "libloading"
@@ -2075,8 +2081,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
 dependencies = [
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -2787,6 +2793,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "ole32-sys"
@@ -3528,10 +3540,10 @@ name = "pallet-staking-reward-curve"
 version = "2.0.0"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
  "sp-runtime",
- "syn 1.0.18",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -3776,9 +3788,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -3811,8 +3823,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.10",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "syn 1.0.21",
  "synstructure",
 ]
 
@@ -3889,9 +3901,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -3953,9 +3965,9 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -4348,9 +4360,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "version_check",
 ]
 
@@ -4360,9 +4372,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "syn-mid",
  "version_check",
 ]
@@ -4381,9 +4393,6 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-<<<<<<< HEAD
-version = "1.0.12"
-=======
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -4393,8 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
->>>>>>> Strong Typing added
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
@@ -4451,9 +4459,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -4511,11 +4519,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.12",
 ]
 
 [[package]]
@@ -5005,9 +5013,9 @@ version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -5772,9 +5780,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -5855,9 +5863,9 @@ checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags",
  "itertools",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -5915,9 +5923,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6007,9 +6015,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6185,9 +6193,9 @@ name = "sp-debug-derive"
 version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6343,9 +6351,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6561,9 +6569,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6582,9 +6590,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6714,9 +6722,6 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "syn"
-<<<<<<< HEAD
-version = "1.0.20"
-=======
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
@@ -6728,13 +6733,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.18"
->>>>>>> Strong Typing added
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1b5e337360b1fae433c59fcafa0c6b77c605e92540afa5221a7b81a9eca91d"
+checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
  "unicode-xid 0.2.0",
 ]
 
@@ -6744,9 +6748,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -6755,9 +6759,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "unicode-xid 0.2.0",
 ]
 
@@ -6820,22 +6824,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
+checksum = "467e5ff447618a916519a4e0d62772ab14f434897f3d63f05d8700ef1e9b22c1"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
+checksum = "e63c1091225b9834089b429bc4a2e01223470e3183e891582909e9d1c4cb55d9"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -7195,8 +7199,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.4",
- "syn 1.0.18",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -7271,9 +7275,9 @@ name = "type-metadata-derive"
 version = "0.1.0"
 source = "git+https://github.com/type-metadata/type-metadata.git?rev=02eae9f35c40c943b56af5b60616219f2b72b47d#02eae9f35c40c943b56af5b60616219f2b72b47d"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
 ]
 
 [[package]]
@@ -7471,9 +7475,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "wasm-bindgen-shared",
 ]
 
@@ -7495,7 +7499,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.4",
+ "quote 1.0.5",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7505,9 +7509,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7736,8 +7740,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.4",
- "syn 1.0.18",
+ "proc-macro2 1.0.12",
+ "quote 1.0.5",
+ "syn 1.0.21",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,8 +166,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -306,8 +306,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
  "regex",
  "rustc-hash",
  "shlex",
@@ -765,9 +765,9 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -893,9 +893,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -1044,9 +1044,9 @@ version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1056,9 +1056,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1066,9 +1066,9 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1233,9 +1233,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1698,9 +1698,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1836,9 +1836,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2075,8 +2075,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2847,6 +2847,7 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
+ "polymesh-primitives-derive",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -2968,6 +2969,7 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
+ "polymesh-primitives-derive",
  "serde",
  "serde_derive",
  "sp-api",
@@ -3364,6 +3366,7 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
+ "polymesh-primitives-derive",
  "serde",
  "serde_derive",
  "shrinkwraprs",
@@ -3525,10 +3528,10 @@ name = "pallet-staking-reward-curve"
 version = "2.0.0"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
  "sp-runtime",
- "syn",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3773,9 +3776,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3808,8 +3811,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.10",
+ "syn 1.0.18",
  "synstructure",
 ]
 
@@ -3886,9 +3889,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3950,9 +3953,9 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4064,6 +4067,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polymesh-primitives",
+ "polymesh-primitives-derive",
  "serde",
  "serde_derive",
  "sp-api",
@@ -4083,6 +4087,7 @@ dependencies = [
  "frame-system",
  "hex",
  "parity-scale-codec",
+ "polymesh-primitives-derive",
  "serde",
  "serde_json",
  "sp-core",
@@ -4090,6 +4095,14 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version",
+]
+
+[[package]]
+name = "polymesh-primitives-derive"
+version = "0.1.0"
+dependencies = [
+ "quote 0.6.13",
+ "syn 0.14.9",
 ]
 
 [[package]]
@@ -4124,6 +4137,7 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
+ "polymesh-primitives-derive",
  "polymesh-runtime-develop",
  "rand 0.7.3",
  "serde",
@@ -4334,9 +4348,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "version_check",
 ]
 
@@ -4346,9 +4360,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "syn-mid",
  "version_check",
 ]
@@ -4367,11 +4381,24 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
+<<<<<<< HEAD
 version = "1.0.12"
+=======
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.10"
+>>>>>>> Strong Typing added
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -4424,9 +4451,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4475,11 +4502,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.10",
 ]
 
 [[package]]
@@ -4969,9 +5005,9 @@ version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5736,9 +5772,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5819,9 +5855,9 @@ checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags",
  "itertools",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5879,9 +5915,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5971,9 +6007,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6149,9 +6185,9 @@ name = "sp-debug-derive"
 version = "2.0.0-alpha.3"
 source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8#a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6307,9 +6343,9 @@ source = "git+https://github.com/paritytech/substrate?rev=a439a7aa5a9a3df2a42d9b
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6525,9 +6561,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6546,9 +6582,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6678,13 +6714,28 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "syn"
+<<<<<<< HEAD
 version = "1.0.20"
+=======
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.18"
+>>>>>>> Strong Typing added
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd1b5e337360b1fae433c59fcafa0c6b77c605e92540afa5221a7b81a9eca91d"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -6693,9 +6744,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6704,10 +6755,10 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
@@ -6782,9 +6833,9 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7144,8 +7195,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7220,9 +7271,9 @@ name = "type-metadata-derive"
 version = "0.1.0"
 source = "git+https://github.com/type-metadata/type-metadata.git?rev=02eae9f35c40c943b56af5b60616219f2b72b47d#02eae9f35c40c943b56af5b60616219f2b72b47d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -7281,6 +7332,12 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -7414,9 +7471,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -7438,7 +7495,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7448,9 +7505,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7679,8 +7736,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.10",
+ "quote 1.0.4",
+ "syn 1.0.18",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [workspace]
 members = [
     "primitives",
-	"primitives_derive",
+    "primitives_derive",
     "pallets/runtime/common",
     "pallets/runtime/develop",
     "pallets/runtime/testnet-v1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [workspace]
 members = [
     "primitives",
+	"primitives_derive",
     "pallets/runtime/common",
     "pallets/runtime/develop",
     "pallets/runtime/testnet-v1",

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 # Common
-polymesh-primitives = { package = "polymesh-primitives", path = "../../primitives", default-features = false }
+polymesh-primitives = { path = "../../primitives", default-features = false }
+polymesh-primitives-derive = { path = "../../primitives_derive", default-features = false }
 polymesh-common-utilities = { package = "polymesh-common-utilities", path = "../common", default-features = false }
 
 # Our Pallets

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -110,6 +110,7 @@ use polymesh_primitives::{
     AccountKey, AuthorizationData, AuthorizationError, Document, IdentityId, LinkData, Signatory,
     SmartExtension, SmartExtensionName, SmartExtensionType, Ticker,
 };
+use polymesh_primitives_derive::VecU8StrongTyped;
 
 use codec::{Decode, Encode};
 use core::result::Result as StdResult;
@@ -181,50 +182,20 @@ impl Default for IdentifierType {
 }
 
 /// A wrapper for a token name.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct AssetName(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for AssetName {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        AssetName(v)
-    }
-}
-
-impl AssetName {
-    /// Returns a reference to the token name.
-    pub fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
-    }
-}
-
 /// A wrapper for an asset ID.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct AssetIdentifier(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for AssetIdentifier {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        AssetIdentifier(v)
-    }
-}
-
 /// A wrapper for a funding round name.
-#[derive(Decode, Encode, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Decode, Encode, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped)]
 pub struct FundingRoundName(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for FundingRoundName {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        FundingRoundName(v)
-    }
-}
 
 impl Default for FundingRoundName {
     fn default() -> Self {

--- a/pallets/balances/Cargo.toml
+++ b/pallets/balances/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 polymesh-common-utilities = { package = "polymesh-common-utilities", path = "../common", default-features = false }
-polymesh-primitives = { package = "polymesh-primitives", path = "../../primitives", default-features = false }
+polymesh-primitives = { path = "../../primitives", default-features = false }
+polymesh-primitives-derive = { path = "../../primitives_derive", default-features = false }
 pallet-transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment", default-features = false }
 
 serde = { version = "1.0.104", default-features = false }

--- a/pallets/common/Cargo.toml
+++ b/pallets/common/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 # Common
-polymesh-primitives = { package = "polymesh-primitives", path = "../../primitives", default-features = false }
+polymesh-primitives = { path = "../../primitives", default-features = false }
+polymesh-primitives-derive = { path = "../../primitives_derive", default-features = false }
 
 # Our Pallets
 pallet-transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment", default-features = false  }

--- a/pallets/common/src/traits/balances.rs
+++ b/pallets/common/src/traits/balances.rs
@@ -15,6 +15,9 @@
 
 use crate::traits::{identity::IdentityTrait, CommonTrait, NegativeImbalance};
 
+use polymesh_primitives::{AccountKey, IdentityId};
+use polymesh_primitives_derive::SliceU8StrongTyped;
+
 use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
@@ -22,35 +25,11 @@ use frame_support::{
     traits::{ExistenceRequirement, Get, OnUnbalanced, StoredMap, WithdrawReason, WithdrawReasons},
 };
 use frame_system::{self as system};
-use polymesh_primitives::{AccountKey, IdentityId};
 use sp_runtime::{traits::Saturating, RuntimeDebug};
-use sp_std::{cmp::min, ops::BitOr};
+use sp_std::ops::BitOr;
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Encode, Default, Decode, Clone, PartialEq, Eq, RuntimeDebug, SliceU8StrongTyped)]
 pub struct Memo(pub [u8; 32]);
-
-impl Default for Memo {
-    fn default() -> Self {
-        Memo([0u8; 32])
-    }
-}
-
-impl From<&[u8]> for Memo {
-    fn from(src: &[u8]) -> Memo {
-        let mut value = [0u8; 32];
-        let limit = min(src.len(), value.len());
-        value[..limit].copy_from_slice(&src[..limit]);
-
-        Memo(value)
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<&str> for Memo {
-    fn from(src: &str) -> Memo {
-        Memo::from(src.as_bytes())
-    }
-}
 
 // POLYMESH-NOTE: Make `AccountData` public to access it from the outside module.
 /// All balance information for an account.

--- a/pallets/pips/Cargo.toml
+++ b/pallets/pips/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 polymesh-common-utilities = { package = "polymesh-common-utilities", path = "../common", default-features = false  }
-polymesh-primitives = { package = "polymesh-primitives", path = "../../primitives", default-features = false  }
+polymesh-primitives = { path = "../../primitives", default-features = false }
+polymesh-primitives-derive = { path = "../../primitives_derive", default-features = false }
 pallet-protocol-fee = { package = "pallet-protocol-fee", path = "../protocol-fee", default-features = false }
 pallet-group = { package = "pallet-group", path = "../group", default-features = false }
 pallet-identity = { package = "pallet-identity", path = "../identity", default-features = false  }

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -83,6 +83,7 @@ use polymesh_common_utilities::{
     CommonTrait, Context, SystematicIssuers,
 };
 use polymesh_primitives::{AccountKey, Beneficiary, IdentityId, Signatory};
+use polymesh_primitives_derive::VecU8StrongTyped;
 use sp_core::H256;
 use sp_runtime::traits::{
     BlakeTwo256, CheckedAdd, CheckedSub, Dispatchable, EnsureOrigin, Hash, Saturating, Zero,
@@ -97,30 +98,16 @@ type BalanceOf<T> =
     <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
 /// A wrapper for a proposal url.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct Url(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for Url {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        Url(v)
-    }
-}
-
 /// A wrapper for a proposal description.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct PipDescription(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for PipDescription {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        PipDescription(v)
-    }
-}
 
 /// Represents a proposal
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]

--- a/pallets/runtime/common/Cargo.toml
+++ b/pallets/runtime/common/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 [dependencies]
 # Common
 polymesh-common-utilities = { package = "polymesh-common-utilities", path = "../../common", default-features = false }
-polymesh-primitives = { package = "polymesh-primitives", path = "../../../primitives", default-features = false }
+polymesh-primitives = { path = "../../../primitives", default-features = false }
+polymesh-primitives-derive = { path = "../../../primitives_derive", default-features = false }
 
 # Our pallets
 pallet-protocol-fee = { package = "pallet-protocol-fee", path = "../../protocol-fee", default-features = false }

--- a/pallets/runtime/common/src/voting.rs
+++ b/pallets/runtime/common/src/voting.rs
@@ -53,6 +53,7 @@ use polymesh_common_utilities::{
     CommonTrait, Context,
 };
 use polymesh_primitives::{AccountKey, IdentityId, Signatory, Ticker};
+use polymesh_primitives_derive::VecU8StrongTyped;
 
 use codec::{Decode, Encode};
 use frame_support::{
@@ -69,30 +70,16 @@ pub trait Trait: pallet_timestamp::Trait + frame_system::Trait + IdentityTrait {
 }
 
 /// A wrapper for a motion title.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct MotionTitle(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for MotionTitle {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        MotionTitle(v)
-    }
-}
-
 /// A wrapper for a motion info link.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct MotionInfoLink(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for MotionInfoLink {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        MotionInfoLink(v)
-    }
-}
 
 /// Details about ballots
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,14 +23,10 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
 
 [dev-dependencies]
-polymesh-primitives-derive = { path = "../primitives_derive" }
 hex = { version = "^0.4.0", default-features = false }
 serde_json = "1.0.48"
 
 [features]
-# Provide derive(VecU8StrongTyped, SliceU8StrongTyped) macros.
-# derive = ["polymesh-primitives-derive"]
-
 default = ["std"]
 std = [
 	"codec/std",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -5,8 +5,13 @@ authors = ["Polymath"]
 edition = "2018"
 
 [dependencies]
+# Ours
+polymesh-primitives-derive = { path = "../primitives_derive" }
+
+# Other 
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
+# Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
 sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
@@ -14,15 +19,18 @@ sp-version = { git = "https://github.com/paritytech/substrate", default-features
 sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
 sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
-
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, rev = "a439a7aa5a9a3df2a42d9b25ea04288d3a0866e8" }
 
 [dev-dependencies]
+polymesh-primitives-derive = { path = "../primitives_derive" }
 hex = { version = "^0.4.0", default-features = false }
 serde_json = "1.0.48"
 
 [features]
+# Provide derive(VecU8StrongTyped, SliceU8StrongTyped) macros.
+# derive = ["polymesh-primitives-derive"]
+
 default = ["std"]
 std = [
 	"codec/std",

--- a/primitives/src/document.rs
+++ b/primitives/src/document.rs
@@ -14,48 +14,27 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! Document type
-
 use codec::{Decode, Encode};
+use polymesh_primitives_derive::VecU8StrongTyped;
 use sp_std::prelude::Vec;
 
 /// A wrapper for a document name.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct DocumentName(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for DocumentName {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        DocumentName(v)
-    }
-}
-
 /// A wrapper for a document URI.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct DocumentUri(pub Vec<u8>);
 
-impl<T: AsRef<[u8]>> From<T> for DocumentUri {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        DocumentUri(v)
-    }
-}
-
 /// A wrapper for a document hash.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct DocumentHash(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for DocumentHash {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        DocumentHash(v)
-    }
-}
 
 /// Represents a document associated with an asset
 #[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/primitives/src/identity_claim.rs
+++ b/primitives/src/identity_claim.rs
@@ -14,6 +14,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{identity_id::IdentityId, Moment};
+use polymesh_primitives_derive::VecU8StrongTyped;
+
 use codec::{Decode, Encode};
 use sp_std::prelude::*;
 
@@ -117,17 +119,10 @@ impl Default for ClaimType {
 }
 
 /// A wrapper for Jurisdiction name.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct JurisdictionName(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for JurisdictionName {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        JurisdictionName(v)
-    }
-}
 
 /// All information of a particular claim
 #[derive(Encode, Decode, Clone, Default, PartialEq, Eq, Debug, PartialOrd, Ord)]

--- a/primitives/src/ignored_case_string.rs
+++ b/primitives/src/ignored_case_string.rs
@@ -22,7 +22,7 @@ pub struct IgnoredCaseString(Vec<u8>);
 
 impl IgnoredCaseString {
     /// It returns a reference to internal data.
-    pub fn as_vec(&self) -> &Vec<u8> {
+    pub fn as_slice(&self) -> &[u8] {
         &self.0
     }
 }
@@ -70,10 +70,10 @@ mod tests {
     #[test]
     fn from_with_upper_test() {
         let ics_from_str = IgnoredCaseString::from("lower case str");
-        assert_eq!(ics_from_str.as_vec().as_slice(), b"LOWER CASE STR");
+        assert_eq!(ics_from_str.as_slice(), b"LOWER CASE STR");
 
         let ics_from_u8 = IgnoredCaseString::from("lower case u8".as_bytes());
-        assert_eq!(ics_from_u8.as_vec().as_slice(), "LOWER CASE U8".as_bytes());
+        assert_eq!(ics_from_u8.as_slice(), "LOWER CASE U8".as_bytes());
     }
 
     #[test]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -170,3 +170,72 @@ pub struct Beneficiary<Balance> {
     /// Amount requested to this beneficiary.
     pub amount: Balance,
 }
+
+#[cfg(test)]
+mod tests {
+    use polymesh_primitives_derive::{SliceU8StrongTyped, VecU8StrongTyped};
+
+    #[derive(VecU8StrongTyped)]
+    struct A(Vec<u8>);
+    #[derive(VecU8StrongTyped)]
+    struct B(Vec<u8>);
+
+    #[derive(Default, SliceU8StrongTyped)]
+    struct C([u8; 16]);
+    #[derive(Default, SliceU8StrongTyped)]
+    struct D([u8; 16]);
+
+    #[test]
+    fn vec_strong_typed() {
+        let text1 = &b"Lorem Ipsum ";
+        let text2 = &b"dolor sit amet";
+        // let text3 = &b"Lorem Ipsum dolor sit amet";
+
+        // From traits.
+        let mut a1 = A::from(text1);
+        let a2: A = text1.into();
+        let _b1 = B::from(text2.to_vec());
+        let _b2: B = text2.to_vec().into();
+
+        // Deref & DerefMut
+        assert_eq!(*a1, text1[..]);
+        a1[6] = b'i';
+        assert_eq!(a1.as_slice(), &b"Lorem ipsum "[..]);
+
+        // Other methods.
+        assert_eq!(a2.len(), text1.len());
+        assert_eq!(a2.as_slice(), &text1[..]);
+        assert_eq!(a2.as_vec().clone(), text1.to_vec());
+
+        // Strong types are not equal.
+        // The below line does NOT compile.
+        // let a3 :A = _b1;
+    }
+
+    #[test]
+    fn slice_strong_typed() {
+        let text1 = &b"lorem Ipsum ";
+        let text2 = &b"dolor sit amet";
+        // let text3 = &b"Lorem Ipsum dolor sit amet";
+
+        // From traits.
+        let mut c1 = C::from(text1);
+        let c2: C = text1.into();
+        let _d1 = D::from(text2.to_vec());
+        let _d2: D = text2.to_vec().into();
+
+        // Deref & DerefMut
+        let text1_with_zeros = &b"lorem Ipsum \0\0\0\0";
+        assert_eq!(*c1, text1_with_zeros[..]);
+        c1[6] = b'i';
+        assert_eq!(c1.as_slice(), &b"lorem ipsum \0\0\0\0"[..]);
+
+        // Other methods.
+        assert_eq!(c2.len(), text1_with_zeros.len());
+        assert_eq!(c2.as_slice(), &text1_with_zeros[..]);
+
+        // Strong types are not equal.
+        // The below line does NOT compile.
+        // let c3 :C = _d1;
+    }
+}

--- a/primitives/src/smart_extension.rs
+++ b/primitives/src/smart_extension.rs
@@ -14,6 +14,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
+use polymesh_primitives_derive::VecU8StrongTyped;
 use sp_std::prelude::Vec;
 
 /// Smart Extension types
@@ -32,17 +33,10 @@ impl Default for SmartExtensionType {
 }
 
 /// A wrapper for a smart extension name.
-#[derive(Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Decode, Encode, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, VecU8StrongTyped,
+)]
 pub struct SmartExtensionName(pub Vec<u8>);
-
-impl<T: AsRef<[u8]>> From<T> for SmartExtensionName {
-    fn from(s: T) -> Self {
-        let s = s.as_ref();
-        let mut v = Vec::with_capacity(s.len());
-        v.extend_from_slice(s);
-        SmartExtensionName(v)
-    }
-}
 
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
 /// U type refers to the AccountId which will act

--- a/primitives_derive/Cargo.toml
+++ b/primitives_derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "polymesh-primitives-derive"
+version = "0.1.0"
+authors = ["Polymath"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.14.4"
+quote = "0.6.3"

--- a/primitives_derive/src/lib.rs
+++ b/primitives_derive/src/lib.rs
@@ -45,14 +45,6 @@ fn impl_vec_u8_strong_typed(ast: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        /*
-        impl AsRef<[u8]> for #name {
-            #[inline]
-            fn as_ref(&self) -> &[u8] {
-                self.0.as_ref()
-            }
-        }*/
-
         impl sp_std::ops::Deref for #name {
             type Target = [u8];
 
@@ -128,20 +120,6 @@ fn impl_slice_u8_strong_typed(ast: &syn::DeriveInput) -> TokenStream {
             }
         }
     };
-
-    /*
-        #[cfg(feature = "std")]
-        impl From<&str> for #name {
-            #name::from(src.as_bytes())
-        }
-
-        impl AsRef<[u8]> for #name {
-            #[inline]
-            fn as_ref(&self) -> &[u8] {
-                #name.0
-            }
-        }
-    */
 
     gen.into()
 }

--- a/primitives_derive/src/lib.rs
+++ b/primitives_derive/src/lib.rs
@@ -67,7 +67,7 @@ fn impl_vec_u8_strong_typed(ast: &syn::DeriveInput) -> TokenStream {
 
 /// Parses the AST to generate the code associated.
 #[proc_macro_derive(SliceU8StrongTyped)]
-pub fn slice_u8strong_typed_derive(input: TokenStream) -> TokenStream {
+pub fn slice_u8_strong_typed_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
 
     impl_slice_u8_strong_typed(&ast)

--- a/primitives_derive/src/lib.rs
+++ b/primitives_derive/src/lib.rs
@@ -1,0 +1,147 @@
+extern crate proc_macro;
+extern crate syn;
+
+#[macro_use]
+extern crate quote;
+
+use proc_macro::TokenStream;
+
+/// Parses the AST to generate the code associated.
+#[proc_macro_derive(VecU8StrongTyped)]
+pub fn vec_u8_strong_typed_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_vec_u8_strong_typed(&ast)
+}
+
+/// Implements utility method for *strong typed* based on `Vec<u8>`.
+fn impl_vec_u8_strong_typed(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = quote! {
+        impl #name {
+
+            /// Returns the number of elements.
+            #[inline]
+            pub fn len(&self) -> usize {
+                self.0.len()
+            }
+
+            /// Extracts a slice containing the entire vector.
+            #[inline]
+            pub fn as_slice(&self) -> &[u8] {
+                &self.0
+            }
+
+            /// Extracts the internal vector.
+            #[inline]
+            pub fn as_vec(&self) -> &Vec<u8> {
+                &self.0
+            }
+        }
+
+        impl<T: AsRef<[u8]>> From<T> for #name {
+            #[inline]
+            fn from(r: T) -> Self {
+                #name(r.as_ref().to_vec())
+            }
+        }
+
+        /*
+        impl AsRef<[u8]> for #name {
+            #[inline]
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
+            }
+        }*/
+
+        impl sp_std::ops::Deref for #name {
+            type Target = [u8];
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                self.0.deref()
+            }
+        }
+
+        impl sp_std::ops::DerefMut for #name {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.0.deref_mut()
+            }
+        }
+    };
+
+    gen.into()
+}
+
+/// Parses the AST to generate the code associated.
+#[proc_macro_derive(SliceU8StrongTyped)]
+pub fn slice_u8strong_typed_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    impl_slice_u8_strong_typed(&ast)
+}
+
+/// Implements all utility method for *strong typed* based on `[u8]`.
+fn impl_slice_u8_strong_typed(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = quote! {
+        impl #name {
+            /// Returns the number of elements.
+            #[inline]
+            pub fn len(&self) -> usize {
+                self.0.len()
+            }
+
+            /// Extracts a slice containing the entire content.
+            #[inline]
+            pub fn as_slice(&self) -> &[u8] {
+                &self.0[..]
+            }
+        }
+
+        impl<T: AsRef<[u8]>> From<T> for #name {
+            fn from(s: T) -> Self {
+                let s = s.as_ref();
+                let mut v = #name::default();
+                let limit = sp_std::cmp::min(v.len(), s.len());
+
+                let inner = &mut v.0[..limit];
+                inner.copy_from_slice( &s[..limit]);
+
+                v
+            }
+        }
+
+        impl sp_std::ops::Deref for #name {
+            type Target = [u8];
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                &self.0[..]
+            }
+        }
+
+        impl sp_std::ops::DerefMut for #name {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0[..]
+            }
+        }
+    };
+
+    /*
+        #[cfg(feature = "std")]
+        impl From<&str> for #name {
+            #name::from(src.as_bytes())
+        }
+
+        impl AsRef<[u8]> for #name {
+            #[inline]
+            fn as_ref(&self) -> &[u8] {
+                #name.0
+            }
+        }
+    */
+
+    gen.into()
+}


### PR DESCRIPTION
- New module for *procedural macros*: `primitives_derive`.
- New `derive` macros:
   - `VecU8StrongTyped`: It generates code for types like `struct StrongTypeXXX( Vec<u8>)`.
   - `SliceU8StrongTyped`: It generates code for types like `struct StrongTypeYYY( [u8; ZZ])`.

@vkomenda y UT has been added to `primitives` crate because we cannot test *procedural macros* in the same crate that they are defined.