### PR TITLE
mesh-1129: Use `TestStorage` & `ExtBuilder` for `transaction_payment_test`

### DIFF
--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -1813,7 +1813,7 @@ fn test_can_transfer_rpc() {
     ExtBuilder::default()
         .cdd_providers(vec![AccountKeyring::Eve.public()])
         .monied(true)
-        .existential_deposit(1)
+        .balance_factor(1)
         .build()
         .execute_with(|| {
             let (alice_signed, alice_did) = make_account(AccountKeyring::Alice.public()).unwrap();

--- a/pallets/runtime/tests/src/balances_test.rs
+++ b/pallets/runtime/tests/src/balances_test.rs
@@ -39,7 +39,7 @@ pub fn info_from_weight(w: Weight) -> DispatchInfo {
 #[ignore]
 fn signed_extension_charge_transaction_payment_work() {
     ExtBuilder::default()
-        .existential_deposit(10)
+        .balance_factor(10)
         .transaction_fees(10, 1, 5)
         .monied(true)
         .build()
@@ -78,7 +78,7 @@ fn signed_extension_charge_transaction_payment_work() {
 #[test]
 fn tipping_fails() {
     ExtBuilder::default()
-        .existential_deposit(10)
+        .balance_factor(10)
         .transaction_fees(10, 1, 5)
         .monied(true)
         .build()
@@ -249,7 +249,7 @@ fn burn_account_balance_works() {
 #[ignore]
 fn should_charge_identity() {
     ExtBuilder::default()
-        .existential_deposit(10)
+        .balance_factor(10)
         .transaction_fees(10, 1, 5)
         .monied(true)
         .build()
@@ -319,7 +319,7 @@ fn should_charge_identity() {
 #[test]
 fn transfer_with_memo() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .cdd_providers(vec![AccountKeyring::Ferdie.public()])
         .build()
@@ -398,7 +398,7 @@ fn transfer_with_memo_we() {
 #[test]
 fn check_top_up_identity_balance() {
     ExtBuilder::default()
-        .existential_deposit(0)
+        .balance_factor(0)
         .monied(true)
         .cdd_providers(vec![AccountKeyring::Ferdie.public()])
         .build()

--- a/pallets/runtime/tests/src/balances_test.rs
+++ b/pallets/runtime/tests/src/balances_test.rs
@@ -40,7 +40,7 @@ pub fn info_from_weight(w: Weight) -> DispatchInfo {
 fn signed_extension_charge_transaction_payment_work() {
     ExtBuilder::default()
         .balance_factor(10)
-        .transaction_fees(10, 1, 5)
+        .transaction_fees(0, 1, 5)
         .monied(true)
         .build()
         .execute_with(|| {
@@ -79,7 +79,7 @@ fn signed_extension_charge_transaction_payment_work() {
 fn tipping_fails() {
     ExtBuilder::default()
         .balance_factor(10)
-        .transaction_fees(10, 1, 5)
+        .transaction_fees(0, 1, 5)
         .monied(true)
         .build()
         .execute_with(|| {
@@ -250,7 +250,7 @@ fn burn_account_balance_works() {
 fn should_charge_identity() {
     ExtBuilder::default()
         .balance_factor(10)
-        .transaction_fees(10, 1, 5)
+        .transaction_fees(0, 1, 5)
         .monied(true)
         .build()
         .execute_with(|| {

--- a/pallets/runtime/tests/src/bridge.rs
+++ b/pallets/runtime/tests/src/bridge.rs
@@ -36,7 +36,7 @@ macro_rules! assert_tx_approvals {
 #[test]
 fn can_issue_to_identity() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(can_issue_to_identity_we);
@@ -267,7 +267,7 @@ fn cannot_call_bridge_callback_extrinsics() {
 #[test]
 fn can_freeze_and_unfreeze_bridge() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(do_freeze_and_unfreeze_bridge);
@@ -401,7 +401,7 @@ fn next_block() -> Weight {
 #[test]
 fn can_timelock_txs() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(do_timelock_txs);
@@ -521,7 +521,7 @@ fn do_timelock_txs() {
 #[test]
 fn can_rate_limit() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(do_rate_limit);
@@ -647,7 +647,7 @@ fn do_rate_limit() {
 #[test]
 fn is_exempted() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(do_exempted);
@@ -771,7 +771,7 @@ fn do_exempted() {
 #[test]
 fn can_force_mint() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .build()
         .execute_with(do_force_mint);

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -111,15 +111,14 @@ impl ExtBuilder {
     /// (`extrinsic_base_weight`, `transaction_byte_fee`, and `weight_to_fee`).
     /// See the corresponding methods for more details.
     pub fn transaction_fees(
-        mut self,
+        self,
         extrinsic_base_weight: u64,
         transaction_byte_fee: u128,
         weight_to_fee: u128,
     ) -> Self {
-        self.extrinsic_base_weight = extrinsic_base_weight;
-        self.transaction_byte_fee = transaction_byte_fee;
-        self.weight_to_fee = weight_to_fee;
-        self
+        self.base_weight(extrinsic_base_weight)
+            .byte_fee(transaction_byte_fee)
+            .weight_fee(weight_to_fee)
     }
 
     /// Set the scaling factor used for initial balances on genesis to `factor`.
@@ -169,7 +168,7 @@ impl ExtBuilder {
         self
     }
 
-    pub fn set_associated_consts(&self) {
+    fn set_associated_consts(&self) {
         EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow_mut() = self.extrinsic_base_weight);
         TRANSACTION_BYTE_FEE.with(|v| *v.borrow_mut() = self.transaction_byte_fee);
         WEIGHT_TO_FEE.with(|v| *v.borrow_mut() = self.weight_to_fee);
@@ -230,6 +229,8 @@ impl ExtBuilder {
     ///     2. CDD provider's account key is linked to its new Identity ID.
     ///     3. That Identity ID is added as member of CDD provider group.
     pub fn build(self) -> TestExternalities {
+        self.set_associated_consts();
+
         let mut storage = frame_system::GenesisConfig::default()
             .build_storage::<TestStorage>()
             .unwrap();

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -81,9 +81,9 @@ pub struct ExtBuilder {
 }
 
 thread_local! {
-    pub static EXTRINSIC_BASE_WEIGHT: RefCell<u64> = RefCell::new(5);
-    pub static TRANSACTION_BYTE_FEE: RefCell<u128> = RefCell::new(10);
-    pub static WEIGHT_TO_FEE: RefCell<u128> = RefCell::new(1);
+    pub static EXTRINSIC_BASE_WEIGHT: RefCell<u64> = RefCell::new(0);
+    pub static TRANSACTION_BYTE_FEE: RefCell<u128> = RefCell::new(0);
+    pub static WEIGHT_TO_FEE: RefCell<u128> = RefCell::new(0);
 }
 
 impl ExtBuilder {

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -59,7 +59,7 @@ impl Default for MockProtocolBaseFees {
 
 #[derive(Default)]
 pub struct ExtBuilder {
-    transaction_base_fee: u128,
+    extrinsic_base_weight: u64,
     transaction_byte_fee: u128,
     weight_to_fee: u128,
     /// Scaling factor for initial balances on genesis.
@@ -81,10 +81,17 @@ thread_local! {
 }
 
 impl ExtBuilder {
-    pub fn transaction_fees(mut self, base_fee: u128, byte_fee: u128, weight_fee: u128) -> Self {
-        self.transaction_base_fee = base_fee;
-        self.transaction_byte_fee = byte_fee;
-        self.weight_to_fee = weight_fee;
+    /// Sets parameters for transaction fees
+    /// (`extrinsic_base_weight`, `transaction_byte_fee`, and `weight_to_fee`).
+    pub fn transaction_fees(
+        mut self,
+        extrinsic_base_weight: u64,
+        transaction_byte_fee: u128,
+        weight_to_fee: u128,
+    ) -> Self {
+        self.extrinsic_base_weight = extrinsic_base_weight;
+        self.transaction_byte_fee = transaction_byte_fee;
+        self.weight_to_fee = weight_to_fee;
         self
     }
 
@@ -136,6 +143,7 @@ impl ExtBuilder {
     }
 
     pub fn set_associated_consts(&self) {
+        EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow_mut() = self.extrinsic_base_weight);
         TRANSACTION_BYTE_FEE.with(|v| *v.borrow_mut() = self.transaction_byte_fee);
         WEIGHT_TO_FEE.with(|v| *v.borrow_mut() = self.weight_to_fee);
     }

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -59,8 +59,14 @@ impl Default for MockProtocolBaseFees {
 
 #[derive(Default)]
 pub struct ExtBuilder {
+    /// Minimum weight for the extrinsic (see `weight_to_fee` below).
     extrinsic_base_weight: u64,
+    /// The transaction fee per byte.
+    /// Transactions with bigger payloads will have a bigger `len_fee`.
+    /// This is calculated as `transaction_byte_fee * tx.len()`.
     transaction_byte_fee: u128,
+    /// Contributes to the `weight_fee`, indicating the compute requirements of a transaction.
+    /// A more resource-intensive transaction will have a higher `weight_fee`.
     weight_to_fee: u128,
     /// Scaling factor for initial balances on genesis.
     balance_factor: u128,
@@ -81,8 +87,29 @@ thread_local! {
 }
 
 impl ExtBuilder {
+    /// Sets the minimum weight for the extrinsic (see also `weight_fee`).
+    pub fn base_weight(mut self, extrinsic_base_weight: u64) -> Self {
+        self.extrinsic_base_weight = extrinsic_base_weight;
+        self
+    }
+
+    /// Sets the fee per each byte in a transaction.
+    /// The full byte fee is defined as: `transaction_byte_fee * tx.len()`.
+    pub fn byte_fee(mut self, transaction_byte_fee: u128) -> Self {
+        self.transaction_byte_fee = transaction_byte_fee;
+        self
+    }
+
+    /// Sets the fee to charge per weight.
+    /// A more demanding computation will have a higher fee for its weight.
+    pub fn weight_fee(mut self, weight_to_fee: u128) -> Self {
+        self.weight_to_fee = weight_to_fee;
+        self
+    }
+
     /// Sets parameters for transaction fees
     /// (`extrinsic_base_weight`, `transaction_byte_fee`, and `weight_to_fee`).
+    /// See the corresponding methods for more details.
     pub fn transaction_fees(
         mut self,
         extrinsic_base_weight: u64,

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -66,7 +66,7 @@ fn fetch_systematic_cdd(target: IdentityId) -> Option<IdentityClaim> {
 #[test]
 fn add_claims_batch_test() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .cdd_providers(vec![
             AccountKeyring::Eve.public(),
@@ -1184,7 +1184,7 @@ fn changing_master_key_with_cdd_auth_we() {
 #[test]
 fn cdd_register_did_test() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .cdd_providers(vec![
             AccountKeyring::Eve.public(),
@@ -1402,7 +1402,7 @@ fn add_identity_signers() {
 #[test]
 fn invalidate_cdd_claims() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .cdd_providers(vec![
             AccountKeyring::Eve.public(),
@@ -1614,7 +1614,7 @@ fn gc_and_cdd_with_systematic_cdd_claims_we() {
 #[test]
 fn add_permission_with_signing_key() {
     ExtBuilder::default()
-        .existential_deposit(1_000)
+        .balance_factor(1_000)
         .monied(true)
         .cdd_providers(vec![
             AccountKeyring::Eve.public(),

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -896,7 +896,7 @@ fn proposal_with_beneficiares() {
     ExtBuilder::default()
         .governance_committee(committee)
         .governance_committee_vote_threshold((2, 3))
-        .existential_deposit(10)
+        .balance_factor(10)
         .build()
         .execute_with(proposal_with_beneficiares_we);
 }

--- a/pallets/runtime/tests/src/transaction_payment_test.rs
+++ b/pallets/runtime/tests/src/transaction_payment_test.rs
@@ -15,9 +15,6 @@ fn call() -> <TestStorage as frame_system::Trait>::Call {
     Call::Balances(BalancesCall::transfer(AccountKeyring::Alice.public(), 69))
 }
 
-type AccountId = u64;
-type Balance = u128;
-type Origin = <TestStorage as frame_system::Trait>::Origin;
 type Balances = pallet_balances::Module<TestStorage>;
 type System = frame_system::Module<TestStorage>;
 type TransactionPayment = pallet_transaction_payment::Module<TestStorage>;

--- a/pallets/runtime/tests/src/treasury_test.rs
+++ b/pallets/runtime/tests/src/treasury_test.rs
@@ -20,7 +20,7 @@ type Origin = <TestStorage as frame_system::Trait>::Origin;
 #[test]
 fn reimbursement_and_disbursement() {
     ExtBuilder::default()
-        .existential_deposit(10)
+        .balance_factor(10)
         .build()
         .execute_with(reimbursement_and_disbursement_we);
 }


### PR DESCRIPTION
Based on https://github.com/PolymathNetwork/Polymesh/pull/493 (first commit).

- Resolves MESH 1129: `transaction_payment_test` now uses `TestStorage` and `ExtBuilder`.
- Some other drive-by cleanup of unused imports.