### PR TITLE
Pay with master key

### DIFF
--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -235,10 +235,10 @@ fn is_auth_valid(
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
                     let master =
-                        Identity::did_records(&identity_data_to_join.target_did).master_key;
-                    let master_signatory = Signatory::Account(master);
+                        Identity::did_records(&did).master_key;
+                    let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
-                        let _ = check_cdd(&identity_data_to_join.target_did);
+                        let _ = check_cdd(&did);
                         return Ok(Some(master_signatory));
                     }
                 }

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -234,8 +234,7 @@ fn is_auth_valid(
             CallType::AcceptIdentitySigner => {
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
-                    let master =
-                        Identity::did_records(&did).master_key;
+                    let master = Identity::did_records(&did).master_key;
                     let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
                         let _ = check_cdd(&did);

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -237,7 +237,7 @@ fn is_auth_valid(
                     let master = Identity::did_records(&did).master_key;
                     let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
-                        let _ = check_cdd(&did);
+                        let _ = check_cdd(&did)?;
                         return Ok(Some(master_signatory));
                     }
                 }

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -234,9 +234,12 @@ fn is_auth_valid(
             CallType::AcceptIdentitySigner => {
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
-                    let master = Identity::did_records(&did).master_key;
-                    if auth.authorized_by == Signatory::from(master) {
-                        return check_cdd(&did);
+                    let master =
+                        Identity::did_records(&identity_data_to_join.target_did).master_key;
+                    let master_signatory = Signatory::Account(master);
+                    if auth.authorized_by == master_signatory {
+                        let _ = check_cdd(&identity_data_to_join.target_did);
+                        return Ok(Some(master_signatory));
                     }
                 }
             }

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -95,8 +95,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh"),
     impl_name: create_runtime_str!("polymath-polymesh"),
     authoring_version: 1,
-    spec_version: 1007,
-    impl_version: 1007,
+    spec_version: 1010,
+    impl_version: 1010,
     apis: RUNTIME_API_VERSIONS,
 };
 

--- a/pallets/runtime/testnet-v1/src/fee_details.rs
+++ b/pallets/runtime/testnet-v1/src/fee_details.rs
@@ -232,9 +232,12 @@ fn is_auth_valid(
             CallType::AcceptIdentitySigner => {
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
-                    let master = Identity::did_records(&did).master_key;
-                    if auth.authorized_by == Signatory::from(master) {
-                        return check_cdd(&did);
+                    let master =
+                        Identity::did_records(&identity_data_to_join.target_did).master_key;
+                    let master_signatory = Signatory::Account(master);
+                    if auth.authorized_by == master_signatory {
+                        let _ = check_cdd(&identity_data_to_join.target_did);
+                        return Ok(Some(master_signatory));
                     }
                 }
             }

--- a/pallets/runtime/testnet-v1/src/fee_details.rs
+++ b/pallets/runtime/testnet-v1/src/fee_details.rs
@@ -235,7 +235,7 @@ fn is_auth_valid(
                     let master = Identity::did_records(&did).master_key;
                     let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
-                        let _ = check_cdd(&did);
+                        let _ = check_cdd(&did)?;
                         return Ok(Some(master_signatory));
                     }
                 }

--- a/pallets/runtime/testnet-v1/src/fee_details.rs
+++ b/pallets/runtime/testnet-v1/src/fee_details.rs
@@ -233,10 +233,10 @@ fn is_auth_valid(
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
                     let master =
-                        Identity::did_records(&identity_data_to_join.target_did).master_key;
-                    let master_signatory = Signatory::Account(master);
+                        Identity::did_records(&did).master_key;
+                    let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
-                        let _ = check_cdd(&identity_data_to_join.target_did);
+                        let _ = check_cdd(&did);
                         return Ok(Some(master_signatory));
                     }
                 }

--- a/pallets/runtime/testnet-v1/src/fee_details.rs
+++ b/pallets/runtime/testnet-v1/src/fee_details.rs
@@ -232,8 +232,7 @@ fn is_auth_valid(
             CallType::AcceptIdentitySigner => {
                 if let AuthorizationData::JoinIdentity(did) = auth.authorization_data {
                     // make sure that the auth was created by the master key of an identity with valid CDD
-                    let master =
-                        Identity::did_records(&did).master_key;
+                    let master = Identity::did_records(&did).master_key;
                     let master_signatory = Signatory::AccountKey(master);
                     if auth.authorized_by == master_signatory {
                         let _ = check_cdd(&did);

--- a/pallets/runtime/testnet-v1/src/runtime.rs
+++ b/pallets/runtime/testnet-v1/src/runtime.rs
@@ -86,8 +86,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh"),
     impl_name: create_runtime_str!("polymath-polymesh"),
     authoring_version: 1,
-    spec_version: 1007,
-    impl_version: 1007,
+    spec_version: 1010,
+    impl_version: 1010,
     apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
This is a temporary change to have keys joining identities pay their transaction fee from the master key of the receiving identity (as opposed to the receiving identity).

This allows the Polymesh Wallet to function without needing explicit identity top up functionality.