### PR TITLE
Rename protocol Ops

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1103,7 +1103,7 @@ decl_module! {
             let signer = Signatory::from(ticker_did);
             <<T as IdentityTrait>::ProtocolFee>::charge_fee_batch(
                 &Signatory::AccountKey(sender_key),
-                ProtocolOp::AssetAddDocument,
+                ProtocolOp::AssetAddDocuments,
                 documents.len()
             )?;
             documents.into_iter().for_each(|doc| {

--- a/pallets/common/src/protocol_fee.rs
+++ b/pallets/common/src/protocol_fee.rs
@@ -25,7 +25,7 @@ use sp_runtime::{Deserialize, Serialize};
 pub enum ProtocolOp {
     AssetRegisterTicker,
     AssetIssue,
-    AssetAddDocument,
+    AssetAddDocuments,
     AssetCreateAsset,
     DividendNew,
     ComplianceManagerAddActiveRule,
@@ -33,7 +33,7 @@ pub enum ProtocolOp {
     IdentityCddRegisterDid,
     IdentityAddClaim,
     IdentitySetMasterKey,
-    IdentityAddSigningItem,
+    IdentityAddSigningItemsWithAuthorization,
     PipsPropose,
     VotingAddBallot,
 }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1077,7 +1077,7 @@ decl_module! {
             // 1.999. Charge the fee.
             T::ProtocolFee::charge_fee_batch(
                 &Signatory::AccountKey(sender_key),
-                ProtocolOp::IdentityAddSigningItem,
+                ProtocolOp::IdentityAddSigningItemsWithAuthorization,
                 additional_keys.len()
             )?;
             // 2.1. Link keys to identity
@@ -1226,14 +1226,14 @@ impl<T: Trait> Module<T> {
             } else {
                 T::ProtocolFee::charge_fee(
                     &Signatory::Identity(identity_to_join),
-                    ProtocolOp::IdentityAddSigningItem,
+                    ProtocolOp::IdentityAddSigningItemsWithAuthorization,
                 )?;
                 Self::link_key_to_did(&key, SignatoryType::External, identity_to_join);
             }
         } else {
             T::ProtocolFee::charge_fee(
                 &Signatory::Identity(identity_to_join),
-                ProtocolOp::IdentityAddSigningItem,
+                ProtocolOp::IdentityAddSigningItemsWithAuthorization,
             )?;
         }
         <DidRecords>::mutate(identity_to_join, |identity| {

--- a/pallets/runtime/common/tests/all/ext_builder.rs
+++ b/pallets/runtime/common/tests/all/ext_builder.rs
@@ -40,7 +40,7 @@ impl Default for MockProtocolBaseFees {
         let ops = vec![
             ProtocolOp::AssetRegisterTicker,
             ProtocolOp::AssetIssue,
-            ProtocolOp::AssetAddDocument,
+            ProtocolOp::AssetAddDocuments,
             ProtocolOp::AssetCreateAsset,
             ProtocolOp::DividendNew,
             ProtocolOp::ComplianceManagerAddActiveRule,
@@ -48,7 +48,7 @@ impl Default for MockProtocolBaseFees {
             ProtocolOp::IdentityCddRegisterDid,
             ProtocolOp::IdentityAddClaim,
             ProtocolOp::IdentitySetMasterKey,
-            ProtocolOp::IdentityAddSigningItem,
+            ProtocolOp::IdentityAddSigningItemsWithAuthorization,
             ProtocolOp::PipsPropose,
             ProtocolOp::VotingAddBallot,
         ];

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -434,7 +434,7 @@
             "_enum": [
                 "AssetRegisterTicker",
                 "AssetIssue",
-                "AssetAddDocument",
+                "AssetAddDocuments",
                 "AssetCreateAsset",
                 "DividendNew",
                 "ComplianceManagerAddActiveRule",
@@ -442,7 +442,7 @@
                 "IdentityCddRegisterDid",
                 "IdentityAddClaim",
                 "IdentitySetMasterKey",
-                "IdentityAddSigningItem",
+                "IdentityAddSigningItemsWithAuthorization",
                 "PipsPropose",
                 "VotingAddBallot"
             ]


### PR DESCRIPTION
Rename protocol ops to pattern: `{ModuleName}{ExtrinsicName}`.