### PR TITLE
MESH-1236: `remove_authorization` payer => `authorized_by` (sometimes)

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -99,12 +99,12 @@ use polymesh_common_utilities::{
         multisig::MultiSigSubTrait,
         transaction_payment::{CddAndFeeDetails, ChargeTxFee},
     },
-    with_each_transaction, Context, SystematicIssuers,
+    Context, SystematicIssuers,
 };
 use polymesh_primitives::{
-    AuthIdentifier, Authorization, AuthorizationData, AuthorizationError, AuthorizationType, CddId,
-    Claim, ClaimType, Identity as DidRecord, IdentityClaim, IdentityId, InvestorUid, Permission,
-    Scope, SecondaryKey, Signatory, Ticker,
+    Authorization, AuthorizationData, AuthorizationError, AuthorizationType, CddId, Claim,
+    ClaimType, Identity as DidRecord, IdentityClaim, IdentityId, InvestorUid, Permission, Scope,
+    SecondaryKey, Signatory, Ticker,
 };
 use sp_core::sr25519::Signature;
 use sp_io::hashing::blake2_256;


### PR DESCRIPTION
Instead of adding a new extrinsic, we alter the payer of `remove_authorization` in some cases.