### PR TITLE
MESH-1213: Add active members limit

### DIFF
--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -67,7 +67,7 @@ use frame_system::{self as system, ensure_signed};
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     governance_group::GovernanceGroupTrait,
-    group::{GroupTrait, InactiveMember},
+    group::{GroupTrait, InactiveMember, MemberCount},
     identity::{IdentityTrait, Trait as IdentityModuleTrait},
     Context, SystematicIssuers,
 };
@@ -78,9 +78,6 @@ use sp_std::{prelude::*, vec};
 
 /// Simple index type for proposal counting.
 pub type ProposalIndex = u32;
-
-/// The number of committee members
-pub type MemberCount = u32;
 
 /// The committee trait.
 pub trait Trait<I>: frame_system::Trait + IdentityModuleTrait {

--- a/pallets/common/src/traits/group.rs
+++ b/pallets/common/src/traits/group.rs
@@ -28,6 +28,9 @@ use sp_std::{
     vec::Vec,
 };
 
+/// The number of group members.
+pub type MemberCount = u32;
+
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 pub struct InactiveMember<Moment> {
     pub id: IdentityId,
@@ -80,6 +83,11 @@ pub trait Trait<I>: frame_system::Trait + pallet_timestamp::Trait + IdentityTrai
     /// The overarching event type.
     type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;
 
+    /// Required origin for changing the active limit.
+    /// It's recommended that e.g., in case of a committee,
+    /// this be an origin that cannot be formed through a committee majority.
+    type LimitOrigin: EnsureOrigin<<Self as frame_system::Trait>::Origin>;
+
     /// Required origin for adding a member (though can always be Root).
     type AddOrigin: EnsureOrigin<<Self as frame_system::Trait>::Origin>;
 
@@ -121,6 +129,8 @@ decl_event!(
         /// The membership was reset; see the transaction for who the new set is.
         /// caller DID, List of new members.
         MembersReset(IdentityId, Vec<IdentityId>),
+        /// The limit of how many active members there can be concurrently was changed.
+        ActiveLimitChanged(IdentityId, MemberCount, MemberCount),
         /// Phantom member, never used.
         Dummy(sp_std::marker::PhantomData<(AccountId, Event)>),
     }

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -76,7 +76,7 @@
 
 use pallet_identity as identity;
 pub use polymesh_common_utilities::{
-    group::{GroupTrait, InactiveMember, RawEvent, Trait},
+    group::{GroupTrait, InactiveMember, MemberCount, RawEvent, Trait},
     Context, SystematicIssuers,
 };
 use polymesh_primitives::IdentityId;
@@ -101,6 +101,8 @@ decl_storage! {
         pub ActiveMembers get(fn active_members) config(): Vec<IdentityId>;
         /// The current "inactive" membership, stored as an ordered Vec.
         pub InactiveMembers get(fn inactive_members): Vec<InactiveMember<T::Moment>>;
+        /// Limit of how many "active" members there can be.
+        pub ActiveMembersLimit get(fn active_members_limit) config(): u32;
     }
     add_extra_genesis {
         config(phantom): sp_std::marker::PhantomData<(T, I)>;
@@ -108,6 +110,7 @@ decl_storage! {
             use frame_support::traits::InitializeMembers;
 
             let mut members = config.active_members.clone();
+            assert!(members.len() as MemberCount <= config.active_members_limit);
             members.sort();
             T::MembershipInitialized::initialize_members(&members);
             <ActiveMembers<I>>::put(members);
@@ -123,6 +126,18 @@ decl_module! {
         type Error = Error<T, I>;
 
         fn deposit_event() = default;
+
+        /// Change this group's limit for how many concurrent active members they may be.
+        ///
+        /// # Arguments
+        /// * `limit` - the numer of active members there may be concurrently.
+        #[weight = (100_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn set_active_members_limit(origin, limit: MemberCount) {
+            T::LimitOrigin::ensure_origin(origin)?;
+            let old = <ActiveMembersLimit<I>>::mutate(|slot| core::mem::replace(slot, limit));
+            let current_did = SystematicIssuers::Committee.as_id();
+            Self::deposit_event(RawEvent::ActiveLimitChanged(current_did, limit, old));
+        }
 
         /// Disables a member at specific moment.
         ///
@@ -163,6 +178,7 @@ decl_module! {
             let mut members = <ActiveMembers<I>>::get();
             let location = members.binary_search(&who).err().ok_or(Error::<T, I>::DuplicateMember)?;
             members.insert(location, who);
+            Self::ensure_within_active_members_limit(&members)?;
             <ActiveMembers<I>>::put(&members);
 
             T::MembershipChanged::change_members_sorted(&[who], &[], &members[..]);
@@ -226,6 +242,8 @@ decl_module! {
         pub fn reset_members(origin, members: Vec<IdentityId>) {
             T::ResetOrigin::ensure_origin(origin)?;
 
+            Self::ensure_within_active_members_limit(&members)?;
+
             let mut new_members = members.clone();
             new_members.sort();
             <ActiveMembers<I>>::mutate(|m| {
@@ -285,11 +303,22 @@ decl_error! {
         /// Last member of the committee can not quit.
         LastMemberCannotQuit,
         /// Missing current DID
-        MissingCurrentIdentity
+        MissingCurrentIdentity,
+        /// The limit for the number of concurrent active members for this group has been exceeded.
+        ActiveMembersLimitExceeded,
     }
 }
 
 impl<T: Trait<I>, I: Instance> Module<T, I> {
+    /// Ensure that updating the active set to `members` will not exceed the set limit.
+    fn ensure_within_active_members_limit(members: &[IdentityId]) -> DispatchResult {
+        ensure!(
+            members.len() as MemberCount <= Self::active_members_limit(),
+            Error::<T, I>::ActiveMembersLimitExceeded
+        );
+        Ok(())
+    }
+
     /// Returns the current "active members" and any "valid member" whose revocation time-stamp is
     /// in the future.
     pub fn get_valid_members() -> Vec<IdentityId> {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -402,6 +402,7 @@ impl committee::Trait<GovernanceCommittee> for Runtime {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for Runtime {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -422,6 +423,8 @@ macro_rules! committee_config {
         }
         impl group::Trait<group::$instance> for Runtime {
             type Event = Event;
+            // Committee cannot alter its own active membership limit.
+            type LimitOrigin = frame_system::EnsureRoot<AccountId>;
             // Can manage its own addition, deletion, and swapping of membership...
             type AddOrigin = VMO<committee::$instance>;
             type RemoveOrigin = VMO<committee::$instance>;
@@ -687,6 +690,8 @@ impl dividend::Trait for Runtime {
 /// CddProviders instance of group
 impl group::Trait<group::Instance2> for Runtime {
     type Event = Event;
+    // Cannot alter its own active membership limit.
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/pallets/runtime/testnet-v1/src/runtime.rs
+++ b/pallets/runtime/testnet-v1/src/runtime.rs
@@ -402,6 +402,7 @@ impl committee::Trait<GovernanceCommittee> for Runtime {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for Runtime {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -422,6 +423,7 @@ macro_rules! committee_config {
         }
         impl group::Trait<group::$instance> for Runtime {
             type Event = Event;
+            type LimitOrigin = frame_system::EnsureRoot<AccountId>;
             // Can manage its own addition, deletion, and swapping of membership...
             type AddOrigin = VMO<committee::$instance>;
             type RemoveOrigin = VMO<committee::$instance>;
@@ -687,6 +689,7 @@ impl dividend::Trait for Runtime {
 /// CddProviders instance of group
 impl group::Trait<group::Instance2> for Runtime {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -293,6 +293,7 @@ impl ExtBuilder {
             .collect::<Vec<_>>();
 
         group::GenesisConfig::<TestStorage, group::Instance2> {
+            active_members_limit: u32::MAX,
             active_members: cdd_ids,
             ..Default::default()
         }
@@ -314,6 +315,7 @@ impl ExtBuilder {
             .collect::<Vec<_>>();
 
         group::GenesisConfig::<TestStorage, group::Instance1> {
+            active_members_limit: u32::MAX,
             active_members: gc_ids.clone(),
             ..Default::default()
         }

--- a/pallets/runtime/tests/src/group_test.rs
+++ b/pallets/runtime/tests/src/group_test.rs
@@ -47,7 +47,7 @@ fn add_member_works_we() {
     let non_root_did = get_identity_id(AccountKeyring::Alice).unwrap();
 
     Context::set_current_identity::<Identity>(Some(non_root_did));
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::add_member(non_root, IdentityId::from(3)),
         DispatchError::BadOrigin
     );
@@ -58,11 +58,91 @@ fn add_member_works_we() {
         CommitteeGroup::add_member(root.clone(), alice_id),
         group::Error::<TestStorage, group::Instance1>::DuplicateMember
     );
-    assert_ok!(CommitteeGroup::add_member(root, IdentityId::from(4)));
+    assert_ok!(CommitteeGroup::add_member(
+        root.clone(),
+        IdentityId::from(4)
+    ));
     assert_eq!(
         CommitteeGroup::get_members(),
         vec![alice_id, IdentityId::from(4)]
     );
+}
+
+#[test]
+fn active_limit_works() {
+    ExtBuilder::default()
+        .governance_committee([AccountKeyring::Alice.public()].to_vec())
+        .build()
+        .execute_with(|| {
+            let root = Origin::from(frame_system::RawOrigin::Root);
+            let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+            let alice_id = get_identity_id(AccountKeyring::Alice).unwrap();
+
+            assert_ok!(CommitteeGroup::add_member(
+                root.clone(),
+                IdentityId::from(4)
+            ));
+            assert_eq!(
+                CommitteeGroup::get_members(),
+                vec![alice_id, IdentityId::from(4)]
+            );
+
+            let bob_id = register_keyring_account(AccountKeyring::Bob).unwrap();
+            let charlie_id = register_keyring_account(AccountKeyring::Charlie).unwrap();
+            assert_ok!(CommitteeGroup::set_active_members_limit(root.clone(), 1));
+            assert_noop!(
+                CommitteeGroup::add_member(root.clone(), bob_id),
+                group::Error::<TestStorage, group::Instance1>::ActiveMembersLimitExceeded,
+            );
+            assert_ok!(CommitteeGroup::set_active_members_limit(root.clone(), 2));
+            assert_noop!(
+                CommitteeGroup::add_member(root.clone(), bob_id),
+                group::Error::<TestStorage, group::Instance1>::ActiveMembersLimitExceeded,
+            );
+            assert_ok!(CommitteeGroup::set_active_members_limit(root.clone(), 3));
+            assert_ok!(CommitteeGroup::add_member(root.clone(), bob_id));
+            assert_eq!(
+                CommitteeGroup::get_members(),
+                vec![alice_id, IdentityId::from(4), bob_id]
+            );
+            assert_noop!(
+                CommitteeGroup::add_member(root.clone(), charlie_id),
+                group::Error::<TestStorage, group::Instance1>::ActiveMembersLimitExceeded,
+            );
+
+            // Test swap, remove, and abdicate.
+            assert_ok!(CommitteeGroup::swap_member(
+                root.clone(),
+                alice_id,
+                charlie_id,
+            ));
+            assert_ok!(CommitteeGroup::remove_member(root.clone(), charlie_id));
+            assert_ok!(CommitteeGroup::add_member(root.clone(), alice_id));
+            assert_ok!(CommitteeGroup::abdicate_membership(alice_signer));
+            assert_ok!(CommitteeGroup::add_member(root.clone(), alice_id));
+
+            // Lower limit below current size; remove, but then we cannot add.
+            assert_ok!(CommitteeGroup::set_active_members_limit(root.clone(), 0));
+            assert_ok!(CommitteeGroup::remove_member(root.clone(), alice_id));
+            assert_noop!(
+                CommitteeGroup::add_member(root.clone(), charlie_id),
+                group::Error::<TestStorage, group::Instance1>::ActiveMembersLimitExceeded,
+            );
+
+            // Limit is 0, try to reset to empty vec.
+            assert_ok!(CommitteeGroup::reset_members(root.clone(), vec![]));
+            // Raise to 2, and reset to 2 members, should also work.
+            assert_ok!(CommitteeGroup::set_active_members_limit(root.clone(), 2));
+            assert_ok!(CommitteeGroup::reset_members(
+                root.clone(),
+                vec![alice_id, bob_id]
+            ));
+            // Resetting to 3 members doesn't, however.
+            assert_noop!(
+                CommitteeGroup::reset_members(root, vec![alice_id, bob_id, charlie_id]),
+                group::Error::<TestStorage, group::Instance1>::ActiveMembersLimitExceeded,
+            );
+        });
 }
 
 #[test]

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -315,6 +315,7 @@ impl pallet_timestamp::Trait for Test {
 
 impl group::Trait<group::Instance2> for Test {
     type Event = MetaEvent;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -690,6 +691,7 @@ impl ExtBuilder {
         .assimilate_storage(&mut storage);
 
         let _ = group::GenesisConfig::<Test, group::Instance2> {
+            active_members_limit: u32::MAX,
             active_members: vec![IdentityId::from(1), IdentityId::from(2)],
             phantom: Default::default(),
         }

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -315,6 +315,7 @@ impl pallet_transaction_payment::Trait for TestStorage {
 
 impl group::Trait<group::DefaultInstance> for TestStorage {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -326,6 +327,7 @@ impl group::Trait<group::DefaultInstance> for TestStorage {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for TestStorage {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -336,6 +338,7 @@ impl group::Trait<group::Instance1> for TestStorage {
 
 impl group::Trait<group::Instance2> for TestStorage {
     type Event = Event;
+    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -310,6 +310,7 @@ fn general_testnet_genesis(
         }),
         // Governance Council:
         group_Instance1: Some(general::runtime::CommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![
                 IdentityId::from(3),
                 IdentityId::from(4),
@@ -325,6 +326,7 @@ fn general_testnet_genesis(
             phantom: Default::default(),
         }),
         group_Instance2: Some(general::runtime::CddServiceProvidersConfig {
+            active_members_limit: u32::MAX,
             // sp1, sp2, first authority
             active_members: vec![
                 IdentityId::from(1),
@@ -335,6 +337,7 @@ fn general_testnet_genesis(
         }),
         // Technical Committee:
         group_Instance3: Some(general::runtime::TechnicalCommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![IdentityId::from(3)],
             phantom: Default::default(),
         }),
@@ -346,6 +349,7 @@ fn general_testnet_genesis(
         }),
         // Upgrade Committee:
         group_Instance4: Some(general::runtime::UpgradeCommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![IdentityId::from(4)],
             phantom: Default::default(),
         }),
@@ -669,6 +673,7 @@ fn alcyone_testnet_genesis(
             },
         }),
         group_Instance1: Some(alcyone::runtime::CommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![
                 IdentityId::from(4),
                 IdentityId::from(5),
@@ -683,6 +688,7 @@ fn alcyone_testnet_genesis(
             phantom: Default::default(),
         }),
         group_Instance2: Some(alcyone::runtime::CddServiceProvidersConfig {
+            active_members_limit: u32::MAX,
             // sp1, sp2, sp3
             active_members: vec![
                 IdentityId::from(1),
@@ -693,6 +699,7 @@ fn alcyone_testnet_genesis(
         }),
         // Technical Committee:
         group_Instance3: Some(alcyone::runtime::TechnicalCommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![IdentityId::from(4)],
             phantom: Default::default(),
         }),
@@ -704,6 +711,7 @@ fn alcyone_testnet_genesis(
         }),
         // Upgrade Committee:
         group_Instance4: Some(alcyone::runtime::UpgradeCommitteeMembershipConfig {
+            active_members_limit: 20,
             active_members: vec![IdentityId::from(5)],
             phantom: Default::default(),
         }),


### PR DESCRIPTION
Add a limit of how many concurrent active members a group can have, defined and configured per group:
```rust
/// Limit of how many "active" members there can be.
pub ActiveMembersLimit get(fn active_members_limit) config(): u32;
```

This is then checked upon potentially group-adding operations (`add_member`, `reset_members`) and an error is thrown on `>` the limit.

The limit is configurable via:
```rust
pub fn set_active_members_limit(origin, limit: MemberCount);
```
which can be called by a newly added `type LimitOrigin` (so that e.g., the technical committee cannot change this themselves).

The choice of a per-group limit provides flexibility, while also seemingly being necessary for the CDD group.