### PR TITLE
Common Systematic Accounts

### DIFF
--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -199,7 +199,7 @@ use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
     traits::{
         Bounded, CheckedAdd, CheckedSub, Hash, MaybeSerializeDeserialize, Saturating, StaticLookup,
-        Zero,
+        Zero, AccountIdConversion,
     },
     DispatchError, DispatchResult, RuntimeDebug,
 };
@@ -275,13 +275,6 @@ decl_storage! {
         // Polymesh-Note : Change to facilitate the DID charging
         /// Signing key => Charge Fee to did?. Default is false i.e. the fee will be charged from user balance
         pub ChargeDid get(charge_did): map hasher(twox_64_concat) AccountKey => bool;
-
-        // Polymesh-Note : Change to facilitate the BRR functionality
-        /// AccountId of the block rewards reserve
-        pub BlockRewardsReserve get(block_rewards_reserve) build(|_| {
-            let h: T::Hash = T::Hashing::hash(&(b"BLOCK_REWARDS_RESERVE").encode());
-            T::AccountId::decode(&mut &h.encode()[..]).unwrap_or_default()
-        }): T::AccountId;
     }
     add_extra_genesis {
         config(balances): Vec<(T::AccountId, T::Balance)>;
@@ -542,6 +535,10 @@ impl<T: Trait> Module<T> {
         Self::account(who.borrow()).reserved
     }
 
+    pub fn block_rewards_reserve() -> T::AccountId {
+        SystematicIssuers::BlockRewardReserve.as_module_id().into_account()
+    }
+
     /// Get both the free and reserved balances of an account.
     fn account(who: &T::AccountId) -> AccountData<T::Balance> {
         T::AccountStore::get(&who)
@@ -750,7 +747,7 @@ impl<T: Trait> BlockRewardsReserveCurrency<T::Balance, NegativeImbalance<T>> for
         if amount.is_zero() {
             return;
         }
-        let brr = <BlockRewardsReserve<T>>::get();
+        let brr = Self::block_rewards_reserve();
         let _ = Self::try_mutate_account(&brr, |account| -> DispatchResult {
             if account.free > Zero::zero() {
                 let old_brr_free_balance = account.free;
@@ -775,7 +772,7 @@ impl<T: Trait> BlockRewardsReserveCurrency<T::Balance, NegativeImbalance<T>> for
         if amount.is_zero() {
             return NegativeImbalance::zero();
         }
-        let brr = <BlockRewardsReserve<T>>::get();
+        let brr = Self::block_rewards_reserve();
         Self::try_mutate_account(&brr, |account| -> Result<NegativeImbalance<T>, ()> {
             let amount_to_mint = if account.free > Zero::zero() {
                 let old_brr_free_balance = account.free;

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -198,8 +198,8 @@ use frame_support::{
 use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
     traits::{
-        Bounded, CheckedAdd, CheckedSub, Hash, MaybeSerializeDeserialize, Saturating, StaticLookup,
-        Zero, AccountIdConversion,
+        AccountIdConversion, Bounded, CheckedAdd, CheckedSub, Hash, MaybeSerializeDeserialize,
+        Saturating, StaticLookup, Zero,
     },
     DispatchError, DispatchResult, RuntimeDebug,
 };
@@ -536,7 +536,9 @@ impl<T: Trait> Module<T> {
     }
 
     pub fn block_rewards_reserve() -> T::AccountId {
-        SystematicIssuers::BlockRewardReserve.as_module_id().into_account()
+        SystematicIssuers::BlockRewardReserve
+            .as_module_id()
+            .into_account()
     }
 
     /// Get both the free and reserved balances of an account.

--- a/pallets/common/src/constants.rs
+++ b/pallets/common/src/constants.rs
@@ -17,12 +17,15 @@ pub mod did {
     pub const USER: &[u8; 5] = b"USER:";
     /// prefix for security token dids
     pub const SECURITY_TOKEN: &[u8; 15] = b"SECURITY_TOKEN:";
+
     /// Governance Committee DID. It is used in systematic CDD claim for Governance Committee members.
     pub const GOVERNANCE_COMMITTEE_DID: &[u8; 32] = b"system:governance_committee\0\0\0\0\0";
     /// CDD Providers DID. It is used in systematic CDD claim for CDD Providers.
     pub const CDD_PROVIDERS_DID: &[u8; 32] = b"system:customer_due_diligence\0\0\0";
     /// Treasury module DID. It is used in systematic CDD claim for the Treasury module.
-    pub const TREASURY_MODULE_DID: &[u8; 32] = b"system:treasury_module_did\0\0\0\0\0\0";
+    pub const TREASURY_DID: &[u8; 32] = b"system:treasury_module_did\0\0\0\0\0\0";
+    /// Block Reward Reserve DID.
+    pub const BLOCK_REWARD_RESERVE_DID: &[u8; 32] = b"system:block_reward_reserve_did\0";
 }
 
 // ERC1400 transfer status codes
@@ -52,3 +55,6 @@ pub const PIP_MAX_REPORTING_SIZE: usize = 1024;
 
 /// Module ids, used for deriving sovereign account IDs for modules.
 pub const TREASURY_MODULE_ID: ModuleId = ModuleId(*b"pm/trsry");
+pub const BRR_MODULE_ID: ModuleId = ModuleId(*b"pm/blrwr");
+pub const GC_MODULE_ID: ModuleId = ModuleId(*b"pm/govcm");
+pub const CDD_MODULE_ID: ModuleId = ModuleId(*b"pm/cusdd");

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -57,6 +57,19 @@ pub enum SystematicIssuers {
     BlockRewardReserve,
 }
 
+impl core::fmt::Display for SystematicIssuers {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let value = match self {
+            SystematicIssuers::Committee => "Governance Committee",
+            SystematicIssuers::CDDProvider => "CDD Trusted Providers",
+            SystematicIssuers::Treasury => "Treasury",
+            SystematicIssuers::BlockRewardReserve => "Block Reward Reserve",
+        };
+
+        write!(f, "'{}'", value)
+    }
+}
+
 pub const SYSTEMATIC_ISSUERS: &[SystematicIssuers] = &[
     SystematicIssuers::Treasury,
     SystematicIssuers::Committee,

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -34,6 +34,7 @@ pub use protocol_fee::ChargeProtocolFee;
 
 use core::convert::From;
 use polymesh_primitives::IdentityId;
+use sp_runtime::ModuleId;
 
 /// It defines the valid issuers for Systematic Claims.
 ///
@@ -52,23 +53,45 @@ use polymesh_primitives::IdentityId;
 pub enum SystematicIssuers {
     Committee,
     CDDProvider,
-    TreasuryModule,
+    Treasury,
+    BlockRewardReserve,
 }
+
+pub const SYSTEMATIC_ISSUERS: &[SystematicIssuers] = &[
+    SystematicIssuers::Treasury,
+    SystematicIssuers::Committee,
+    SystematicIssuers::CDDProvider,
+    SystematicIssuers::BlockRewardReserve,
+];
 
 impl SystematicIssuers {
     /// It returns the representation of this issuer as a raw public key.
     pub fn as_bytes(self) -> &'static [u8; 32] {
-        use constants::did::{CDD_PROVIDERS_DID, GOVERNANCE_COMMITTEE_DID, TREASURY_MODULE_DID};
+        use constants::did::{
+            BLOCK_REWARD_RESERVE_DID, CDD_PROVIDERS_DID, GOVERNANCE_COMMITTEE_DID, TREASURY_DID,
+        };
 
         match self {
             SystematicIssuers::Committee => GOVERNANCE_COMMITTEE_DID,
             SystematicIssuers::CDDProvider => CDD_PROVIDERS_DID,
-            SystematicIssuers::TreasuryModule => TREASURY_MODULE_DID,
+            SystematicIssuers::Treasury => TREASURY_DID,
+            SystematicIssuers::BlockRewardReserve => BLOCK_REWARD_RESERVE_DID,
         }
     }
 
     /// It returns the Identity Identifier of this issuer.
     pub fn as_id(self) -> IdentityId {
         IdentityId::from(*self.as_bytes())
+    }
+
+    pub fn as_module_id(self) -> ModuleId {
+        use constants::{BRR_MODULE_ID, CDD_MODULE_ID, GC_MODULE_ID, TREASURY_MODULE_ID};
+
+        match self {
+            SystematicIssuers::Committee => GC_MODULE_ID,
+            SystematicIssuers::CDDProvider => CDD_MODULE_ID,
+            SystematicIssuers::Treasury => TREASURY_MODULE_ID,
+            SystematicIssuers::BlockRewardReserve => BRR_MODULE_ID,
+        }
     }
 }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -87,10 +87,7 @@ pub mod benchmarking;
 use pallet_identity_rpc_runtime_api::DidRecords as RpcDidRecords;
 use pallet_transaction_payment::{CddAndFeeDetails, ChargeTxFee};
 use polymesh_common_utilities::{
-    constants::{
-        did::{CDD_PROVIDERS_DID, GOVERNANCE_COMMITTEE_DID, SECURITY_TOKEN, USER},
-        TREASURY_MODULE_ID,
-    },
+    constants::did::{SECURITY_TOKEN, USER},
     protocol_fee::{ChargeProtocolFee, ProtocolOp},
     traits::{
         asset::AcceptTransfer,
@@ -101,7 +98,7 @@ use polymesh_common_utilities::{
         },
         multisig::AddSignerMultiSig,
     },
-    Context, SystematicIssuers,
+    Context, SystematicIssuers, SYSTEMATIC_ISSUERS,
 };
 use polymesh_primitives::{
     AccountKey, AuthIdentifier, Authorization, AuthorizationData, AuthorizationError, Claim,
@@ -207,74 +204,25 @@ decl_storage! {
         config(identities): Vec<(T::AccountId, IdentityId, IdentityId, Option<u64>)>;
         config(signing_keys): Vec<(T::AccountId, IdentityId)>;
         build(|config: &GenesisConfig<T>| {
-            // Add systematic CDD for the Treasury module
-            let treasury_account_id: T::AccountId = TREASURY_MODULE_ID.into_account();
-            let treasury_master_key = AccountKey::try_from(treasury_account_id.encode()).unwrap();
-            let treasury_did = SystematicIssuers::TreasuryModule.as_id();
-            <Module<T>>::link_key_to_did(&treasury_master_key, SignatoryType::External, treasury_did);
-            let record = DidRecord {
-                master_key: treasury_master_key,
-                ..Default::default()
-            };
-            <DidRecords>::insert(&treasury_did, record);
-            <Module<T>>::deposit_event(RawEvent::DidCreated(treasury_did.clone(), treasury_account_id.clone(), vec![]));
+            SYSTEMATIC_ISSUERS.iter()
+                .for_each(|s| <Module<T>>::register_systematic_id(*s));
 
-            // Add the claim data for the CustomerDueDiligence type claim for Treasury module
-            let claim_type = ClaimType::CustomerDueDiligence;
-            let pk = Claim1stKey{ target: treasury_did, claim_type };
-            let sk = Claim2ndKey{ issuer: treasury_did, scope: None };
-            let id_claim = IdentityClaim {
-                claim_issuer: treasury_did,
-                issuance_date: 0_u64,
-                last_update_date: 0_u64,
-                expiry: None,
-                claim: Claim::CustomerDueDiligence,
-            };
-
-            <Claims>::insert(&pk, &sk, id_claim.clone());
-            <Module<T>>::deposit_event(RawEvent::ClaimAdded(treasury_did, id_claim));
-
-            // Add System DID: Governance committee && CDD providers
-            [GOVERNANCE_COMMITTEE_DID, CDD_PROVIDERS_DID, ].iter()
-                .for_each(|raw_id| {
-                    let id = IdentityId::from(**raw_id);
-                    let master_key = AccountKey::from(**raw_id);
-
-                    <DidRecords>::insert( id, DidRecord {
-                        master_key,
-                        ..Default::default()
-                    });
-                    <Module<T>>::deposit_event(RawEvent::DidCreated(id.clone(), T::AccountId::decode(&mut master_key.as_slice()).unwrap(), vec![]));
-                });
+            // Add CDD claims to Treasury & BRR
+            let sys_issuers_with_cdd = [
+                SystematicIssuers::Treasury.as_id(),
+                SystematicIssuers::BlockRewardReserve.as_id()];
+            <Module<T>>::unsafe_add_systematic_cdd_claims( &sys_issuers_with_cdd, SystematicIssuers::CDDProvider);
 
             //  Other
             for &(ref master_account_id, issuer, did, expiry) in &config.identities {
                 // Direct storage change for registering the DID and providing the claim
-                let master_key = AccountKey::try_from(master_account_id.encode()).unwrap();
                 assert!(!<DidRecords>::contains_key(did), "Identity already exist");
                 <MultiPurposeNonce>::mutate(|n| *n += 1_u64);
-                <Module<T>>::link_key_to_did(&master_key, SignatoryType::External, did);
-                let record = DidRecord {
-                    master_key,
-                    ..Default::default()
-                };
-                <DidRecords>::insert(&did, record);
-                <Module<T>>::deposit_event(RawEvent::DidCreated(did.clone(), master_account_id.clone(), vec![]));
-                // Add the claim data for the CustomerDueDiligence type claim
-                let claim_type = ClaimType::CustomerDueDiligence;
-                let pk = Claim1stKey{ target: did, claim_type };
-                let sk = Claim2ndKey{ issuer, scope: None };
-                let id_claim = IdentityClaim {
-                    claim_issuer: issuer,
-                    issuance_date: 0_u64,
-                    last_update_date: 0_u64,
-                    expiry: expiry,
-                    claim: Claim::CustomerDueDiligence,
-                };
-
-                <Claims>::insert(&pk, &sk, id_claim.clone());
-                <Module<T>>::deposit_event(RawEvent::ClaimAdded(did, id_claim));
+                let expiry = expiry.iter().map(|m| T::Moment::from(*m as u32)).next();
+                <Module<T>>::unsafe_register_id(master_account_id.clone(), did);
+                <Module<T>>::unsafe_add_claim( did, Claim::CustomerDueDiligence, issuer, expiry);
             }
+
             for &(ref signer_id, did) in &config.signing_keys {
                 // Direct storage change for attaching some signing keys to identities
                 let signer_key = AccountKey::try_from(signer_id.encode()).unwrap();
@@ -1672,14 +1620,8 @@ impl<T: Trait> Module<T> {
         active_cdds: &[IdentityId],
         inactive_not_expired_cdds: &[InactiveMember<T::Moment>],
     ) -> bool {
-        let systematic_cdds = [
-            SystematicIssuers::TreasuryModule.as_id(),
-            SystematicIssuers::Committee.as_id(),
-            SystematicIssuers::CDDProvider.as_id(),
-        ];
         Self::is_identity_claim_not_expired_at(id_claim, exp_with_leeway)
             && (active_cdds.contains(&id_claim.claim_issuer)
-                || systematic_cdds.contains(&id_claim.claim_issuer)
                 || inactive_not_expired_cdds
                     .iter()
                     .filter(|cdd| cdd.id == id_claim.claim_issuer)
@@ -2048,6 +1990,27 @@ impl<T: Trait> Module<T> {
         } else {
             RpcDidRecords::IdNotFound
         }
+    }
+
+    /// Registers the systematic issuer with its DID.
+    fn register_systematic_id(issuer: SystematicIssuers) {
+        let acc = issuer.as_module_id().into_account();
+        let id = issuer.as_id();
+
+        Self::unsafe_register_id(acc, id);
+    }
+
+    /// Registers `master_key` as `id` identity.
+    fn unsafe_register_id(acc: T::AccountId, id: IdentityId) {
+        let master_key = AccountKey::try_from(acc.encode()).unwrap();
+        <Module<T>>::link_key_to_did(&master_key, SignatoryType::External, id);
+        let record = DidRecord {
+            master_key,
+            ..Default::default()
+        };
+        <DidRecords>::insert(&id, record);
+
+        Self::deposit_event(RawEvent::DidCreated(id, acc, vec![]));
     }
 }
 


### PR DESCRIPTION
- Common way to initialize Systematic Account, see `Identity::add_extra_genesis`.
- BRR and Treasury identities have a CDD claim from Systematic CDD providers (like CDD trusted provider members).
- BRR is now a real account with Id & CDD claim.