### PR TITLE
Bump substrate rc4 => rc5+2 => rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,18 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -46,9 +40,21 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft",
- "aesni",
+ "aes-soft 0.4.0",
+ "aesni 0.7.0",
  "block-cipher",
+]
+
+[[package]]
+name = "aes-ctr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
+dependencies = [
+ "aes-soft 0.3.3",
+ "aesni 0.6.0",
+ "ctr",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -61,7 +67,18 @@ dependencies = [
  "aes",
  "block-cipher",
  "ghash",
- "subtle 2.2.3",
+ "subtle 2.3.0",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+dependencies = [
+ "block-cipher-trait",
+ "byteorder 1.3.4",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -71,8 +88,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
  "block-cipher",
- "byteorder",
+ "byteorder 1.3.4",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "aesni"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+dependencies = [
+ "block-cipher-trait",
+ "opaque-debug 0.2.3",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -117,7 +145,7 @@ checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
 dependencies = [
  "approx",
  "num-complex",
- "num-traits 0.2.12",
+ "num-traits",
 ]
 
 [[package]]
@@ -150,7 +178,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits",
 ]
 
 [[package]]
@@ -195,21 +223,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
-
-[[package]]
 name = "async-channel"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59386c3aa61f4e14c4ddda1a6744c119b4bf278ec9f866d3c20bc5728ee0eb97"
+checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -240,7 +262,7 @@ dependencies = [
  "concurrent-queue",
  "futures-lite",
  "libc",
- "once_cell",
+ "once_cell 1.4.1",
  "parking 2.0.0",
  "polling",
  "socket2",
@@ -251,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "async-mutex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065de1ccf10280d0d75c2f3a71a970ee1007c85c51aa3e7deee1df100f1dfadb"
+checksum = "66941c2577c4fa351e4ce5fdde8f86c69b88d623f3b955be1bc7362a23434632"
 dependencies = [
  "event-listener",
 ]
@@ -279,7 +301,7 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "once_cell",
+ "once_cell 1.4.1",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -303,6 +325,23 @@ dependencies = [
  "webpki",
  "webpki-roots 0.19.0",
 ]
+
+[[package]]
+name = "async-trait"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f46ca51dca4837f1520754d1c8c36636356b81553d928dc9c177025369a06e"
 
 [[package]]
 name = "atomic-waker"
@@ -329,9 +368,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
@@ -382,11 +421,26 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.7",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
  "which",
+]
+
+[[package]]
+name = "bip39"
+version = "0.6.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059804e226b3ac116519a252d7f5fb985a5ccc0e93255e036a5f7e7283323f4"
+dependencies = [
+ "failure",
+ "hashbrown 0.1.8",
+ "hmac",
+ "once_cell 0.1.8",
+ "pbkdf2",
+ "rand 0.6.5",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -418,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
  "byte-tools",
- "byteorder",
+ "byteorder 1.3.4",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.2.3",
@@ -462,9 +516,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
- "byteorder",
+ "byteorder 1.3.4",
  "generic-array 0.12.3",
 ]
 
@@ -474,7 +528,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.3",
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -483,7 +538,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+dependencies = [
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -496,6 +560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
 name = "blocking"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +574,7 @@ dependencies = [
  "async-channel",
  "atomic-waker",
  "futures-lite",
- "once_cell",
+ "once_cell 1.4.1",
  "waker-fn",
 ]
 
@@ -540,7 +610,7 @@ name = "bulletproofs"
 version = "2.0.1"
 source = "git+https://github.com/PolymathNetwork/bulletproofs.git?branch=main#ed546e5b8919dc2ba4b9cee6fbd8320c495fcbe1"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "curve25519-dalek 2.1.0",
  "digest 0.8.1",
  "merlin",
@@ -548,8 +618,8 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "serde_derive",
- "sha3",
- "subtle 2.2.3",
+ "sha3 0.8.2",
+ "subtle 2.3.0",
  "thiserror",
  "zeroize",
 ]
@@ -574,6 +644,12 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+
+[[package]]
+name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -584,7 +660,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "either",
  "iovec",
 ]
@@ -630,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 dependencies = [
  "jobserver",
 ]
@@ -658,7 +734,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
- "stream-cipher",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
@@ -671,18 +747,18 @@ dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits",
  "time",
 ]
 
@@ -699,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
@@ -717,6 +793,15 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
@@ -810,7 +895,7 @@ dependencies = [
  "csv",
  "itertools 0.9.0",
  "lazy_static",
- "num-traits 0.2.12",
+ "num-traits",
  "oorandom",
  "plotters",
  "rayon",
@@ -834,6 +919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,13 +945,13 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
- "scopeguard",
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -876,7 +971,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cfg-if",
  "lazy_static",
 ]
@@ -903,8 +998,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.3",
- "subtle 2.2.3",
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
 ]
 
 [[package]]
@@ -927,8 +1022,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha3",
- "sp-std 2.0.0-rc6",
+ "sha3 0.8.2",
+ "sp-std",
  "wasm-bindgen-test",
  "zeroize",
 ]
@@ -965,17 +1060,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
+dependencies = [
+ "block-cipher-trait",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "cuckoofilter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
+dependencies = [
+ "byteorder 0.5.3",
+ "rand 0.3.23",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "digest 0.8.1",
  "packed_simd",
  "rand_core 0.5.1",
  "serde",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
@@ -985,28 +1100,28 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
 name = "derive_more"
-version = "0.99.9"
+version = "0.99.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
+checksum = "1dcfabdab475c16a93d669dddfc393027803e347d09663f524447f642fbb84ba"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1024,7 +1139,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1054,15 +1169,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "quick-error",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clonable"
@@ -1081,8 +1190,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1093,9 +1202,9 @@ checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
 dependencies = [
  "signature",
 ]
@@ -1116,20 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "enum-primitive-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
-dependencies = [
- "num-traits 0.1.43",
- "quote 0.3.15",
- "syn 0.11.11",
-]
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "env_logger"
@@ -1191,8 +1289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -1227,7 +1325,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-timer 2.0.2",
  "log",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.9.0",
 ]
@@ -1238,7 +1336,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -1252,9 +1350,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
+checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -1271,72 +1369,61 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "linregress",
  "parity-scale-codec",
  "paste",
- "sp-api 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "Inflector",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-db",
  "sc-executor",
  "sc-service",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
  "structopt",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-tracing 2.0.0-rc5",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "11.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -1346,33 +1433,8 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "frame-support"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "bitmask",
- "frame-metadata 11.0.0-rc5",
- "frame-support-procedural 2.0.0-rc5",
- "impl-trait-for-tuples",
- "log",
- "once_cell",
- "parity-scale-codec",
- "paste",
- "serde",
- "smallvec 1.4.1",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-tracing 2.0.0-rc5",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
@@ -1381,34 +1443,23 @@ version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "bitmask",
- "frame-metadata 11.0.0-rc6",
- "frame-support-procedural 2.0.0-rc6",
+ "frame-metadata",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "once_cell",
+ "once_cell 1.4.1",
  "parity-scale-codec",
  "paste",
  "serde",
- "smallvec 1.4.1",
- "sp-arithmetic 2.0.0-rc6",
- "sp-core 2.0.0-rc6",
- "sp-inherents 2.0.0-rc6",
- "sp-io 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-state-machine 0.8.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-tracing 2.0.0-rc6",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "frame-support-procedural-tools 2.0.0-rc5",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "smallvec 1.4.2",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -1416,22 +1467,10 @@ name = "frame-support-procedural"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support-procedural-tools 2.0.0-rc6",
+ "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "frame-support-procedural-tools-derive 2.0.0-rc5",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1439,21 +1478,11 @@ name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0-rc6",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1462,24 +1491,8 @@ version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
-]
-
-[[package]]
-name = "frame-system"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "frame-support 2.0.0-rc5",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1487,24 +1500,24 @@ name = "frame-system"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc6",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc6",
- "sp-io 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-version 2.0.0-rc6",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
+ "sp-api",
 ]
 
 [[package]]
@@ -1670,8 +1683,8 @@ checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1686,7 +1699,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
- "once_cell",
+ "once_cell 1.4.1",
 ]
 
 [[package]]
@@ -1702,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
  "gloo-timers",
- "send_wrapper 0.4.0",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -1767,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -1799,13 +1812,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1861,7 +1874,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "bytes 0.4.12",
  "fnv",
  "futures 0.1.29",
@@ -1915,6 +1928,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
+dependencies = [
+ "byteorder 1.3.4",
+ "scopeguard 0.3.3",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
@@ -1925,13 +1948,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
  "ahash 0.3.8",
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "heck"
@@ -2190,18 +2219,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
- "autocfg 1.0.0",
- "hashbrown 0.8.1",
+ "autocfg 1.0.1",
+ "hashbrown 0.9.0",
 ]
 
 [[package]]
@@ -2224,10 +2253,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-sqrt"
-version = "0.1.3"
+name = "instant"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65877bf7d44897a473350b1046277941cee20b263397e90869c50b6e766088b"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "intervalier"
@@ -2295,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2342,14 +2380,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.2.1"
+version = "14.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
+checksum = "d0e77e8812f02155b85a677a96e1d16b60181950c0636199bc4528524fba98dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2456,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -2485,7 +2523,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -2499,33 +2537,15 @@ dependencies = [
 
 [[package]]
 name = "lazycell"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
-
-[[package]]
-name = "libflate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bac9023e1db29c084f9f8cd9d3852e5e8fddf98fb47c4964a0ea4663d95949"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "libloading"
@@ -2554,12 +2574,52 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
+ "libp2p-deflate",
+ "libp2p-dns",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-mplex",
+ "libp2p-noise 0.21.0",
+ "libp2p-ping",
+ "libp2p-plaintext",
+ "libp2p-pnet",
+ "libp2p-request-response",
+ "libp2p-secio",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-uds",
+ "libp2p-wasm-ext",
+ "libp2p-websocket",
+ "libp2p-yamux",
+ "multihash",
+ "parity-multiaddr",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "smallvec 1.4.2",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ebb6c031584a5af181fe3a1e4b074af5d0b1a3b31663200f0251f4bcff6b5c"
+dependencies = [
+ "atomic",
+ "bytes 0.5.6",
+ "futures 0.3.5",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-mplex",
- "libp2p-noise",
+ "libp2p-noise 0.22.0",
  "libp2p-ping",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -2570,7 +2630,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "wasm-timer",
 ]
 
@@ -2601,7 +2661,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2614,8 +2674,19 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-deflate"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abeff37fa533fead23fc71b14ed0a2aced36c0c65c3d0078aff07821fb71029e"
+dependencies = [
+ "flate2",
+ "futures 0.3.5",
+ "libp2p-core",
 ]
 
 [[package]]
@@ -2630,6 +2701,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-floodsub"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d4f310a02441b681075037ffb41649ee8836619559311b801ef3d5cdbe14cf"
+dependencies = [
+ "cuckoofilter",
+ "fnv",
+ "futures 0.3.5",
+ "libp2p-core",
+ "libp2p-swarm",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70f76b6c53ae9c97c234498c799802e43f91766bcf4a2a1f94f9339617d713b"
+dependencies = [
+ "base64 0.11.0",
+ "byteorder 1.3.4",
+ "bytes 0.5.6",
+ "fnv",
+ "futures 0.3.5",
+ "futures_codec",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "lru",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.8.2",
+ "smallvec 1.4.2",
+ "unsigned-varint 0.4.0",
+ "wasm-timer",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,7 +2754,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "wasm-timer",
 ]
 
@@ -2665,7 +2778,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2689,7 +2802,7 @@ dependencies = [
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "void",
  "wasm-timer",
 ]
@@ -2733,6 +2846,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-noise"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e594f2de0c23c2b7ad14802c991a2e68e95315c6a6c7715e53801506f20135d"
+dependencies = [
+ "bytes 0.5.6",
+ "curve25519-dalek 2.1.0",
+ "futures 0.3.5",
+ "lazy_static",
+ "libp2p-core",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.8.2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "libp2p-ping"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2883,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-plaintext"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f0308a97f6fdd37a2bc388070e471c3ce9d92aa45c99d75c87c2dc5d5cac96"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.5",
+ "futures_codec",
+ "libp2p-core",
+ "log",
+ "prost",
+ "prost-build",
+ "rw-stream-sink",
+ "unsigned-varint 0.4.0",
+ "void",
+]
+
+[[package]]
+name = "libp2p-pnet"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d0db10e139d22d7af0b23ed7949449ec86262798aa0fd01595abdbcb02dc87"
+dependencies = [
+ "futures 0.3.5",
+ "log",
+ "pin-project",
+ "rand 0.7.3",
+ "salsa20",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f48682b48a96545a323edd150c1d64fc1e250240bba02866e9f902e3dc032a9"
+dependencies = [
+ "async-trait",
+ "futures 0.3.5",
+ "libp2p-core",
+ "libp2p-swarm",
+ "smallvec 1.4.2",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-secio"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff43513c383f7cdab2736eb98465fc4c5dd5d1988df89749dc8a68950349d56"
+dependencies = [
+ "aes-ctr",
+ "ctr",
+ "futures 0.3.5",
+ "hmac",
+ "js-sys",
+ "lazy_static",
+ "libp2p-core",
+ "log",
+ "parity-send-wrapper",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "quicksink",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.8.2",
+ "static_assertions",
+ "twofish",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "libp2p-swarm"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,7 +2968,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "void",
  "wasm-timer",
 ]
@@ -2776,6 +2987,18 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
+]
+
+[[package]]
+name = "libp2p-uds"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9db9fce9e3588c3118475d9ca761c5c133b639a624a7341e2a61e4b28c376b8"
+dependencies = [
+ "async-std",
+ "futures 0.3.5",
+ "libp2p-core",
+ "log",
 ]
 
 [[package]]
@@ -2849,18 +3072,17 @@ dependencies = [
  "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "typenum",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2893,11 +3115,29 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+dependencies = [
+ "scopeguard 0.3.3",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
- "scopeguard",
+ "scopeguard 1.1.0",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -2916,6 +3156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
  "hashbrown 0.6.3",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2961,7 +3210,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -2971,7 +3220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f36ddb0b2cdc25d38babba472108798e3477f02be5165f038c5e393e50c57a"
 dependencies = [
  "hash-db",
- "hashbrown 0.8.1",
+ "hashbrown 0.8.2",
  "parity-util-mem",
 ]
 
@@ -2987,7 +3236,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
@@ -2995,11 +3244,12 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -3080,24 +3330,24 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75db05d738947aa5389863aadafbcf2e509d7ba099dc2ddcdf4fc66bf7a9e03"
+checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
- "digest 0.8.1",
- "sha-1",
- "sha2 0.8.2",
- "sha3",
- "unsigned-varint 0.3.3",
+ "digest 0.9.0",
+ "sha-1 0.9.1",
+ "sha2 0.9.1",
+ "sha3 0.9.1",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
@@ -3109,7 +3359,7 @@ dependencies = [
  "futures 0.3.5",
  "log",
  "pin-project",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "unsigned-varint 0.4.0",
 ]
 
@@ -3136,7 +3386,7 @@ dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-rational",
- "num-traits 0.2.12",
+ "num-traits",
  "rand 0.6.5",
  "typenum",
 ]
@@ -3152,27 +3402,13 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "netstat2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29449d242064c48d3057a194b049a2bdcccadda16faa18a91468677b44e8d422"
-dependencies = [
- "bitflags",
- "byteorder",
- "enum-primitive-derive",
- "libc",
- "num-traits 0.2.12",
- "thiserror",
 ]
 
 [[package]]
@@ -3192,8 +3428,8 @@ dependencies = [
 name = "node-rpc"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -3206,20 +3442,20 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-primitives",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "node-rpc-runtime-api"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-compliance-manager",
  "pallet-identity",
  "pallet-pips",
@@ -3229,9 +3465,9 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3257,23 +3493,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits",
 ]
 
 [[package]]
@@ -3282,8 +3509,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.0",
- "num-traits 0.2.12",
+ "autocfg 1.0.1",
+ "num-traits",
 ]
 
 [[package]]
@@ -3292,8 +3519,8 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.0",
- "num-traits 0.2.12",
+ "autocfg 1.0.1",
+ "num-traits",
 ]
 
 [[package]]
@@ -3302,19 +3529,10 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.12",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.12",
+ "num-traits",
 ]
 
 [[package]]
@@ -3323,7 +3541,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "libm",
 ]
 
@@ -3345,11 +3563,20 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.7.1",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+dependencies = [
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -3400,8 +3627,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec 0.5.1",
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "hex-literal 0.2.1",
  "libsecp256k1",
  "pallet-balances 0.1.0",
@@ -3410,7 +3637,7 @@ dependencies = [
  "pallet-portfolio",
  "pallet-session",
  "pallet-statistics",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
@@ -3418,78 +3645,78 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-authorship",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-authorship",
  "pallet-session",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc5",
- "sp-timestamp 2.0.0-rc5",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
- "pallet-timestamp 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polymesh-common-utilities",
@@ -3497,70 +3724,70 @@ dependencies = [
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
  "substrate-test-runtime-client",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-basic-sto"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-asset",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "pallet-settlement",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-serializer 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-serializer",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "pallet-cdd-offchain-worker"
 version = "2.0.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-staking",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3568,43 +3795,43 @@ name = "pallet-committee"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "pallet-compliance-manager"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
@@ -3614,60 +3841,60 @@ dependencies = [
  "bulletproofs",
  "cryptography",
  "curve25519-dalek 2.1.0",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "bitflags",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-contracts-primitives",
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "pwasm-utils",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-sandbox",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "wasmi-validation",
 ]
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts-rpc"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3676,82 +3903,82 @@ dependencies = [
  "pallet-contracts-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
  "sp-finality-tracker",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-authorship",
  "pallet-finality-tracker",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-group"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
@@ -3765,10 +3992,10 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-primitives",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
@@ -3781,9 +4008,9 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3791,21 +4018,21 @@ name = "pallet-identity"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-balances 0.1.0",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
  "substrate-test-runtime-client",
 ]
 
@@ -3814,78 +4041,78 @@ name = "pallet-im-online"
 version = "2.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
- "pallet-balances 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
+ "pallet-balances 2.0.0-rc6",
  "parity-scale-codec",
  "serde",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-pips"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-balances 0.1.0",
  "pallet-group",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "pallet-treasury",
  "parity-scale-codec",
  "polymesh-common-utilities",
@@ -3893,45 +4120,45 @@ dependencies = [
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "pallet-portfolio"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-arithmetic 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-arithmetic",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-protocol-fee"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-identity",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3945,79 +4172,79 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-protocol-fee-rpc-runtime-api"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
+ "frame-support",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "serde",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "safe-mix",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc5",
- "sp-trie 2.0.0-rc5",
+ "sp-std",
+ "sp-trie",
 ]
 
 [[package]]
 name = "pallet-settlement"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc6",
- "frame-system 2.0.0-rc6",
+ "frame-support",
+ "frame-system",
  "pallet-balances 0.1.0",
  "pallet-identity",
- "pallet-timestamp 2.0.0-rc6",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc6",
- "sp-core 2.0.0-rc6",
- "sp-io 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-serializer 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-version 2.0.0-rc6",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-serializer",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
@@ -4025,8 +4252,8 @@ name = "pallet-staking"
 version = "2.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-authorship",
  "pallet-babe",
  "pallet-identity",
@@ -4036,13 +4263,13 @@ dependencies = [
  "polymesh-primitives",
  "rand_chacha 0.2.2",
  "serde",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -4052,9 +4279,9 @@ version = "2.0.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "sp-runtime 2.0.0-rc5",
- "syn 1.0.38",
+ "quote",
+ "sp-runtime",
+ "syn",
 ]
 
 [[package]]
@@ -4067,73 +4294,56 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-staking-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
+ "frame-support",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-statistics"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "lazy_static",
  "pallet-session",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-timestamp 2.0.0-rc5",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4141,38 +4351,40 @@ name = "pallet-timestamp"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "frame-support 2.0.0-rc6",
- "frame-system 2.0.0-rc6",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-inherents 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-timestamp 2.0.0-rc6",
+ "serde",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "parity-scale-codec",
@@ -4180,28 +4392,28 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4220,13 +4432,13 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
+checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
 dependencies = [
  "arrayref",
  "bs58",
- "byteorder",
+ "byteorder 1.3.4",
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
@@ -4238,9 +4450,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
+checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -4251,14 +4463,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20ff7e0399b274a5f5bb37b712fccb5b3a64b9128200d1c3cc40fe709cb073"
+checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4293,12 +4505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
  "cfg-if",
- "hashbrown 0.8.1",
+ "hashbrown 0.8.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "winapi 0.3.9",
 ]
 
@@ -4309,7 +4521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.38",
+ "syn",
  "synstructure",
 ]
 
@@ -4319,7 +4531,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
 ]
 
 [[package]]
@@ -4342,11 +4554,21 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+dependencies = [
+ "lock_api 0.1.5",
+ "parking_lot_core 0.4.0",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -4357,8 +4579,32 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+dependencies = [
+ "libc",
+ "rand 0.6.5",
+ "rustc_version",
+ "smallvec 0.6.13",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4368,7 +4614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -4383,10 +4629,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.2",
  "winapi 0.3.9",
 ]
 
@@ -4415,8 +4676,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "crypto-mac 0.7.0",
+ "rayon",
 ]
 
 [[package]]
@@ -4469,8 +4731,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4498,16 +4760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
 dependencies = [
  "js-sys",
- "num-traits 0.2.12",
+ "num-traits",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "polling"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c5afb3e8bc82c2780a807374bda0fb8886904d8e9d51e6f4f3743fb1dd27fb"
+checksum = "8fffa183f6bd5f1a8a3e1f60ce2f8d5621e350eed84a62d6daaa5b9d1aaf6fbd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4536,6 +4798,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
  "jsonrpc-core",
+ "jsonrpc-pubsub",
  "log",
  "node-rpc",
  "node-rpc-runtime-api",
@@ -4573,17 +4836,17 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "serde_json",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-inherents 2.0.0-rc5",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
  "structopt",
@@ -4595,22 +4858,22 @@ dependencies = [
 name = "polymesh-common-utilities"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "lazy_static",
  "pallet-session",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
@@ -4619,6 +4882,7 @@ name = "polymesh-node-rpc"
 version = "0.1.0"
 dependencies = [
  "jsonrpc-core",
+ "jsonrpc-pubsub",
  "node-rpc",
  "pallet-contracts-rpc",
  "pallet-group-rpc",
@@ -4634,12 +4898,12 @@ dependencies = [
  "sc-finality-grandpa-rpc",
  "sc-keystore",
  "sc-rpc",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-transaction-pool",
  "substrate-frame-rpc-system",
 ]
@@ -4651,28 +4915,28 @@ dependencies = [
  "blake2",
  "cryptography",
  "curve25519-dalek 2.1.0",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "hex",
  "parity-scale-codec",
  "polymesh-primitives-derive",
  "schnorrkel",
  "serde",
  "serde_json",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "polymesh-primitives-derive"
 version = "0.1.0"
 dependencies = [
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4680,8 +4944,8 @@ name = "polymesh-runtime-common"
 version = "1.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "pallet-asset",
  "pallet-authorship",
  "pallet-balances 0.1.0",
@@ -4691,17 +4955,17 @@ dependencies = [
  "pallet-identity",
  "pallet-multisig",
  "pallet-portfolio",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "rand 0.7.3",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4710,8 +4974,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "node-rpc-runtime-api",
  "pallet-asset",
@@ -4747,7 +5011,7 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "pallet-statistics",
  "pallet-sudo",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4756,22 +5020,22 @@ dependencies = [
  "polymesh-primitives",
  "polymesh-runtime-common",
  "serde",
- "smallvec 1.4.1",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
+ "smallvec 1.4.2",
+ "sp-api",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "sp-transaction-pool",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "substrate-wasm-builder-runner",
 ]
 
@@ -4781,8 +5045,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "hex-literal 0.2.1",
  "ink_primitives",
@@ -4822,7 +5086,7 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "pallet-statistics",
  "pallet-sudo",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4835,22 +5099,22 @@ dependencies = [
  "safe-mix",
  "serde",
  "serde_derive",
- "smallvec 1.4.1",
- "sp-api 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
+ "smallvec 1.4.2",
+ "sp-api",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "sp-transaction-pool",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
 ]
@@ -4863,8 +5127,8 @@ dependencies = [
  "cryptography",
  "env_logger",
  "frame-benchmarking",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "hex-literal 0.3.1",
  "ink_primitives",
  "lazy_static",
@@ -4892,7 +5156,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-statistics",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4905,14 +5169,14 @@ dependencies = [
  "polymesh-runtime-develop",
  "rand 0.7.3",
  "serde",
- "smallvec 1.4.1",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "smallvec 1.4.2",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "substrate-test-runtime-client",
  "substrate-test-utils",
 ]
@@ -4929,9 +5193,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "primitive-types"
@@ -4962,8 +5226,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -4974,7 +5238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
+ "quote",
  "version_check",
 ]
 
@@ -4992,38 +5256,22 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "procfs"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c434e93ef69c216e68e4f417c927b4f31502c3560b72cfdb6827e2321c5c6b3e"
-dependencies = [
- "bitflags",
- "byteorder",
- "chrono",
- "hex",
- "lazy_static",
- "libc",
- "libflate",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
+checksum = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "protobuf",
  "spin",
  "thiserror",
 ]
@@ -5065,8 +5313,8 @@ dependencies = [
  "anyhow",
  "itertools 0.8.2",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5080,18 +5328,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d883f78645c21b7281d21305181aa1f4dd9e9363e7cf2566c93121552cff003e"
-
-[[package]]
 name = "pwasm-utils"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
+checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "log",
  "parity-wasm 0.41.0",
 ]
@@ -5112,12 +5354,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -5163,7 +5399,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
@@ -5291,7 +5527,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -5335,11 +5571,11 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
+checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -5347,12 +5583,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
+checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-queue",
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
@@ -5375,9 +5611,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
  "redox_syscall",
@@ -5400,8 +5636,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5422,7 +5658,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5457,8 +5694,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5475,18 +5712,12 @@ checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
  "cc",
  "libc",
- "once_cell",
+ "once_cell 1.4.1",
  "spin",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rocksdb"
@@ -5510,11 +5741,11 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -5599,6 +5830,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
+dependencies = [
+ "byteorder 1.3.4",
+ "salsa20-core",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "salsa20-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
+dependencies = [
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5609,14 +5860,14 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.23.0",
  "log",
  "parity-scale-codec",
  "prost",
@@ -5626,18 +5877,18 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "serde_json",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5647,12 +5898,12 @@ dependencies = [
  "sc-client-api",
  "sc-proposer-metrics",
  "sc-telemetry",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "tokio-executor 0.2.0-alpha.6",
@@ -5660,25 +5911,25 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5687,42 +5938,48 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
+ "bip39",
  "chrono",
  "derive_more",
  "env_logger",
  "fdlimit",
  "futures 0.3.5",
+ "hex",
  "lazy_static",
+ "libp2p 0.22.0",
  "log",
  "names",
  "nix",
+ "parity-scale-codec",
  "parity-util-mem",
+ "rand 0.7.3",
  "regex",
  "rpassword",
  "sc-client-api",
  "sc-informant",
+ "sc-keystore",
  "sc-network",
  "sc-service",
  "sc-telemetry",
@@ -5730,13 +5987,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-keyring",
- "sp-panic-handler 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-panic-handler",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-utils",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
@@ -5745,8 +6002,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5760,29 +6017,29 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor",
  "sc-telemetry",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.8.0-rc5",
- "sp-inherents 2.0.0-rc5",
+ "sp-externalities",
+ "sp-inherents",
  "sp-keyring",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-storage 2.0.0-rc5",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
- "sp-trie 2.0.0-rc5",
+ "sp-trie",
  "sp-utils",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5798,31 +6055,32 @@ dependencies = [
  "sc-client-api",
  "sc-executor",
  "sc-state-db",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-database",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-trie 2.0.0-rc5",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5832,11 +6090,12 @@ dependencies = [
  "merlin",
  "num-bigint",
  "num-rational",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "pdqselect",
  "rand 0.7.3",
+ "retain_mut",
  "sc-client-api",
  "sc-consensus-epochs",
  "sc-consensus-slots",
@@ -5845,26 +6104,27 @@ dependencies = [
  "sc-telemetry",
  "schnorrkel",
  "serde",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-vrf",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-timestamp 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-utils",
+ "sp-version",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5876,32 +6136,32 @@ dependencies = [
  "sc-keystore",
  "sc-rpc-api",
  "serde",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-client-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5910,35 +6170,35 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-telemetry",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "log",
  "sc-client-api",
  "sp-authorship",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5949,57 +6209,56 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor-common",
  "sc-executor-wasmi",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-panic-handler 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-serializer 2.0.0-rc5",
- "sp-trie 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-panic-handler",
+ "sp-runtime-interface",
+ "sp-serializer",
+ "sp-trie",
+ "sp-version",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "log",
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "sp-allocator",
- "sp-core 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-serializer 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime-interface",
+ "sp-serializer",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "log",
  "parity-scale-codec",
  "sc-executor-common",
  "sp-allocator",
- "sp-core 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "assert_matches",
  "derive_more",
  "finality-grandpa",
  "fork-tree",
@@ -6018,24 +6277,24 @@ dependencies = [
  "sc-network-gossip",
  "sc-telemetry",
  "serde_json",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-finality-tracker",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-inherents",
+ "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-finality-grandpa-rpc"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6043,16 +6302,20 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
+ "jsonrpc-pubsub",
  "log",
+ "parity-scale-codec",
  "sc-finality-grandpa",
+ "sc-rpc",
  "serde",
  "serde_json",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6061,7 +6324,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -6069,8 +6332,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "hex",
@@ -6078,15 +6341,15 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde_json",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "subtle 2.2.3",
+ "sp-application-crypto",
+ "sp-core",
+ "subtle 2.3.0",
 ]
 
 [[package]]
 name = "sc-light"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6094,19 +6357,20 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-executor",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
+ "async-std",
  "bitflags",
  "bs58",
  "bytes 0.5.6",
@@ -6120,7 +6384,7 @@ dependencies = [
  "futures_codec",
  "hex",
  "ip_network",
- "libp2p",
+ "libp2p 0.23.0",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6140,11 +6404,11 @@ dependencies = [
  "slog",
  "slog_derive",
  "smallvec 0.6.13",
- "sp-arithmetic 2.0.0-rc5",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -6156,23 +6420,23 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.23.0",
  "log",
  "lru",
  "sc-network",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6188,21 +6452,21 @@ dependencies = [
  "sc-client-api",
  "sc-keystore",
  "sc-network",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
  "sp-offchain",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-utils",
  "threadpool",
 ]
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
- "libp2p",
+ "libp2p 0.23.0",
  "log",
  "serde_json",
  "sp-utils",
@@ -6211,8 +6475,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6220,8 +6484,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6236,24 +6500,24 @@ dependencies = [
  "sc-keystore",
  "sc-rpc-api",
  "serde_json",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
  "sp-chain-spec",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.8.0-rc5",
+ "sp-state-machine",
  "sp-transaction-pool",
  "sp-utils",
- "sp-version 2.0.0-rc5",
+ "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6267,17 +6531,17 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
  "sp-transaction-pool",
- "sp-version 2.0.0-rc5",
+ "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6287,13 +6551,13 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "directories",
@@ -6302,15 +6566,14 @@ dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "hash-db",
+ "jsonrpc-core",
  "jsonrpc-pubsub",
  "lazy_static",
  "log",
- "netstat2",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
  "pin-project",
- "procfs",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -6330,23 +6593,23 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.8.0-rc5",
+ "sp-state-machine",
  "sp-transaction-pool",
- "sp-trie 2.0.0-rc5",
+ "sp-trie",
  "sp-utils",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "substrate-prometheus-endpoint",
- "sysinfo",
  "tempfile",
  "tracing",
  "wasm-timer",
@@ -6354,8 +6617,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6363,17 +6626,17 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "sc-client-api",
- "sp-core 2.0.0-rc5",
+ "sp-core",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.23.0",
  "log",
  "parking_lot 0.10.2",
  "pin-project",
@@ -6389,8 +6652,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "erased-serde",
  "log",
@@ -6400,14 +6663,15 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-tracing 2.0.0-rc5",
- "tracing-core",
+ "sp-tracing",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6418,8 +6682,8 @@ dependencies = [
  "retain_mut",
  "serde",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -6427,8 +6691,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6440,11 +6704,11 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-transaction-graph",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-tracing 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-utils",
  "substrate-prometheus-endpoint",
@@ -6476,7 +6740,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "sha2 0.8.2",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
@@ -6485,6 +6749,12 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "scopeguard"
@@ -6561,21 +6831,15 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
-
-[[package]]
-name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
@@ -6601,13 +6865,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6631,6 +6895,19 @@ dependencies = [
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -6669,6 +6946,27 @@ dependencies = [
  "digest 0.8.1",
  "keccak",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -6739,8 +7037,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6754,9 +7052,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "snow"
@@ -6772,15 +7070,15 @@ dependencies = [
  "ring",
  "rustc_version",
  "sha2 0.9.1",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6790,9 +7088,9 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85457366ae0c6ce56bf05a958aef14cd38513c236568618edbcd9a8c52cb80b0"
+checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
 dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
@@ -6801,34 +7099,19 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1",
+ "sha-1 0.9.1",
 ]
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "log",
- "sp-core 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-api"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "hash-db",
- "parity-scale-codec",
- "sp-api-proc-macro 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-core",
+ "sp-std",
+ "sp-wasm-interface",
 ]
 
 [[package]]
@@ -6838,24 +7121,12 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "hash-db",
  "parity-scale-codec",
- "sp-api-proc-macro 2.0.0-rc6",
- "sp-core 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-state-machine 0.8.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-version 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "blake2-rfc",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "sp-api-proc-macro",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
@@ -6866,20 +7137,8 @@ dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6889,22 +7148,9 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc6",
- "sp-io 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "integer-sqrt",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "serde",
- "sp-debug-derive 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -6913,52 +7159,52 @@ version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-scale-codec",
  "serde",
- "sp-debug-derive 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "log",
@@ -6968,14 +7214,14 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus",
  "sp-database",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6983,124 +7229,82 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.23.0",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-trie 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
  "sp-utils",
- "sp-version 2.0.0-rc5",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-timestamp 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "merlin",
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-vrf",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-timestamp 2.0.0-rc5",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 2.0.0-rc5",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sp-consensus-vrf"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-core"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "base58",
- "blake2-rfc",
- "byteorder",
- "derive_more",
- "ed25519-dalek",
- "futures 0.3.5",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "impl-serde 0.3.1",
- "lazy_static",
- "libsecp256k1",
- "log",
- "merlin",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "parity-util-mem",
- "parking_lot 0.10.2",
- "primitive-types",
- "rand 0.7.3",
- "regex",
- "schnorrkel",
- "secrecy",
- "serde",
- "sha2 0.8.2",
- "sp-debug-derive 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-storage 2.0.0-rc5",
- "substrate-bip39",
- "tiny-bip39",
- "tiny-keccak",
- "twox-hash",
- "wasmi",
- "zeroize",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7110,7 +7314,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "base58",
  "blake2-rfc",
- "byteorder",
+ "byteorder 1.3.4",
  "derive_more",
  "dyn-clonable",
  "ed25519-dalek",
@@ -7123,7 +7327,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
@@ -7134,11 +7338,11 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2 0.8.2",
- "sp-debug-derive 2.0.0-rc6",
- "sp-externalities 0.8.0-rc6",
- "sp-runtime-interface 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-storage 2.0.0-rc6",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "substrate-bip39",
  "tiny-bip39",
  "tiny-keccak",
@@ -7149,21 +7353,11 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
 ]
 
 [[package]]
@@ -7172,19 +7366,8 @@ version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 2.0.0-rc5",
- "sp-storage 2.0.0-rc5",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7194,46 +7377,34 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 2.0.0-rc6",
- "sp-storage 2.0.0-rc6",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "serde",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "sp-core 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-inherents",
+ "sp-std",
 ]
 
 [[package]]
@@ -7244,29 +7415,8 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-io"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "futures 0.3.5",
- "hash-db",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-tracing 2.0.0-rc5",
- "sp-trie 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
@@ -7280,67 +7430,58 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core 2.0.0-rc6",
- "sp-externalities 0.8.0-rc6",
- "sp-runtime-interface 2.0.0-rc6",
- "sp-state-machine 0.8.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-tracing 2.0.0-rc6",
- "sp-trie 2.0.0-rc6",
- "sp-wasm-interface 2.0.0-rc6",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "lazy_static",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "strum",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-arithmetic 2.0.0-rc5",
+ "sp-arithmetic",
  "sp-npos-elections-compact",
- "sp-std 2.0.0-rc5",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-npos-elections-compact"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "backtrace",
- "log",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7354,33 +7495,11 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "serde",
- "sp-core 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "parity-util-mem",
- "paste",
- "rand 0.7.3",
- "serde",
- "sp-application-crypto 2.0.0-rc5",
- "sp-arithmetic 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-core",
 ]
 
 [[package]]
@@ -7397,27 +7516,12 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto 2.0.0-rc6",
- "sp-arithmetic 2.0.0-rc6",
- "sp-core 2.0.0-rc6",
- "sp-inherents 2.0.0-rc6",
- "sp-io 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.8.0-rc5",
- "sp-runtime-interface-proc-macro 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-tracing 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
- "static_assertions",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -7427,25 +7531,13 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.8.0-rc6",
- "sp-runtime-interface-proc-macro 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
- "sp-storage 2.0.0-rc6",
- "sp-tracing 2.0.0-rc6",
- "sp-wasm-interface 2.0.0-rc6",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
 ]
 
 [[package]]
@@ -7456,30 +7548,21 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "sp-sandbox"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-core 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "sp-wasm-interface 2.0.0-rc5",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "sp-wasm-interface",
  "wasmi",
-]
-
-[[package]]
-name = "sp-serializer"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -7493,46 +7576,25 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc5",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "hash-db",
- "itertools 0.9.0",
- "log",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "rand 0.7.3",
- "smallvec 1.4.1",
- "sp-core 2.0.0-rc5",
- "sp-externalities 0.8.0-rc5",
- "sp-panic-handler 2.0.0-rc5",
- "sp-trie 2.0.0-rc5",
- "trie-db",
- "trie-root",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7543,40 +7605,23 @@ dependencies = [
  "hash-db",
  "itertools 0.9.0",
  "log",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "smallvec 1.4.1",
- "sp-core 2.0.0-rc6",
- "sp-externalities 0.8.0-rc6",
- "sp-panic-handler 2.0.0-rc6",
- "sp-trie 2.0.0-rc6",
+ "smallvec 1.4.2",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie",
  "trie-db",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-
-[[package]]
-name = "sp-std"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
-
-[[package]]
-name = "sp-storage"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "impl-serde 0.2.3",
- "ref-cast",
- "serde",
- "sp-debug-derive 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
 
 [[package]]
 name = "sp-storage"
@@ -7587,45 +7632,22 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-api 2.0.0-rc5",
- "sp-inherents 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
  "wasm-timer",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-api 2.0.0-rc6",
- "sp-inherents 2.0.0-rc6",
- "sp-runtime 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "log",
- "rental",
- "tracing",
 ]
 
 [[package]]
@@ -7640,31 +7662,17 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "log",
  "parity-scale-codec",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-trie"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "hash-db",
- "memory-db",
- "parity-scale-codec",
- "sp-core 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
- "trie-db",
- "trie-root",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7675,16 +7683,16 @@ dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "sp-core 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
+ "sp-core",
+ "sp-std",
  "trie-db",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7695,37 +7703,14 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "impl-serde 0.2.3",
- "parity-scale-codec",
- "serde",
- "sp-runtime 2.0.0-rc5",
- "sp-std 2.0.0-rc5",
-]
-
-[[package]]
-name = "sp-version"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
  "serde",
- "sp-runtime 2.0.0-rc6",
- "sp-std 2.0.0-rc6",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-std 2.0.0-rc5",
- "wasmi",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7735,7 +7720,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "wasmi",
 ]
 
@@ -7768,11 +7753,20 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "stream-cipher"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -7792,9 +7786,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
 dependencies = [
  "clap",
  "lazy_static",
@@ -7803,15 +7797,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7831,26 +7825,27 @@ checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
+checksum = "bed6646a0159b9935b5d045611560eeef842b78d7adc3ba36f5ca325a13a0236"
 dependencies = [
  "hmac",
  "pbkdf2",
  "schnorrkel",
  "sha2 0.8.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7862,18 +7857,18 @@ dependencies = [
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7886,8 +7881,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-client"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -7904,56 +7899,56 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 2.0.0-rc5",
- "sp-state-machine 0.8.0-rc5",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "substrate-test-runtime"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "cfg-if",
  "frame-executive",
- "frame-support 2.0.0-rc5",
- "frame-system 2.0.0-rc5",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "log",
  "memory-db",
  "pallet-babe",
- "pallet-timestamp 2.0.0-rc5",
+ "pallet-timestamp",
  "parity-scale-codec",
  "parity-util-mem",
  "sc-service",
  "serde",
- "sp-api 2.0.0-rc5",
- "sp-application-crypto 2.0.0-rc5",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-babe",
- "sp-core 2.0.0-rc5",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-inherents 2.0.0-rc5",
- "sp-io 2.0.0-rc5",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 2.0.0-rc5",
- "sp-runtime-interface 2.0.0-rc5",
+ "sp-runtime",
+ "sp-runtime-interface",
  "sp-session",
- "sp-std 2.0.0-rc5",
+ "sp-std",
  "sp-transaction-pool",
- "sp-trie 2.0.0-rc5",
- "sp-version 2.0.0-rc5",
+ "sp-trie",
+ "sp-version",
  "substrate-wasm-builder-runner",
  "trie-db",
 ]
 
 [[package]]
 name = "substrate-test-runtime-client"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7962,19 +7957,34 @@ dependencies = [
  "sc-consensus",
  "sc-light",
  "sc-service",
- "sp-api 2.0.0-rc5",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc5",
- "sp-runtime 2.0.0-rc5",
+ "sp-core",
+ "sp-runtime",
  "substrate-test-client",
  "substrate-test-runtime",
 ]
 
 [[package]]
 name = "substrate-test-utils"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "futures 0.3.5",
+ "substrate-test-utils-derive",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "substrate-test-utils-derive"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "proc-macro-crate",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "substrate-wasm-builder"
@@ -7994,7 +8004,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 
 [[package]]
 name = "subtle"
@@ -8004,39 +8014,19 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8046,24 +8036,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
-dependencies = [
- "cfg-if",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi 0.3.9",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8120,8 +8095,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8144,11 +8119,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -8160,7 +8136,7 @@ checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
- "once_cell",
+ "once_cell 1.4.1",
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
@@ -8189,9 +8165,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
@@ -8236,6 +8212,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -8312,6 +8289,17 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "log",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8495,9 +8483,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
  "log",
@@ -8507,22 +8495,64 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.4.2",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -8532,10 +8562,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e55f7ace33d6237e14137e386f4e1672e2a5c6bbc97fef9f438581a143971f0"
 dependencies = [
  "hash-db",
- "hashbrown 0.8.1",
+ "hashbrown 0.8.2",
  "log",
  "rustc-hex",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -8552,6 +8582,17 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "twofish"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
+dependencies = [
+ "block-cipher-trait",
+ "byteorder 1.3.4",
+ "opaque-debug 0.2.3",
+]
 
 [[package]]
 name = "twox-hash"
@@ -8578,8 +8619,8 @@ version = "0.1.0"
 source = "git+https://github.com/type-metadata/type-metadata.git?rev=02eae9f35c40c943b56af5b60616219f2b72b47d#02eae9f35c40c943b56af5b60616219f2b72b47d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8590,11 +8631,11 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429ffcad8c8c15f874578c7337d156a3727eb4a1c2374c0ae937ad9a9b748c80"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -8641,12 +8682,6 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
@@ -8657,15 +8692,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.3",
- "subtle 2.2.3",
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "unsigned-varint"
@@ -8678,6 +8707,12 @@ dependencies = [
  "futures-util",
  "futures_codec",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "untrusted"
@@ -8792,10 +8827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.67"
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8803,24 +8844,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8830,38 +8871,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d92df9d5715606f9e48f85df3b78cb77ae44a2ea9a5f2a785a97bd0066b9300"
+checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -8873,12 +8914,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51611ce8e84cba89379d91fc5074bacc5530f69da1c09a2853d906129d12b3b8"
+checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
+ "quote",
 ]
 
 [[package]]
@@ -8894,15 +8935,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-timer"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c5e65a08699c9c4334ba136597ab22b85dccd4b65dd1e36ccf8f723a95b54"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
- "parking_lot 0.9.0",
+ "parking_lot 0.11.0",
  "pin-utils",
- "send_wrapper 0.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8917,7 +8957,7 @@ dependencies = [
  "libc",
  "memory_units",
  "num-rational",
- "num-traits 0.2.12",
+ "num-traits",
  "parity-wasm 0.41.0",
  "wasmi-validation",
 ]
@@ -8933,9 +8973,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8971,9 +9011,9 @@ dependencies = [
 
 [[package]]
 name = "wepoll-sys-stjepang"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
+checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
 dependencies = [
  "cc",
 ]
@@ -9036,14 +9076,14 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
 dependencies = [
- "byteorder",
+ "byteorder 1.3.4",
  "bytes 0.4.12",
  "httparse",
  "log",
  "mio",
  "mio-extras",
  "rand 0.7.3",
- "sha-1",
+ "sha-1 0.8.2",
  "slab",
  "url 2.1.1",
 ]
@@ -9071,9 +9111,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
+checksum = "053585b18bca1a3d00e4b5ef93e72d4f49a10005374c455db7177e27149c899d"
 dependencies = [
  "futures 0.3.5",
  "log",
@@ -9099,7 +9139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.38",
+ "quote",
+ "syn",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,52 +206,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
-name = "async-std"
-version = "1.5.0"
+name = "async-channel"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
+checksum = "59386c3aa61f4e14c4ddda1a6744c119b4bf278ec9f866d3c20bc5728ee0eb97"
 dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
+dependencies = [
+ "async-io",
+ "futures-lite",
+ "multitask",
+ "parking 1.0.6",
+ "scoped-tls",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "parking 2.0.0",
+ "polling",
+ "socket2",
+ "vec-arena",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065de1ccf10280d0d75c2f3a71a970ee1007c85c51aa3e7deee1df100f1dfadb"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-mutex",
  "async-task",
- "broadcaster",
- "crossbeam-channel",
- "crossbeam-deque",
+ "blocking",
  "crossbeam-utils",
+ "futures-channel",
  "futures-core",
  "futures-io",
- "futures-timer 2.0.2",
+ "futures-lite",
+ "futures-timer 3.0.2",
  "kv-log-macro",
  "log",
  "memchr",
- "mio",
- "mio-uds",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
  "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "async-task"
-version = "1.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
+checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-tls"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fd83426b89b034bf4e9ceb9c533c2f2386b813fd3dcae0a425ec6f1837d78a"
+checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
 dependencies = [
  "futures 0.3.5",
  "rustls",
  "webpki",
  "webpki-roots 0.19.0",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -297,10 +360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
-name = "bindgen"
-version = "0.53.3"
+name = "base64"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "bindgen"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -340,18 +409,6 @@ checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
  "either",
  "radium",
-]
-
-[[package]]
-name = "blake2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -439,17 +496,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "broadcaster"
-version = "1.0.0"
+name = "blocking"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
+checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "futures-util",
- "parking_lot 0.10.2",
- "slab",
+ "async-channel",
+ "atomic-waker",
+ "futures-lite",
+ "once_cell",
+ "waker-fn",
 ]
 
 [[package]]
@@ -485,7 +541,7 @@ version = "2.0.1"
 source = "git+https://github.com/PolymathNetwork/bulletproofs.git?branch=main#ed546e5b8919dc2ba4b9cee6fbd8320c495fcbe1"
 dependencies = [
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "digest 0.8.1",
  "merlin",
  "rand 0.7.3",
@@ -544,6 +600,12 @@ name = "c_linked_list"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo_metadata"
@@ -651,21 +713,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -772,16 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,10 +911,10 @@ dependencies = [
 name = "cryptography"
 version = "0.1.0"
 dependencies = [
- "blake2 0.9.0",
+ "blake2",
  "bulletproofs",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "failure",
  "getrandom",
  "lazy_static",
@@ -905,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "ct-logs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
+checksum = "8c8e13110a84b6315df212c045be706af261fd364791cad863285439ebba672e"
 dependencies = [
  "sct",
 ]
@@ -923,6 +975,19 @@ dependencies = [
  "packed_simd",
  "rand_core 0.5.1",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -1000,15 +1065,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+name = "ed25519"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
- "clear_on_drop",
- "curve25519-dalek",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
+dependencies = [
+ "curve25519-dalek 3.0.0",
+ "ed25519",
  "rand 0.7.3",
- "sha2 0.8.2",
+ "serde",
+ "sha2 0.9.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1057,6 +1133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+
+[[package]]
 name = "exit-future"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1174,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
 
 [[package]]
 name = "fdlimit"
@@ -1156,16 +1244,16 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1181,9 +1269,10 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
+ "Inflector",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",
@@ -1199,8 +1288,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1214,8 +1303,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "11.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1225,8 +1314,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1250,8 +1339,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1261,8 +1350,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1273,8 +1362,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1283,8 +1372,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1299,8 +1388,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1447,6 +1536,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
+name = "futures-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97999970129b808f0ccba93211201d431fcc12d7e1ffae03a61b5cedd1a7ced2"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking 2.0.0",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1588,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -1516,18 +1624,6 @@ dependencies = [
  "futures-core-preview",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.5",
- "memchr",
- "pin-project",
 ]
 
 [[package]]
@@ -1635,6 +1731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "h2"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,7 +1807,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash",
+ "ahash 0.2.18",
  "autocfg 0.1.7",
 ]
 
@@ -1708,6 +1817,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
+ "ahash 0.3.8",
  "autocfg 1.0.0",
 ]
 
@@ -1896,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
  "bytes 0.5.6",
  "ct-logs",
@@ -2229,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
+checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
  "smallvec 1.4.1",
@@ -2239,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73027d5e228de6f503b5b7335d530404fc26230a6ae3e09b33ec6e45408509a4"
+checksum = "73de822b260a3bdfb889dbbb65bb2d473eee2253973d6fa4a5d149a2a4a7c66e"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2250,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
+checksum = "44947dd392f09475af614d740fe0320b66d01cb5b977f664bbbb5e45a70ea4c1"
 dependencies = [
  "fs-swap",
  "kvdb",
@@ -2323,9 +2433,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.19.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057eba5432d3e740e313c6e13c9153d0cb76b4f71bfc2e5242ae5bdb7d41af67"
+checksum = "0306a49ee6a89468f96089906f36b0eef82c988dcfc8acf3e2dcd6ad1c859f85"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
@@ -2345,7 +2455,7 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multihash",
- "parity-multiaddr 0.9.1",
+ "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.1",
@@ -2354,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.19.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0387b930c3d4c2533dc4893c1e0394185ddcc019846121b1b27491e45a2c08"
+checksum = "6a694fd76d7c33a45a0e6e1525e9b9b5d11127c9c94e560ac0f8abba54ed80af"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2370,7 +2480,7 @@ dependencies = [
  "log",
  "multihash",
  "multistream-select",
- "parity-multiaddr 0.9.1",
+ "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2388,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.19.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
+checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
 dependencies = [
  "quote 1.0.7",
  "syn 1.0.38",
@@ -2398,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc186d9a941fd0207cf8f08ef225a735e2d7296258f570155e525f6ee732f87"
+checksum = "f751924b6b98e350005e0b87a822beb246792a3fb878c684e088f866158120ac"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2409,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f76075b170d908bae616f550ade410d9d27c013fa69042551dbfc757c7c094"
+checksum = "912c00a7bf67e0e765daf0cc37e08f675ea26aba3d6d1fbfaee81f19a4c23049"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2425,16 +2535,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d6c1d5100973527ae70d82687465b17049c1b717a7964de38b8e65000878ff"
+checksum = "44ed3a4c8111c570ab2bffb30c6353178d7603ce3787e3c5f2493c8d3d16d1f0"
 dependencies = [
  "arrayvec 0.5.1",
  "bytes 0.5.6",
  "either",
  "fnv",
  "futures 0.3.5",
- "futures_codec 0.3.4",
+ "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2445,16 +2555,16 @@ dependencies = [
  "sha2 0.8.2",
  "smallvec 1.4.1",
  "uint",
- "unsigned-varint 0.3.3",
+ "unsigned-varint 0.4.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55b2d4b80986e5bf158270ab23268ec0e7f644ece5436fbaabc5155472f357"
+checksum = "cd004c668160fd922f7268b2cd1e4550ff69165d9c744e9eb5770086eb753d02"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -2474,14 +2584,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7d913a4cd57de2013257ec73f07d77bfce390b370023e2d59083e5ca079864"
+checksum = "14ae0ffacd30f073f96cd518b2c9cd2cb18ac27c3d136a4b23cf1af99f33e541"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
- "futures_codec 0.4.1",
+ "futures_codec",
  "libp2p-core",
  "log",
  "parking_lot 0.10.2",
@@ -2490,11 +2600,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.19.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03db664653369f46ee03fcec483a378c20195089bb43a26cb9fb0058009ac88"
+checksum = "8f353f8966bbaaf7456535fffd3f366f153148773a0cf04b2ec3860955cb720e"
 dependencies = [
- "curve25519-dalek",
+ "bytes 0.5.6",
+ "curve25519-dalek 2.1.0",
  "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
@@ -2511,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.19.3"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dedd34e35a9728d52d59ef36a218e411359a353f9011b2574b86ee790978f6"
+checksum = "70130cf130e4ba6dc177366e72dd9f86f9e3588fa1a0c4145247e676f16affad"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2526,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce53ff4d127cf8b39adf84dbd381ca32d49bd85788cee08e6669da2495993930"
+checksum = "f88d5e2a090a2aadf042cd33484e2f015c6dab212567406a59deece5dedbd133"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2541,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481500c5774c62e8c413e9535b3f33a0e3dbacf2da63b8d3056c686a9df4146"
+checksum = "9b1fa2bbad054020cb875546a577a66a65a5bf42eff55ed5265f92ffee3cc052"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -2557,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59fdbb5706f2723ca108c088b1c7a37f735a8c328021f0508007162627e9885"
+checksum = "0feb99e32fea20ffb1bbf56a6fb2614bff7325ff44a515728385170b3420d2c3"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
@@ -2571,12 +2682,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085fbe4c05c4116c2164ab4d5a521eb6e00516c444f61b3ee9f68c7b1e53580b"
+checksum = "046a5201f6e471f22b22b394e4d084269ed1e28cf7300f7b49874385db84c7bd"
 dependencies = [
  "async-tls",
- "bytes 0.5.6",
  "either",
  "futures 0.3.5",
  "libp2p-core",
@@ -2592,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da33e7b5f49c75c6a8afb0b8d1e229f5fa48be9f39bd14cdbc21459a02ac6fc"
+checksum = "46ae9bf2f7d8a4be9c7e9b61df9de9dc1bd66419d669098f22f81f8d9571029a"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2605,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.7.4"
+version = "6.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
 dependencies = [
  "bindgen",
  "cc",
@@ -2744,13 +2854,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.21.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
+checksum = "36f36ddb0b2cdc25d38babba472108798e3477f02be5165f038c5e393e50c57a"
 dependencies = [
- "ahash",
  "hash-db",
- "hashbrown 0.6.3",
+ "hashbrown 0.8.1",
  "parity-util-mem",
 ]
 
@@ -2890,6 +2999,17 @@ dependencies = [
  "pin-project",
  "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
+]
+
+[[package]]
+name = "multitask"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
 ]
 
 [[package]]
@@ -3197,8 +3317,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3213,8 +3333,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3228,11 +3348,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -3243,6 +3365,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
+ "sp-session",
  "sp-staking",
  "sp-std",
  "sp-timestamp",
@@ -3273,8 +3396,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3378,7 +3501,7 @@ version = "0.1.0"
 dependencies = [
  "bulletproofs",
  "cryptography",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "frame-support",
  "frame-system",
  "pallet-identity",
@@ -3400,9 +3523,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
+ "bitflags",
  "frame-support",
  "frame-system",
  "pallet-contracts-primitives",
@@ -3420,8 +3544,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -3430,8 +3554,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3449,8 +3573,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -3461,8 +3585,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3477,11 +3601,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "pallet-authorship",
  "pallet-finality-tracker",
  "pallet-session",
  "parity-scale-codec",
@@ -3592,8 +3718,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3625,12 +3751,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-balances 2.0.0-rc4",
+ "pallet-balances 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
  "sp-runtime",
@@ -3727,8 +3853,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3740,8 +3866,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3869,8 +3995,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3883,8 +4009,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3967,24 +4093,6 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "parity-multihash",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint 0.3.3",
- "url 2.1.1",
-]
-
-[[package]]
-name = "parity-multiaddr"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
@@ -3999,21 +4107,6 @@ dependencies = [
  "static_assertions",
  "unsigned-varint 0.4.0",
  "url 2.1.1",
-]
-
-[[package]]
-name = "parity-multihash"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
-dependencies = [
- "blake2 0.8.1",
- "bytes 0.5.6",
- "rand 0.7.3",
- "sha-1",
- "sha2 0.8.2",
- "sha3",
- "unsigned-varint 0.3.3",
 ]
 
 [[package]]
@@ -4068,11 +4161,12 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
+checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.8.1",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
@@ -4106,6 +4200,18 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parking"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -4271,6 +4377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c5afb3e8bc82c2780a807374bda0fb8886904d8e9d51e6f4f3743fb1dd27fb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,9 +4519,9 @@ dependencies = [
 name = "polymesh-primitives"
 version = "2.0.0"
 dependencies = [
- "blake2 0.9.0",
+ "blake2",
  "cryptography",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "frame-support",
  "frame-system",
  "hex",
@@ -5214,6 +5333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
+
+[[package]]
 name = "ring"
 version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,9 +5361,9 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rocksdb"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
+checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5260,7 +5385,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -5295,11 +5420,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "log",
  "ring",
  "sct",
@@ -5308,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
+checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
 dependencies = [
  "openssl-probe",
  "rustls",
@@ -5355,8 +5480,8 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
@@ -5382,8 +5507,8 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5406,8 +5531,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5416,14 +5541,15 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5438,8 +5564,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5449,8 +5575,8 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5472,6 +5598,7 @@ dependencies = [
  "sc-service",
  "sc-telemetry",
  "sc-tracing",
+ "serde",
  "serde_json",
  "sp-blockchain",
  "sp-core",
@@ -5489,8 +5616,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5525,8 +5652,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5554,8 +5681,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5565,8 +5692,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5607,8 +5734,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5631,8 +5758,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5644,8 +5771,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5658,6 +5785,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -5666,8 +5794,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5680,8 +5808,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5707,8 +5835,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "log",
@@ -5724,8 +5852,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5739,8 +5867,8 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -5777,8 +5905,8 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa-rpc"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5794,14 +5922,13 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
  "log",
  "parity-util-mem",
- "parking_lot 0.10.2",
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
@@ -5813,8 +5940,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "hex",
@@ -5829,8 +5956,8 @@ dependencies = [
 
 [[package]]
 name = "sc-light"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5848,8 +5975,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bitflags",
  "bs58",
@@ -5861,7 +5988,7 @@ dependencies = [
  "fork-tree",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "futures_codec 0.3.4",
+ "futures_codec",
  "hex",
  "ip_network",
  "libp2p",
@@ -5892,7 +6019,7 @@ dependencies = [
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint 0.3.3",
+ "unsigned-varint 0.4.0",
  "void",
  "wasm-timer",
  "zeroize",
@@ -5900,8 +6027,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5915,8 +6042,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5942,8 +6069,8 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5955,8 +6082,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5964,8 +6091,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5996,8 +6123,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6020,8 +6147,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6036,8 +6163,8 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "directories",
@@ -6050,7 +6177,6 @@ dependencies = [
  "lazy_static",
  "log",
  "netstat2",
- "parity-multiaddr 0.7.3",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
@@ -6099,8 +6225,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6113,10 +6239,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "bytes 0.5.6",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
@@ -6135,8 +6260,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "erased-serde",
  "log",
@@ -6152,8 +6277,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6161,6 +6286,7 @@ dependencies = [
  "log",
  "parity-util-mem",
  "parking_lot 0.10.2",
+ "retain_mut",
  "serde",
  "sp-blockchain",
  "sp-core",
@@ -6172,8 +6298,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6214,7 +6340,7 @@ checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "getrandom",
  "merlin",
  "rand 0.7.3",
@@ -6248,10 +6374,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "0.4.4"
+name = "secrecy"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6262,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6300,6 +6435,12 @@ name = "send_wrapper"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -6364,12 +6505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6422,6 +6557,12 @@ dependencies = [
  "arc-swap",
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 
 [[package]]
 name = "slab"
@@ -6495,7 +6636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
 dependencies = [
  "aes-gcm",
- "blake2 0.9.0",
+ "blake2",
  "chacha20poly1305",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -6520,28 +6661,24 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
+checksum = "85457366ae0c6ce56bf05a958aef14cd38513c236568618edbcd9a8c52cb80b0"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
  "futures 0.3.5",
- "http 0.2.1",
  "httparse",
  "log",
  "rand 0.7.3",
- "sha1",
- "smallvec 1.4.1",
- "static_assertions",
- "thiserror",
+ "sha-1",
 ]
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "log",
@@ -6552,8 +6689,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6567,8 +6704,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6579,8 +6716,8 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6591,8 +6728,8 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6604,8 +6741,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6616,8 +6753,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6627,8 +6764,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6639,8 +6776,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "log",
@@ -6649,14 +6786,15 @@ dependencies = [
  "parking_lot 0.10.2",
  "sp-block-builder",
  "sp-consensus",
+ "sp-database",
  "sp-runtime",
  "sp-state-machine",
 ]
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "serde",
  "serde_json",
@@ -6664,8 +6802,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6680,6 +6818,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-trie",
  "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
@@ -6688,8 +6827,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6702,14 +6841,15 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "merlin",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
+ "sp-consensus-slots",
  "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
@@ -6719,9 +6859,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-slots"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+dependencies = [
+ "parity-scale-codec",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sp-consensus-vrf"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6732,8 +6881,8 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6757,6 +6906,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "schnorrkel",
+ "secrecy",
  "serde",
  "sha2 0.8.2",
  "sp-debug-derive",
@@ -6774,8 +6924,8 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6783,8 +6933,8 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -6793,8 +6943,8 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6804,8 +6954,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6820,8 +6970,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6830,8 +6980,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6842,8 +6992,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6863,8 +7013,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6874,8 +7024,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6886,8 +7036,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections-compact"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6897,8 +7047,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6907,8 +7057,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "backtrace",
  "log",
@@ -6916,8 +7066,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "serde",
  "sp-core",
@@ -6925,8 +7075,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6947,8 +7097,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6962,8 +7112,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6974,8 +7124,8 @@ dependencies = [
 
 [[package]]
 name = "sp-sandbox"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -6987,8 +7137,8 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "serde",
  "serde_json",
@@ -6996,8 +7146,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7009,8 +7159,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7019,8 +7169,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7040,13 +7190,13 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7057,8 +7207,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7071,8 +7221,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "log",
  "rental",
@@ -7081,8 +7231,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7092,13 +7242,12 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
- "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7111,8 +7260,8 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7123,8 +7272,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7135,8 +7284,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7254,8 +7403,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7277,8 +7426,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "0.8.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7291,11 +7440,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-client"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
+ "futures 0.1.29",
  "futures 0.3.5",
  "hash-db",
+ "hex",
  "parity-scale-codec",
  "sc-client-api",
  "sc-client-db",
@@ -7303,6 +7454,8 @@ dependencies = [
  "sc-executor",
  "sc-light",
  "sc-service",
+ "serde",
+ "serde_json",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
@@ -7313,8 +7466,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7353,8 +7506,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime-client"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7374,8 +7527,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-utils"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+version = "2.0.0-rc5"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 
 [[package]]
 name = "substrate-wasm-builder"
@@ -7395,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 
 [[package]]
 name = "subtle"
@@ -7454,9 +7607,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.13.4"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac193374347e7c263c5f547524f36ff8ec6702d56c8799c8331d26dffe8c1e"
+checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
 dependencies = [
  "cfg-if",
  "doc-comment",
@@ -7749,9 +7902,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
@@ -7928,12 +8081,12 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
+checksum = "9e55f7ace33d6237e14137e386f4e1672e2a5c6bbc97fef9f438581a143971f0"
 dependencies = [
  "hash-db",
- "hashbrown 0.6.3",
+ "hashbrown 0.8.1",
  "log",
  "rustc-hex",
  "smallvec 1.4.1",
@@ -8067,12 +8220,6 @@ name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
-dependencies = [
- "bytes 0.5.6",
- "futures-io",
- "futures-util",
- "futures_codec 0.3.4",
-]
 
 [[package]]
 name = "unsigned-varint"
@@ -8081,7 +8228,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
 dependencies = [
  "bytes 0.5.6",
- "futures_codec 0.4.1",
+ "futures-io",
+ "futures-util",
+ "futures_codec",
 ]
 
 [[package]]
@@ -8119,6 +8268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
+name = "vec-arena"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb18268690309760d59ee1a9b21132c126ba384f374c59a94db4bc03adeb561"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8145,6 +8300,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -8295,7 +8456,7 @@ dependencies = [
  "js-sys",
  "parking_lot 0.9.0",
  "pin-utils",
- "send_wrapper",
+ "send_wrapper 0.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8360,6 +8521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wepoll-sys-stjepang"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -8448,7 +8618,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,17 +2033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "honggfuzz"
-version = "0.5.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f085725a5828d7e959f014f624773094dfe20acc91be310ef106923c30594bc"
-dependencies = [
- "arbitrary",
- "lazy_static",
- "memmap",
-]
-
-[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9136,18 +9125,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "honggfuzz"
+version = "0.5.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f085725a5828d7e959f014f624773094dfe20acc91be310ef106923c30594bc"
+dependencies = [
+ "arbitrary",
+ "lazy_static",
+ "memmap",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha3",
- "sp-std",
+ "sp-std 2.0.0-rc6",
  "wasm-bindgen-test",
  "zeroize",
 ]
@@ -1063,6 +1063,33 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dyn-clonable"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
+dependencies = [
+ "dyn-clonable-impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "dyn-clonable-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
 
 [[package]]
 name = "ed25519"
@@ -1255,16 +1282,16 @@ name = "frame-benchmarking"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "linregress",
  "parity-scale-codec",
  "paste",
- "sp-api",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -1279,10 +1306,10 @@ dependencies = [
  "sc-client-db",
  "sc-executor",
  "sc-service",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
  "structopt",
 ]
 
@@ -1291,14 +1318,14 @@ name = "frame-executive"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-tracing",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-tracing 2.0.0-rc5",
 ]
 
 [[package]]
@@ -1308,8 +1335,19 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "11.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -1318,8 +1356,8 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bitmask",
- "frame-metadata",
- "frame-support-procedural",
+ "frame-metadata 11.0.0-rc5",
+ "frame-support-procedural 2.0.0-rc5",
  "impl-trait-for-tuples",
  "log",
  "once_cell",
@@ -1327,14 +1365,39 @@ dependencies = [
  "paste",
  "serde",
  "smallvec 1.4.1",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-tracing",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-tracing 2.0.0-rc5",
+]
+
+[[package]]
+name = "frame-support"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "bitmask",
+ "frame-metadata 11.0.0-rc6",
+ "frame-support-procedural 2.0.0-rc6",
+ "impl-trait-for-tuples",
+ "log",
+ "once_cell",
+ "parity-scale-codec",
+ "paste",
+ "serde",
+ "smallvec 1.4.1",
+ "sp-arithmetic 2.0.0-rc6",
+ "sp-core 2.0.0-rc6",
+ "sp-inherents 2.0.0-rc6",
+ "sp-io 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-state-machine 0.8.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-tracing 2.0.0-rc6",
 ]
 
 [[package]]
@@ -1342,7 +1405,18 @@ name = "frame-support-procedural"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 2.0.0-rc5",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "frame-support-procedural-tools 2.0.0-rc6",
  "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.38",
@@ -1353,7 +1427,19 @@ name = "frame-support-procedural-tools"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 2.0.0-rc5",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "frame-support-procedural-tools-derive 2.0.0-rc6",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
@@ -1371,19 +1457,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-support-procedural-tools-derive"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
 name = "frame-system"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc5",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
+]
+
+[[package]]
+name = "frame-system"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "frame-support 2.0.0-rc6",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc6",
+ "sp-io 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-version 2.0.0-rc6",
 ]
 
 [[package]]
@@ -1392,7 +1504,7 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3080,8 +3192,8 @@ dependencies = [
 name = "node-rpc"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -3094,20 +3206,20 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-primitives",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-rpc",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "node-rpc-runtime-api"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-compliance-manager",
  "pallet-identity",
  "pallet-pips",
@@ -3117,9 +3229,9 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3288,8 +3400,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec 0.5.1",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "hex-literal 0.2.1",
  "libsecp256k1",
  "pallet-balances 0.1.0",
@@ -3298,7 +3410,7 @@ dependencies = [
  "pallet-portfolio",
  "pallet-session",
  "pallet-statistics",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
@@ -3306,13 +3418,13 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3320,15 +3432,15 @@ name = "pallet-authority-discovery"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-authority-discovery",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3336,14 +3448,14 @@ name = "pallet-authorship"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-authorship",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3352,32 +3464,32 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-authorship",
  "pallet-session",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-consensus-babe",
  "sp-consensus-vrf",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-staking",
- "sp-std",
- "sp-timestamp",
+ "sp-std 2.0.0-rc5",
+ "sp-timestamp 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
- "pallet-timestamp",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
+ "pallet-timestamp 2.0.0-rc5",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polymesh-common-utilities",
@@ -3385,12 +3497,12 @@ dependencies = [
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
  "substrate-test-runtime-client",
 ]
 
@@ -3400,55 +3512,55 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-basic-sto"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-asset",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "pallet-settlement",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-serializer",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-serializer 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-cdd-offchain-worker"
 version = "2.0.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-staking",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3456,43 +3568,43 @@ name = "pallet-committee"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-compliance-manager"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3502,23 +3614,23 @@ dependencies = [
  "bulletproofs",
  "cryptography",
  "curve25519-dalek 2.1.0",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3527,18 +3639,18 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "bitflags",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-contracts-primitives",
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "pwasm-utils",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-sandbox",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "wasmi-validation",
 ]
 
@@ -3548,8 +3660,8 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3564,11 +3676,11 @@ dependencies = [
  "pallet-contracts-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3578,9 +3690,9 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3588,15 +3700,15 @@ name = "pallet-finality-tracker"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
  "sp-finality-tracker",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3605,41 +3717,41 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-authorship",
  "pallet-finality-tracker",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-group"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3653,10 +3765,10 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-primitives",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
  "substrate-test-runtime-client",
 ]
 
@@ -3669,9 +3781,9 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3679,21 +3791,21 @@ name = "pallet-identity"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-balances 0.1.0",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
  "substrate-test-runtime-client",
 ]
 
@@ -3702,18 +3814,18 @@ name = "pallet-im-online"
 version = "2.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3721,32 +3833,32 @@ name = "pallet-indices"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-keyring",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3754,26 +3866,26 @@ name = "pallet-offences"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-balances 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-pips"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-balances 0.1.0",
  "pallet-group",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "pallet-treasury",
  "parity-scale-codec",
  "polymesh-common-utilities",
@@ -3781,45 +3893,45 @@ dependencies = [
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-portfolio"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-arithmetic",
- "sp-std",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-protocol-fee"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-identity",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3833,22 +3945,22 @@ dependencies = [
  "parity-scale-codec",
  "polymesh-common-utilities",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-protocol-fee-rpc-runtime-api"
 version = "0.1.0"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "serde",
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3856,12 +3968,12 @@ name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "safe-mix",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -3869,43 +3981,43 @@ name = "pallet-session"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "impl-trait-for-tuples",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-staking",
- "sp-std",
- "sp-trie",
+ "sp-std 2.0.0-rc5",
+ "sp-trie 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-settlement"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc6",
+ "frame-system 2.0.0-rc6",
  "pallet-balances 0.1.0",
  "pallet-identity",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc6",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-serializer",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc6",
+ "sp-core 2.0.0-rc6",
+ "sp-io 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-serializer 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-version 2.0.0-rc6",
 ]
 
 [[package]]
@@ -3913,8 +4025,8 @@ name = "pallet-staking"
 version = "2.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-authorship",
  "pallet-babe",
  "pallet-identity",
@@ -3924,13 +4036,13 @@ dependencies = [
  "polymesh-primitives",
  "rand_chacha 0.2.2",
  "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "static_assertions",
 ]
 
@@ -3941,7 +4053,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "syn 1.0.38",
 ]
 
@@ -3955,41 +4067,41 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-staking-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc5",
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-statistics"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "lazy_static",
  "pallet-session",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
  "substrate-test-runtime-client",
 ]
 
@@ -3998,13 +4110,13 @@ name = "pallet-sudo"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -4013,39 +4125,54 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-timestamp 2.0.0-rc5",
+]
+
+[[package]]
+name = "pallet-timestamp"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "frame-support 2.0.0-rc6",
+ "frame-system 2.0.0-rc6",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-inherents 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-timestamp 2.0.0-rc6",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
  "serde_json",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-balances 0.1.0",
  "pallet-identity",
  "parity-scale-codec",
@@ -4053,28 +4180,28 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -4434,27 +4561,29 @@ dependencies = [
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
+ "sc-client-db",
  "sc-consensus",
  "sc-consensus-babe",
  "sc-executor",
  "sc-finality-grandpa",
+ "sc-light",
  "sc-network",
  "sc-rpc",
  "sc-service",
  "sc-telemetry",
  "sc-transaction-pool",
  "serde_json",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-finality-grandpa",
- "sp-inherents",
+ "sp-inherents 2.0.0-rc5",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-transaction-pool",
  "structopt",
@@ -4466,22 +4595,22 @@ dependencies = [
 name = "polymesh-common-utilities"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "lazy_static",
  "pallet-session",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "serde",
  "serde_derive",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
  "substrate-test-runtime-client",
 ]
 
@@ -4505,12 +4634,12 @@ dependencies = [
  "sc-finality-grandpa-rpc",
  "sc-keystore",
  "sc-rpc",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
  "substrate-frame-rpc-system",
 ]
@@ -4522,20 +4651,20 @@ dependencies = [
  "blake2",
  "cryptography",
  "curve25519-dalek 2.1.0",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "hex",
  "parity-scale-codec",
  "polymesh-primitives-derive",
  "schnorrkel",
  "serde",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -4551,8 +4680,8 @@ name = "polymesh-runtime-common"
 version = "1.0.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "pallet-asset",
  "pallet-authorship",
  "pallet-balances 0.1.0",
@@ -4562,17 +4691,17 @@ dependencies = [
  "pallet-identity",
  "pallet-multisig",
  "pallet-portfolio",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
  "rand 0.7.3",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -4581,8 +4710,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "frame-system-rpc-runtime-api",
  "node-rpc-runtime-api",
  "pallet-asset",
@@ -4618,7 +4747,7 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "pallet-statistics",
  "pallet-sudo",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4628,21 +4757,21 @@ dependencies = [
  "polymesh-runtime-common",
  "serde",
  "smallvec 1.4.1",
- "sp-api",
- "sp-arithmetic",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "substrate-wasm-builder-runner",
 ]
 
@@ -4652,8 +4781,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "frame-system-rpc-runtime-api",
  "hex-literal 0.2.1",
  "ink_primitives",
@@ -4693,7 +4822,7 @@ dependencies = [
  "pallet-staking-rpc-runtime-api",
  "pallet-statistics",
  "pallet-sudo",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4707,21 +4836,21 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec 1.4.1",
- "sp-api",
- "sp-arithmetic",
+ "sp-api 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
 ]
@@ -4734,8 +4863,8 @@ dependencies = [
  "cryptography",
  "env_logger",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "hex-literal 0.3.1",
  "ink_primitives",
  "lazy_static",
@@ -4763,7 +4892,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-statistics",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-utility",
@@ -4777,13 +4906,13 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "smallvec 1.4.1",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "substrate-test-runtime-client",
  "substrate-test-utils",
 ]
@@ -5497,11 +5626,11 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "serde_json",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "substrate-prometheus-endpoint",
 ]
 
@@ -5518,12 +5647,12 @@ dependencies = [
  "sc-client-api",
  "sc-proposer-metrics",
  "sc-telemetry",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "tokio-executor 0.2.0-alpha.6",
@@ -5536,14 +5665,14 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
 ]
 
 [[package]]
@@ -5558,8 +5687,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -5601,13 +5730,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-keyring",
- "sp-panic-handler",
- "sp-runtime",
- "sp-state-machine",
+ "sp-panic-handler 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
@@ -5631,22 +5760,22 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor",
  "sc-telemetry",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-database",
- "sp-externalities",
- "sp-inherents",
+ "sp-externalities 0.8.0-rc5",
+ "sp-inherents 2.0.0-rc5",
  "sp-keyring",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-storage",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-storage 2.0.0-rc5",
  "sp-transaction-pool",
- "sp-trie",
+ "sp-trie 2.0.0-rc5",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "substrate-prometheus-endpoint",
 ]
 
@@ -5671,11 +5800,11 @@ dependencies = [
  "sc-state-db",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-trie 2.0.0-rc5",
  "substrate-prometheus-endpoint",
 ]
 
@@ -5687,7 +5816,7 @@ dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -5716,19 +5845,19 @@ dependencies = [
  "sc-telemetry",
  "schnorrkel",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-vrf",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-timestamp",
- "sp-version",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-timestamp 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
  "substrate-prometheus-endpoint",
 ]
 
@@ -5747,13 +5876,13 @@ dependencies = [
  "sc-keystore",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -5766,7 +5895,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -5781,15 +5910,15 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
 ]
 
 [[package]]
@@ -5801,9 +5930,9 @@ dependencies = [
  "sc-client-api",
  "sp-authorship",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -5820,16 +5949,16 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor-common",
  "sc-executor-wasmi",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-panic-handler",
- "sp-runtime-interface",
- "sp-serializer",
- "sp-trie",
- "sp-version",
- "sp-wasm-interface",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-panic-handler 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-serializer 2.0.0-rc5",
+ "sp-trie 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
  "wasmi",
 ]
 
@@ -5843,10 +5972,10 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-serializer",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-serializer 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
  "wasmi",
 ]
 
@@ -5859,9 +5988,9 @@ dependencies = [
  "parity-scale-codec",
  "sc-executor-common",
  "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
  "wasmi",
 ]
 
@@ -5889,16 +6018,16 @@ dependencies = [
  "sc-network-gossip",
  "sc-telemetry",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-finality-grandpa",
  "sp-finality-tracker",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-utils",
  "substrate-prometheus-endpoint",
 ]
@@ -5932,7 +6061,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -5949,8 +6078,8 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
  "subtle 2.2.3",
 ]
 
@@ -5965,12 +6094,12 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-executor",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
 ]
 
 [[package]]
@@ -6011,11 +6140,11 @@ dependencies = [
  "slog",
  "slog_derive",
  "smallvec 0.6.13",
- "sp-arithmetic",
+ "sp-arithmetic 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -6036,7 +6165,7 @@ dependencies = [
  "log",
  "lru",
  "sc-network",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "wasm-timer",
 ]
 
@@ -6059,10 +6188,10 @@ dependencies = [
  "sc-client-api",
  "sc-keystore",
  "sc-network",
- "sp-api",
- "sp-core",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-utils",
  "threadpool",
 ]
@@ -6107,18 +6236,18 @@ dependencies = [
  "sc-keystore",
  "sc-rpc-api",
  "serde_json",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
  "sp-chain-spec",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.8.0-rc5",
  "sp-transaction-pool",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6138,11 +6267,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6158,7 +6287,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6201,21 +6330,21 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.8.0-rc5",
  "sp-transaction-pool",
- "sp-trie",
+ "sp-trie 2.0.0-rc5",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "substrate-prometheus-endpoint",
  "sysinfo",
  "tempfile",
@@ -6234,7 +6363,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "sc-client-api",
- "sp-core",
+ "sp-core 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6271,7 +6400,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-tracing",
+ "sp-tracing 2.0.0-rc5",
  "tracing-core",
 ]
 
@@ -6289,8 +6418,8 @@ dependencies = [
  "retain_mut",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -6311,11 +6440,11 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-transaction-graph",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "sp-tracing",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-tracing 2.0.0-rc5",
  "sp-transaction-pool",
  "sp-utils",
  "substrate-prometheus-endpoint",
@@ -6682,9 +6811,9 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "derive_more",
  "log",
- "sp-core",
- "sp-std",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6694,12 +6823,27 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "hash-db",
  "parity-scale-codec",
- "sp-api-proc-macro",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-version",
+ "sp-api-proc-macro 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-api"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "hash-db",
+ "parity-scale-codec",
+ "sp-api-proc-macro 2.0.0-rc6",
+ "sp-core 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-state-machine 0.8.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-version 2.0.0-rc6",
 ]
 
 [[package]]
@@ -6715,15 +6859,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-api-proc-macro"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "blake2-rfc",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc6",
+ "sp-io 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -6735,8 +6903,21 @@ dependencies = [
  "num-traits 0.2.12",
  "parity-scale-codec",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "integer-sqrt",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "serde",
+ "sp-debug-derive 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -6745,10 +6926,10 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6757,9 +6938,9 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6768,10 +6949,10 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6787,8 +6968,8 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
 ]
 
 [[package]]
@@ -6813,14 +6994,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-trie 2.0.0-rc5",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc5",
  "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
@@ -6831,12 +7012,12 @@ version = "0.8.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-application-crypto",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-timestamp 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6846,16 +7027,16 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "merlin",
  "parity-scale-codec",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-vrf",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-timestamp 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6864,7 +7045,7 @@ version = "0.8.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6874,9 +7055,9 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6909,11 +7090,55 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2 0.8.2",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
+ "sp-debug-derive 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-storage 2.0.0-rc5",
+ "substrate-bip39",
+ "tiny-bip39",
+ "tiny-keccak",
+ "twox-hash",
+ "wasmi",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "base58",
+ "blake2-rfc",
+ "byteorder",
+ "derive_more",
+ "dyn-clonable",
+ "ed25519-dalek",
+ "futures 0.3.5",
+ "hash-db",
+ "hash256-std-hasher",
+ "hex",
+ "impl-serde 0.3.1",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "primitive-types",
+ "rand 0.7.3",
+ "regex",
+ "schnorrkel",
+ "secrecy",
+ "serde",
+ "sha2 0.8.2",
+ "sp-debug-derive 2.0.0-rc6",
+ "sp-externalities 0.8.0-rc6",
+ "sp-runtime-interface 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-storage 2.0.0-rc6",
  "substrate-bip39",
  "tiny-bip39",
  "tiny-keccak",
@@ -6942,14 +7167,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-debug-derive"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
 name = "sp-externalities"
 version = "0.8.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
- "sp-storage",
+ "sp-std 2.0.0-rc5",
+ "sp-storage 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std 2.0.0-rc6",
+ "sp-storage 2.0.0-rc6",
 ]
 
 [[package]]
@@ -6961,11 +7207,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6974,8 +7220,8 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents",
- "sp-std",
+ "sp-inherents 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -6986,8 +7232,20 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -7001,14 +7259,35 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-state-machine",
- "sp-std",
- "sp-tracing",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-tracing 2.0.0-rc5",
+ "sp-trie 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-io"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "futures 0.3.5",
+ "hash-db",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0-rc6",
+ "sp-externalities 0.8.0-rc6",
+ "sp-runtime-interface 2.0.0-rc6",
+ "sp-state-machine 0.8.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-tracing 2.0.0-rc6",
+ "sp-trie 2.0.0-rc6",
+ "sp-wasm-interface 2.0.0-rc6",
 ]
 
 [[package]]
@@ -7017,8 +7296,8 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "lazy_static",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "strum",
 ]
 
@@ -7029,9 +7308,9 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-arithmetic",
+ "sp-arithmetic 2.0.0-rc5",
  "sp-npos-elections-compact",
- "sp-std",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7050,9 +7329,9 @@ name = "sp-offchain"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7065,12 +7344,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-panic-handler"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
 name = "sp-rpc"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "serde",
- "sp-core",
+ "sp-core 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7087,12 +7375,34 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-std",
+ "sp-application-crypto 2.0.0-rc5",
+ "sp-arithmetic 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "paste",
+ "rand 0.7.3",
+ "serde",
+ "sp-application-crypto 2.0.0-rc6",
+ "sp-arithmetic 2.0.0-rc6",
+ "sp-core 2.0.0-rc6",
+ "sp-inherents 2.0.0-rc6",
+ "sp-io 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -7102,11 +7412,27 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-externalities 0.8.0-rc5",
+ "sp-runtime-interface-proc-macro 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-tracing 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.8.0-rc6",
+ "sp-runtime-interface-proc-macro 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
+ "sp-storage 2.0.0-rc6",
+ "sp-tracing 2.0.0-rc6",
+ "sp-wasm-interface 2.0.0-rc6",
  "static_assertions",
 ]
 
@@ -7123,15 +7449,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-core",
- "sp-io",
- "sp-std",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "sp-wasm-interface 2.0.0-rc5",
  "wasmi",
 ]
 
@@ -7145,16 +7483,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-serializer"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sp-session"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 2.0.0-rc5",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7163,8 +7510,8 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7180,10 +7527,31 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "smallvec 1.4.1",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie",
+ "sp-core 2.0.0-rc5",
+ "sp-externalities 0.8.0-rc5",
+ "sp-panic-handler 2.0.0-rc5",
+ "sp-trie 2.0.0-rc5",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.8.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "hash-db",
+ "itertools 0.9.0",
+ "log",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "smallvec 1.4.1",
+ "sp-core 2.0.0-rc6",
+ "sp-externalities 0.8.0-rc6",
+ "sp-panic-handler 2.0.0-rc6",
+ "sp-trie 2.0.0-rc6",
  "trie-db",
  "trie-root",
 ]
@@ -7194,6 +7562,11 @@ version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
 
 [[package]]
+name = "sp-std"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+
+[[package]]
 name = "sp-storage"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
@@ -7201,8 +7574,21 @@ dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-storage"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "impl-serde 0.2.3",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -7212,17 +7598,40 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-api 2.0.0-rc5",
+ "sp-inherents 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
  "wasm-timer",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-api 2.0.0-rc6",
+ "sp-inherents 2.0.0-rc6",
+ "sp-runtime 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc5"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e45a704d1e2852e38ad669687ef02f68b"
+dependencies = [
+ "log",
+ "rental",
+ "tracing",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 dependencies = [
  "log",
  "rental",
@@ -7239,9 +7648,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc5",
 ]
 
 [[package]]
@@ -7252,8 +7661,22 @@ dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec",
+ "sp-core 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
  "trie-db",
  "trie-root",
 ]
@@ -7278,8 +7701,20 @@ dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc5",
+ "sp-std 2.0.0-rc5",
+]
+
+[[package]]
+name = "sp-version"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "impl-serde 0.2.3",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime 2.0.0-rc6",
+ "sp-std 2.0.0-rc6",
 ]
 
 [[package]]
@@ -7289,7 +7724,18 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 2.0.0-rc5",
+ "wasmi",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "2.0.0-rc6"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-std 2.0.0-rc6",
  "wasmi",
 ]
 
@@ -7416,11 +7862,11 @@ dependencies = [
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "sp-transaction-pool",
 ]
 
@@ -7458,10 +7904,10 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-keyring",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 2.0.0-rc5",
+ "sp-state-machine 0.8.0-rc5",
 ]
 
 [[package]]
@@ -7471,35 +7917,35 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc5+2#1502626e4
 dependencies = [
  "cfg-if",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc5",
+ "frame-system 2.0.0-rc5",
  "frame-system-rpc-runtime-api",
  "log",
  "memory-db",
  "pallet-babe",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0-rc5",
  "parity-scale-codec",
  "parity-util-mem",
  "sc-service",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 2.0.0-rc5",
+ "sp-application-crypto 2.0.0-rc5",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-babe",
- "sp-core",
+ "sp-core 2.0.0-rc5",
  "sp-finality-grandpa",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 2.0.0-rc5",
+ "sp-io 2.0.0-rc5",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-runtime 2.0.0-rc5",
+ "sp-runtime-interface 2.0.0-rc5",
  "sp-session",
- "sp-std",
+ "sp-std 2.0.0-rc5",
  "sp-transaction-pool",
- "sp-trie",
- "sp-version",
+ "sp-trie 2.0.0-rc5",
+ "sp-version 2.0.0-rc5",
  "substrate-wasm-builder-runner",
  "trie-db",
 ]
@@ -7516,11 +7962,11 @@ dependencies = [
  "sc-consensus",
  "sc-light",
  "sc-service",
- "sp-api",
+ "sp-api 2.0.0-rc5",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc5",
+ "sp-runtime 2.0.0-rc5",
  "substrate-test-client",
  "substrate-test-runtime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,13 @@ im-online = { package = "pallet-im-online", path = "pallets/im-online" }
 node-rpc = { path = "rpc" }
 node-rpc-runtime-api = { path = "rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { path = "pallets/protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 pallet-staking-rpc-runtime-api = { path = "pallets/staking/rpc/runtime-api" }
 pallet-protocol-fee-rpc = { path = "pallets/protocol-fee/rpc" }
 pallet-group-rpc = { path = "pallets/group/rpc" }
 pallet-group-rpc-runtime-api = { path = "pallets/group/rpc/runtime-api", default-features = false }
 polymesh-node-rpc = { path = "node-rpc" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
 # Runtimes
 polymesh-runtime-develop = { path = "pallets/runtime/develop" }
@@ -79,51 +79,52 @@ polymesh-runtime-testnet = { path = "pallets/runtime/testnet" }
 ed25519-dalek = "1.0.0"
 log = "0.4.8"
 futures = "0.3.4"
-jsonrpc-core = "14.0.5"
+jsonrpc-core = "14.2.0"
+jsonrpc-pubsub = "14.2.0"
 serde_json = '1.0.48'
 structopt = "0.3.15"
 chrono = "0.4.11"
 
 # Substrate
 codec = { version = "1.2.0", package = "parity-scale-codec" }
-sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-transaction-pool = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-transaction-pool = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-contracts = { package = "pallet-contracts", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+contracts = { package = "pallet-contracts", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-sc-service = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-executor = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-network = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-service = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-executor = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-network = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-sc-light = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-light = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
 [build-dependencies]
 vergen = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,20 +63,20 @@ im-online = { package = "pallet-im-online", path = "pallets/im-online" }
 node-rpc = { path = "rpc" }
 node-rpc-runtime-api = { path = "rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { path = "pallets/protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 pallet-staking-rpc-runtime-api = { path = "pallets/staking/rpc/runtime-api" }
 pallet-protocol-fee-rpc = { path = "pallets/protocol-fee/rpc" }
 pallet-group-rpc = { path = "pallets/group/rpc" }
 pallet-group-rpc-runtime-api = { path = "pallets/group/rpc/runtime-api", default-features = false }
 polymesh-node-rpc = { path = "node-rpc" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
 # Runtimes
 polymesh-runtime-develop = { path = "pallets/runtime/develop" }
 polymesh-runtime-testnet = { path = "pallets/runtime/testnet" }
 
 # General
-ed25519-dalek = "=1.0.0-pre.3"
+ed25519-dalek = "1.0.0"
 log = "0.4.8"
 futures = "0.3.4"
 jsonrpc-core = "14.0.5"
@@ -86,41 +86,41 @@ chrono = "0.4.11"
 
 # Substrate
 codec = { version = "1.2.0", package = "parity-scale-codec" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-transaction-pool = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-transaction-pool = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
-contracts = { package = "pallet-contracts", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+contracts = { package = "pallet-contracts", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+sc-service = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-executor = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-network = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
 [build-dependencies]
 vergen = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,9 @@ grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytec
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 sc-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
+sc-light = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }

--- a/contracts/examples/custom-ink-env-types/Cargo.toml
+++ b/contracts/examples/custom-ink-env-types/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 [dependencies]
 ink_core = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", package = "ink_core", default-features = false }
 ink_prelude = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", package = "ink_prelude", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime", branch = "at-add-dispatch-call", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime", tag = "v2.0.0-rc5+2", default-features = false }
 scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 polymesh-derive = { path = "../../../primitives_derive", default-features = false, package = "polymesh-primitives-derive"}
 scale-info = { version = "0.3", default-features = false, features = ["derive"], optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-sp-io = { git = "https://github.com/paritytech/substrate/", package = "sp-io", branch = "at-add-dispatch-call", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-io = { git = "https://github.com/paritytech/substrate/", package = "sp-io", tag = "v2.0.0-rc5+2", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 
 [dependencies.type-metadata]
 git = "https://github.com/type-metadata/type-metadata.git"

--- a/contracts/examples/custom-ink-env-types/Cargo.toml
+++ b/contracts/examples/custom-ink-env-types/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 [dependencies]
 ink_core = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", package = "ink_core", default-features = false }
 ink_prelude = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", package = "ink_prelude", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime", tag = "v2.0.0-rc5+2", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime", tag = "v2.0.0-rc6", default-features = false }
 scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 polymesh-derive = { path = "../../../primitives_derive", default-features = false, package = "polymesh-primitives-derive"}
 scale-info = { version = "0.3", default-features = false, features = ["derive"], optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-sp-io = { git = "https://github.com/paritytech/substrate/", package = "sp-io", tag = "v2.0.0-rc5+2", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-io = { git = "https://github.com/paritytech/substrate/", package = "sp-io", tag = "v2.0.0-rc6", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 
 [dependencies.type-metadata]
 git = "https://github.com/type-metadata/type-metadata.git"

--- a/node-rpc/Cargo.toml
+++ b/node-rpc/Cargo.toml
@@ -11,30 +11,31 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 polymesh-primitives = { path = "../primitives" }
-pallet-contracts-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+pallet-contracts-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 pallet-group-rpc = { path = "../pallets/group/rpc" }
 pallet-staking-rpc = { path = "../pallets/staking/rpc" }
 pallet-protocol-fee-rpc = {  path = "../pallets/protocol-fee/rpc" }
 node-rpc = { path = "../rpc" }
 
 jsonrpc-core = "14.2.0"
+jsonrpc-pubsub = "14.2.0"
 
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2"  }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6"  }

--- a/node-rpc/Cargo.toml
+++ b/node-rpc/Cargo.toml
@@ -11,7 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 polymesh-primitives = { path = "../primitives" }
-pallet-contracts-rpc = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+pallet-contracts-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 pallet-group-rpc = { path = "../pallets/group/rpc" }
 pallet-staking-rpc = { path = "../pallets/staking/rpc" }
 pallet-protocol-fee-rpc = {  path = "../pallets/protocol-fee/rpc" }
@@ -20,21 +20,21 @@ node-rpc = { path = "../rpc" }
 jsonrpc-core = "14.2.0"
 
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+txpool-api = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-consensus-babe = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-consensus-babe-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-consensus-epochs = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sc-keystore = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call"  }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2"  }

--- a/node-rpc/src/lib.rs
+++ b/node-rpc/src/lib.rs
@@ -77,6 +77,10 @@ pub struct GrandpaDeps {
     pub shared_voter_state: sc_finality_grandpa::SharedVoterState,
     /// Authority set info.
     pub shared_authority_set: sc_finality_grandpa::SharedAuthoritySet<Hash, BlockNumber>,
+    /// Receives notifications about justification events from Grandpa.
+    pub justification_stream: sc_finality_grandpa::GrandpaJustificationStream<Block>,
+    /// Subscription manager to keep track of pubsub subscribers.
+    pub subscriptions: jsonrpc_pubsub::manager::SubscriptionManager,
 }
 
 /// Full client dependencies
@@ -158,6 +162,8 @@ where
     let GrandpaDeps {
         shared_voter_state,
         shared_authority_set,
+        justification_stream,
+        subscriptions,
     } = grandpa;
 
     io.extend_with(SystemApi::to_delegate(FullSystem::new(
@@ -182,6 +188,8 @@ where
     io.extend_with(GrandpaApi::to_delegate(GrandpaRpcHandler::new(
         shared_authority_set,
         shared_voter_state,
+        justification_stream,
+        subscriptions,
     )));
     io.extend_with(StakingApi::to_delegate(Staking::new(client.clone())));
     io.extend_with(PipsApi::to_delegate(Pips::new(client.clone())));

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -12,7 +12,7 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 
 # Our Pallets
 pallet-balances = { path = "../balances", default-features = false  }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-portfolio = { path = "../portfolio", default-features = false }
 pallet-statistics = { path = "../statistics", default-features = false }
@@ -26,21 +26,21 @@ arrayvec = { version = "0.5.1", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = ["hmac"] }
 
 # Only in STD
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [features]
 equalize = []

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -12,7 +12,7 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 
 # Our Pallets
 pallet-balances = { path = "../balances", default-features = false  }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-portfolio = { path = "../portfolio", default-features = false }
 pallet-statistics = { path = "../statistics", default-features = false }
@@ -26,21 +26,21 @@ arrayvec = { version = "0.5.1", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = ["hmac"] }
 
 # Only in STD
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [features]
 equalize = []

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -95,7 +95,7 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 use hex_literal::hex;
-use pallet_contracts::{ExecReturnValue, Gas};
+use pallet_contracts::{ExecResult, Gas};
 use pallet_identity as identity;
 use pallet_statistics::{self as statistics, Counter};
 use polymesh_common_utilities::{
@@ -1843,7 +1843,7 @@ impl<T: Trait> Module<T> {
         _value: T::Balance,
         gas_limit: Gas,
         data: Vec<u8>,
-    ) -> (Result<ExecReturnValue, DispatchError>, Gas) {
+    ) -> (ExecResult, Gas) {
         // TODO: Fix the value conversion into Currency
         <pallet_contracts::Module<T>>::bare_call(from, dest, 0.into(), gas_limit, data)
     }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -93,7 +93,7 @@ use frame_support::{
     traits::{Currency, Get},
     weights::Weight,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use hex_literal::hex;
 use pallet_contracts::{ExecReturnValue, Gas};
 use pallet_identity as identity;
@@ -1816,11 +1816,14 @@ impl<T: Trait> Module<T> {
         // native currency value should be `0` as no funds need to transfer to the smart extension
         // We are passing arbitrary high `gas_limit` value to make sure extension's function execute successfully
         // TODO: Once gas estimate function will be introduced, arbitrary gas value will be replaced by the estimated gas
-        let is_allowed =
+        // TODO(centril): what to do with `_gas_spent`?
+        let (res, _gas_spent) =
             Self::call_extension(extension_caller, dest, 0.into(), GAS_LIMIT, encoded_data);
-        if is_allowed.is_success() {
-            if let Ok(allowed) = RestrictionResult::decode(&mut &is_allowed.data[..]) {
-                return allowed;
+        if let Ok(is_allowed) = res {
+            if is_allowed.is_success() {
+                if let Ok(allowed) = RestrictionResult::decode(&mut &is_allowed.data[..]) {
+                    return allowed;
+                }
             }
         }
         RestrictionResult::Invalid
@@ -1840,19 +1843,9 @@ impl<T: Trait> Module<T> {
         _value: T::Balance,
         gas_limit: Gas,
         data: Vec<u8>,
-    ) -> ExecReturnValue {
+    ) -> (Result<ExecReturnValue, DispatchError>, Gas) {
         // TODO: Fix the value conversion into Currency
-        match <pallet_contracts::Module<T>>::bare_call(from, dest, 0.into(), gas_limit, data) {
-            Ok(encoded_value) => encoded_value,
-            Err(err) => {
-                let reason: &'static str = err.reason.into();
-                // status 0 is used for extension call successfully executed
-                ExecReturnValue {
-                    status: 1,
-                    data: reason.as_bytes().to_vec(),
-                }
-            }
-        }
+        <pallet_contracts::Module<T>>::bare_call(from, dest, 0.into(), gas_limit, data)
     }
 
     /// RPC: Function allows external users to know wether the transfer extrinsic

--- a/pallets/balances/Cargo.toml
+++ b/pallets/balances/Cargo.toml
@@ -14,20 +14,20 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false}
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-sp-std = {  git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-std = {  git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false,  branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
 
 # Only for test in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true}
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true}
 
 [features]
 equalize = []

--- a/pallets/balances/Cargo.toml
+++ b/pallets/balances/Cargo.toml
@@ -14,20 +14,20 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false}
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-sp-std = {  git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+sp-std = {  git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false,  tag = "v2.0.0-rc6" }
 
 # Only for test in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true}
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true}
 
 [features]
 equalize = []

--- a/pallets/basic-sto/Cargo.toml
+++ b/pallets/basic-sto/Cargo.toml
@@ -17,17 +17,17 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false  }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
 
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/basic-sto/Cargo.toml
+++ b/pallets/basic-sto/Cargo.toml
@@ -17,17 +17,17 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false  }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
 
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/basic-sto/src/lib.rs
+++ b/pallets/basic-sto/src/lib.rs
@@ -11,7 +11,7 @@ use codec::{Decode, Encode};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_identity as identity;
 use pallet_settlement::{Leg, SettlementType};
 use polymesh_common_utilities::{

--- a/pallets/cdd-offchain-worker/Cargo.toml
+++ b/pallets/cdd-offchain-worker/Cargo.toml
@@ -11,15 +11,15 @@ pallet-staking = { path = "../staking", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 # 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
  
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/cdd-offchain-worker/Cargo.toml
+++ b/pallets/cdd-offchain-worker/Cargo.toml
@@ -11,15 +11,15 @@ pallet-staking = { path = "../staking", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 # 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
  
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/committee/Cargo.toml
+++ b/pallets/committee/Cargo.toml
@@ -15,18 +15,18 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6", optional = true }
 
 [features]
 equalize = []

--- a/pallets/committee/Cargo.toml
+++ b/pallets/committee/Cargo.toml
@@ -15,18 +15,18 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", optional = true }
 
 [features]
 equalize = []

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -98,7 +98,7 @@ pub trait Trait<I>: frame_system::Trait + IdentityModuleTrait {
 }
 
 /// Origin for the committee module.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
 pub enum RawOrigin<AccountId, I> {
     /// It has been condoned by M of N members of this committee.
     Members(MemberCount, MemberCount),

--- a/pallets/common/Cargo.toml
+++ b/pallets/common/Cargo.toml
@@ -15,21 +15,21 @@ serde_derive = { version = "1.0.112", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Only for test in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true}
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true}
 
 [dev-dependencies]
 lazy_static = { version = "1.4.0", default-features = false }

--- a/pallets/common/Cargo.toml
+++ b/pallets/common/Cargo.toml
@@ -15,21 +15,21 @@ serde_derive = { version = "1.0.112", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Only for test in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true}
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true}
 
 [dev-dependencies]
 lazy_static = { version = "1.4.0", default-features = false }

--- a/pallets/compliance-manager/Cargo.toml
+++ b/pallets/compliance-manager/Cargo.toml
@@ -19,17 +19,17 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 
 [features]

--- a/pallets/compliance-manager/Cargo.toml
+++ b/pallets/compliance-manager/Cargo.toml
@@ -19,17 +19,17 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 
 [features]

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -84,7 +84,7 @@ use frame_support::{
     traits::Get,
     weights::Weight,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     asset::Trait as AssetTrait,

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -13,19 +13,19 @@ pallet-identity = { path = "../identity", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Crypto
 rand_core = { version = "0.5", default-features = false }

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -13,19 +13,19 @@ pallet-identity = { path = "../identity", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Crypto
 rand_core = { version = "0.5", default-features = false }

--- a/pallets/confidential/src/lib.rs
+++ b/pallets/confidential/src/lib.rs
@@ -31,7 +31,7 @@ use codec::{Decode, Encode};
 use frame_support::{
     debug, decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use sp_std::prelude::*;
 
 pub mod rng;

--- a/pallets/group/Cargo.toml
+++ b/pallets/group/Cargo.toml
@@ -16,16 +16,16 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 
 [features]

--- a/pallets/group/Cargo.toml
+++ b/pallets/group/Cargo.toml
@@ -16,16 +16,16 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 
 [features]

--- a/pallets/group/rpc/Cargo.toml
+++ b/pallets/group/rpc/Cargo.toml
@@ -21,10 +21,10 @@ jsonrpc-derive = "14.0.5"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
-sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-api = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
+sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-api = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
-substrate-test-runtime-client = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+substrate-test-runtime-client = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }

--- a/pallets/group/rpc/Cargo.toml
+++ b/pallets/group/rpc/Cargo.toml
@@ -21,10 +21,10 @@ jsonrpc-derive = "14.0.5"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
-sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-api = {git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-api = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
-substrate-test-runtime-client = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
+substrate-test-runtime-client = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }

--- a/pallets/group/rpc/runtime-api/Cargo.toml
+++ b/pallets/group/rpc/runtime-api/Cargo.toml
@@ -14,9 +14,9 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/pallets/group/rpc/runtime-api/Cargo.toml
+++ b/pallets/group/rpc/runtime-api/Cargo.toml
@@ -14,9 +14,9 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -89,7 +89,7 @@ use frame_support::{
     weights::{DispatchClass, Pays},
     StorageValue,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use sp_std::prelude::*;
 
 pub type Event<T, I> = polymesh_common_utilities::group::Event<T, I>;

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -15,20 +15,20 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Only in STD
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", default-features = false, optional = true  }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false, optional = true  }
 
 [features]
 equalize = []

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -15,20 +15,20 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Only in STD
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false, optional = true  }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", default-features = false, optional = true  }
 
 [features]
 equalize = []

--- a/pallets/im-online/Cargo.toml
+++ b/pallets/im-online/Cargo.toml
@@ -11,22 +11,22 @@ serde = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call", features = ["historical"] }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", features = ["historical"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Only in STD
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, tag = "v2.0.0-rc5+2", optional = true }
 [features]
 default = ["std", "pallet-session/historical"]
 no_std = []

--- a/pallets/im-online/Cargo.toml
+++ b/pallets/im-online/Cargo.toml
@@ -11,22 +11,22 @@ serde = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", features = ["historical"] }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6", features = ["historical"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Only in STD
-frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false, tag = "v2.0.0-rc6", optional = true }
 [features]
 default = ["std", "pallet-session/historical"]
 no_std = []

--- a/pallets/im-online/src/lib.rs
+++ b/pallets/im-online/src/lib.rs
@@ -87,8 +87,8 @@ use frame_support::{
     weights::{DispatchClass, Weight},
     Parameter,
 };
+use frame_system::ensure_none;
 use frame_system::offchain::{SendTransactionTypes, SubmitTransaction};
-use frame_system::{self as system, ensure_none};
 use pallet_session::historical::IdentificationTuple;
 use sp_application_crypto::RuntimeAppPublic;
 use sp_core::offchain::OpaqueNetworkState;

--- a/pallets/multisig/Cargo.toml
+++ b/pallets/multisig/Cargo.toml
@@ -16,14 +16,14 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/multisig/Cargo.toml
+++ b/pallets/multisig/Cargo.toml
@@ -16,14 +16,14 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -89,7 +89,7 @@ use frame_support::{
     weights::GetDispatchInfo,
     StorageDoubleMap, StorageValue,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     identity::Trait as IdentityTrait,

--- a/pallets/pips/Cargo.toml
+++ b/pallets/pips/Cargo.toml
@@ -20,17 +20,17 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/pips/Cargo.toml
+++ b/pallets/pips/Cargo.toml
@@ -20,17 +20,17 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/portfolio/Cargo.toml
+++ b/pallets/portfolio/Cargo.toml
@@ -18,10 +18,10 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/portfolio/Cargo.toml
+++ b/pallets/portfolio/Cargo.toml
@@ -18,10 +18,10 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -48,17 +48,12 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
     IterableStorageDoubleMap,
 };
-use frame_system::{self as system, ensure_signed};
-use pallet_identity as identity;
-use polymesh_common_utilities::{
-    identity::Trait as IdentityTrait, portfolio::PortfolioSubTrait, CommonTrait, Context,
-};
-use polymesh_primitives::{
-    AuthorizationData, AuthorizationError, IdentityId, PortfolioId, PortfolioKind, PortfolioName,
-    PortfolioNumber, Signatory, Ticker,
-};
-use sp_arithmetic::traits::{CheckedSub, Saturating};
+use frame_system::ensure_signed;
+use polymesh_common_utilities::{identity::Trait as IdentityTrait, CommonTrait, Context};
+use polymesh_primitives::{IdentityId, PortfolioId, PortfolioName, PortfolioNumber, Ticker};
+use sp_arithmetic::traits::Saturating;
 use sp_std::{convert::TryFrom, prelude::Vec};
+
 type Identity<T> = identity::Module<T>;
 
 /// The ticker and balance of an asset to be moved from one portfolio to another.

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -49,9 +49,15 @@ use frame_support::{
     IterableStorageDoubleMap,
 };
 use frame_system::ensure_signed;
-use polymesh_common_utilities::{identity::Trait as IdentityTrait, CommonTrait, Context};
-use polymesh_primitives::{IdentityId, PortfolioId, PortfolioName, PortfolioNumber, Ticker};
-use sp_arithmetic::traits::Saturating;
+use pallet_identity as identity;
+use polymesh_common_utilities::{
+    identity::Trait as IdentityTrait, portfolio::PortfolioSubTrait, CommonTrait, Context,
+};
+use polymesh_primitives::{
+    AuthorizationData, AuthorizationError, IdentityId, PortfolioId, PortfolioKind, PortfolioName,
+    PortfolioNumber, Signatory, Ticker,
+};
+use sp_arithmetic::traits::{CheckedSub, Saturating};
 use sp_std::{convert::TryFrom, prelude::Vec};
 
 type Identity<T> = identity::Module<T>;

--- a/pallets/protocol-fee/Cargo.toml
+++ b/pallets/protocol-fee/Cargo.toml
@@ -14,12 +14,12 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 default = ["std"]

--- a/pallets/protocol-fee/Cargo.toml
+++ b/pallets/protocol-fee/Cargo.toml
@@ -14,12 +14,12 @@ serde = { version = "1.0.104", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 default = ["std"]

--- a/pallets/protocol-fee/rpc/Cargo.toml
+++ b/pallets/protocol-fee/rpc/Cargo.toml
@@ -16,6 +16,6 @@ jsonrpc-derive = "14.0.5"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}

--- a/pallets/protocol-fee/rpc/Cargo.toml
+++ b/pallets/protocol-fee/rpc/Cargo.toml
@@ -16,6 +16,6 @@ jsonrpc-derive = "14.0.5"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}

--- a/pallets/protocol-fee/rpc/runtime-api/Cargo.toml
+++ b/pallets/protocol-fee/rpc/runtime-api/Cargo.toml
@@ -12,9 +12,9 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  branch = "at-add-dispatch-call"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc5+2"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 serde_json = "1.0.48"

--- a/pallets/protocol-fee/rpc/runtime-api/Cargo.toml
+++ b/pallets/protocol-fee/rpc/runtime-api/Cargo.toml
@@ -12,9 +12,9 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc5+2"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc6"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 serde_json = "1.0.48"

--- a/pallets/protocol-fee/src/lib.rs
+++ b/pallets/protocol-fee/src/lib.rs
@@ -41,7 +41,7 @@ use frame_support::{
     traits::{Currency, ExistenceRequirement, OnUnbalanced, WithdrawReason},
     weights::{DispatchClass, Pays},
 };
-use frame_system::{self as system, ensure_root};
+use frame_system::ensure_root;
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     identity::Trait as IdentityTrait,

--- a/pallets/runtime/common/Cargo.toml
+++ b/pallets/runtime/common/Cargo.toml
@@ -12,7 +12,7 @@ polymesh-primitives-derive = { path = "../../../primitives_derive", default-feat
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false  }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false  }
 pallet-multisig = { path = "../../multisig", default-features = false}
 pallet-portfolio = { path = "../../portfolio", default-features = false  }
@@ -26,17 +26,17 @@ rand = { version = "0.7.3", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [features]
 equalize = []

--- a/pallets/runtime/common/Cargo.toml
+++ b/pallets/runtime/common/Cargo.toml
@@ -12,7 +12,7 @@ polymesh-primitives-derive = { path = "../../../primitives_derive", default-feat
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false  }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false  }
 pallet-multisig = { path = "../../multisig", default-features = false}
 pallet-portfolio = { path = "../../portfolio", default-features = false  }
@@ -26,17 +26,17 @@ rand = { version = "0.7.3", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [features]
 equalize = []

--- a/pallets/runtime/common/src/dividend.rs
+++ b/pallets/runtime/common/src/dividend.rs
@@ -49,7 +49,7 @@
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_asset::{self as asset, BalanceOf, Trait as AssetTrait};
 use pallet_identity as identity;
 use polymesh_common_utilities::{

--- a/pallets/runtime/common/src/exemption.rs
+++ b/pallets/runtime/common/src/exemption.rs
@@ -16,7 +16,7 @@
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     asset::Trait as AssetTrait, balances::Trait as BalancesTrait,

--- a/pallets/runtime/common/src/sto_capped.rs
+++ b/pallets/runtime/common/src/sto_capped.rs
@@ -46,7 +46,7 @@ use frame_support::traits::Currency;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;
 use pallet_identity as identity;

--- a/pallets/runtime/common/src/voting.rs
+++ b/pallets/runtime/common/src/voting.rs
@@ -60,7 +60,7 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
     storage::StorageMap,
 };
-use frame_system::{self as system, ensure_signed};
+use frame_system::ensure_signed;
 use sp_std::{convert::TryFrom, prelude::*, vec};
 
 /// The module's configuration trait.

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -31,8 +31,8 @@ pallet-settlement = { path = "../../settlement", default-features = false }
 pallet-im-online = { path = "../../im-online", default-features = false }
 pallet-statistics = { path = "../../statistics", default-features = false }
 pallet-transaction-payment = { path = "../../transaction-payment", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 pallet-staking = { path = "../../staking", default-features = false }
 pallet-staking-reward-curve = { path = "../../staking/reward-curve", default-features = false }
 
@@ -42,51 +42,51 @@ smallvec = "1.4.0"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 #
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # RPC
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 pallet-staking-rpc-runtime-api = { path = "../../staking/rpc/runtime-api", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 
 # Benchmark
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
 
 [features]
 default = ["std", "equalize"]

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -31,8 +31,8 @@ pallet-settlement = { path = "../../settlement", default-features = false }
 pallet-im-online = { path = "../../im-online", default-features = false }
 pallet-statistics = { path = "../../statistics", default-features = false }
 pallet-transaction-payment = { path = "../../transaction-payment", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 pallet-staking = { path = "../../staking", default-features = false }
 pallet-staking-reward-curve = { path = "../../staking/reward-curve", default-features = false }
 
@@ -42,51 +42,51 @@ smallvec = "1.4.0"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 #
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # RPC
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 pallet-staking-rpc-runtime-api = { path = "../../staking/rpc/runtime-api", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 
 # Benchmark
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
 
 [features]
 default = ["std", "equalize"]

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -481,7 +481,6 @@ impl pallet_contracts::Trait for Runtime {
     type Time = Timestamp;
     type Randomness = RandomnessCollectiveFlip;
     type Currency = Balances;
-    //type Call = Call;
     type Event = Event;
     type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<Runtime>;
     type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Runtime>;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -766,7 +766,7 @@ construct_runtime!(
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         // Must be before session.
-        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent},
+        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent, ValidateUnsigned},
 
         Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
         Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -188,6 +188,7 @@ impl frame_system::Trait for Runtime {
     type OnKilledAccount = ();
     /// The data to be stored in an account.
     type AccountData = AccountData<Balance>;
+    type SystemWeightInfo = ();
 }
 
 parameter_types! {
@@ -199,6 +200,21 @@ impl pallet_babe::Trait for Runtime {
     type EpochDuration = EpochDuration;
     type ExpectedBlockTime = ExpectedBlockTime;
     type EpochChangeTrigger = pallet_babe::ExternalTrigger;
+
+    type KeyOwnerProofSystem = Historical;
+
+    type KeyOwnerProof = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::Proof;
+
+    type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::IdentificationTuple;
+
+    type HandleEquivocation =
+        pallet_babe::EquivocationHandler<Self::KeyOwnerIdentification, Offences>;
 }
 
 parameter_types! {
@@ -210,6 +226,7 @@ impl pallet_indices::Trait for Runtime {
     type Currency = Balances;
     type Deposit = IndexDeposit;
     type Event = Event;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -284,6 +301,7 @@ impl pallet_timestamp::Trait for Runtime {
     type Moment = Moment;
     type OnTimestampSet = Babe;
     type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -326,6 +344,7 @@ impl pallet_session::Trait for Runtime {
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Runtime {
@@ -462,7 +481,7 @@ impl pallet_contracts::Trait for Runtime {
     type Time = Timestamp;
     type Randomness = RandomnessCollectiveFlip;
     type Currency = Balances;
-    type Call = Call;
+    //type Call = Call;
     type Event = Event;
     type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<Runtime>;
     type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Runtime>;
@@ -507,7 +526,6 @@ where
             frame_system::CheckNonce::<Runtime>::from(nonce),
             frame_system::CheckWeight::<Runtime>::new(),
             pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
-            pallet_grandpa::ValidateEquivocationReport::<Runtime>::new(),
         );
         let raw_payload = SignedPayload::new(call, extra)
             .map_err(|e| {
@@ -564,6 +582,7 @@ impl pallet_offences::Trait for Runtime {
     type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
     type OnOffenceHandler = Staking;
     type WeightSoftLimit = OffencesWeightSoftLimit;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -596,12 +615,8 @@ impl pallet_grandpa::Trait for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
 
-    type HandleEquivocation = pallet_grandpa::EquivocationHandler<
-        Self::KeyOwnerIdentification,
-        polymesh_primitives::report::ReporterAppCrypto,
-        Runtime,
-        Offences,
-    >;
+    type HandleEquivocation =
+        pallet_grandpa::EquivocationHandler<Self::KeyOwnerIdentification, Offences>;
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}
@@ -752,7 +767,7 @@ construct_runtime!(
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         // Must be before session.
-        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent(Timestamp)},
+        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent},
 
         Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
         Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},
@@ -834,7 +849,6 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-    pallet_grandpa::ValidateEquivocationReport<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
@@ -914,7 +928,7 @@ impl_runtime_apis! {
             Grandpa::grandpa_authorities()
         }
 
-        fn submit_report_equivocation_extrinsic(
+        fn submit_report_equivocation_unsigned_extrinsic(
             equivocation_proof: fg_primitives::EquivocationProof<
                 <Block as BlockT>::Hash,
                 NumberFor<Block>,
@@ -923,7 +937,7 @@ impl_runtime_apis! {
         ) -> Option<()> {
             let key_owner_proof = key_owner_proof.decode()?;
 
-            Grandpa::submit_report_equivocation_extrinsic(
+            Grandpa::submit_unsigned_equivocation_report(
                 equivocation_proof,
                 key_owner_proof,
             )
@@ -961,6 +975,29 @@ impl_runtime_apis! {
         fn current_epoch_start() -> sp_consensus_babe::SlotNumber {
             Babe::current_epoch_start()
         }
+
+        fn generate_key_ownership_proof(
+            _slot_number: sp_consensus_babe::SlotNumber,
+            authority_id: sp_consensus_babe::AuthorityId,
+        ) -> Option<sp_consensus_babe::OpaqueKeyOwnershipProof> {
+            use codec::Encode;
+
+            Historical::prove((sp_consensus_babe::KEY_TYPE, authority_id))
+                .map(|p| p.encode())
+                .map(sp_consensus_babe::OpaqueKeyOwnershipProof::new)
+        }
+
+        fn submit_report_equivocation_unsigned_extrinsic(
+            equivocation_proof: sp_consensus_babe::EquivocationProof<<Block as BlockT>::Header>,
+            key_owner_proof: sp_consensus_babe::OpaqueKeyOwnershipProof,
+        ) -> Option<()> {
+            let key_owner_proof = key_owner_proof.decode()?;
+
+            Babe::submit_unsigned_equivocation_report(
+                equivocation_proof,
+                key_owner_proof,
+            )
+        }
     }
 
     impl sp_authority_discovery::AuthorityDiscoveryApi<Block> for Runtime {
@@ -985,12 +1022,13 @@ impl_runtime_apis! {
             gas_limit: u64,
             input_data: Vec<u8>,
         ) -> ContractExecResult {
-            let exec_result =
-                Contracts::bare_call(origin, dest, value, gas_limit, input_data);
+            let (exec_result, gas_consumed) =
+                Contracts::bare_call(origin, dest.into(), value, gas_limit, input_data);
             match exec_result {
                 Ok(v) => ContractExecResult::Success {
-                    status: v.status,
+                    flags: v.flags.bits(),
                     data: v.data,
+                    gas_consumed: gas_consumed,
                 },
                 Err(_) => ContractExecResult::Error,
             }

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -20,8 +20,8 @@ pallet-basic-sto = { path = "../../basic-sto", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
 pallet-confidential = { path = "../../confidential", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
+pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
 pallet-group = { path = "../../group", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false }
@@ -42,7 +42,7 @@ pallet-utility = { path = "../../utility", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-staking-rpc-runtime-api = { package = "pallet-staking-rpc-runtime-api", path = "../../staking/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runtime-api", path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 
 # Others
@@ -56,50 +56,50 @@ serde_derive = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 ink_primitives = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", default-features = false }
 hex-literal = "0.2.1"
 smallvec = "1.4.0"
 
 # Benchmark
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [dev-dependencies]
-test-client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+test-client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
 
 [features]
 equalize = []

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -20,8 +20,8 @@ pallet-basic-sto = { path = "../../basic-sto", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
 pallet-confidential = { path = "../../confidential", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+pallet-contracts = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
 pallet-group = { path = "../../group", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false }
@@ -42,7 +42,7 @@ pallet-utility = { path = "../../utility", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-staking-rpc-runtime-api = { package = "pallet-staking-rpc-runtime-api", path = "../../staking/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runtime-api", path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 
 # Others
@@ -56,50 +56,50 @@ serde_derive = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-consensus-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-executive = { package = "frame-executive", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-finality-tracker = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 ink_primitives = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", default-features = false }
 hex-literal = "0.2.1"
 smallvec = "1.4.0"
 
 # Benchmark
-frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [dev-dependencies]
-test-client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+test-client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
 
 [features]
 equalize = []

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -187,6 +187,7 @@ impl frame_system::Trait for Runtime {
     type OnKilledAccount = ();
     /// The data to be stored in an account.
     type AccountData = AccountData<Balance>;
+    type SystemWeightInfo = ();
 }
 
 parameter_types! {
@@ -198,6 +199,21 @@ impl pallet_babe::Trait for Runtime {
     type EpochDuration = EpochDuration;
     type ExpectedBlockTime = ExpectedBlockTime;
     type EpochChangeTrigger = pallet_babe::ExternalTrigger;
+
+    type KeyOwnerProofSystem = Historical;
+
+    type KeyOwnerProof = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::Proof;
+
+    type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::IdentificationTuple;
+
+    type HandleEquivocation =
+        pallet_babe::EquivocationHandler<Self::KeyOwnerIdentification, Offences>;
 }
 
 parameter_types! {
@@ -209,6 +225,7 @@ impl pallet_indices::Trait for Runtime {
     type Event = Event;
     type Currency = Balances;
     type Deposit = IndexDeposit;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -283,6 +300,7 @@ impl pallet_timestamp::Trait for Runtime {
     type Moment = Moment;
     type OnTimestampSet = Babe;
     type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -325,6 +343,7 @@ impl pallet_session::Trait for Runtime {
     type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
     type Keys = SessionKeys;
     type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Runtime {
@@ -462,7 +481,7 @@ impl pallet_contracts::Trait for Runtime {
     type Randomness = RandomnessCollectiveFlip;
     type Currency = Balances;
     type Event = Event;
-    type Call = Call;
+    //type Call = Call;
     type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<Runtime>;
     type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Runtime>;
     type RentPayment = ();
@@ -506,7 +525,6 @@ where
             frame_system::CheckNonce::<Runtime>::from(nonce),
             frame_system::CheckWeight::<Runtime>::new(),
             pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
-            pallet_grandpa::ValidateEquivocationReport::<Runtime>::new(),
         );
         let raw_payload = SignedPayload::new(call, extra)
             .map_err(|e| {
@@ -563,6 +581,7 @@ impl pallet_offences::Trait for Runtime {
     type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
     type OnOffenceHandler = Staking;
     type WeightSoftLimit = OffencesWeightSoftLimit;
+    type WeightInfo = ();
 }
 
 parameter_types! {
@@ -595,12 +614,8 @@ impl pallet_grandpa::Trait for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
 
-    type HandleEquivocation = pallet_grandpa::EquivocationHandler<
-        Self::KeyOwnerIdentification,
-        polymesh_primitives::report::ReporterAppCrypto,
-        Runtime,
-        Offences,
-    >;
+    type HandleEquivocation =
+        pallet_grandpa::EquivocationHandler<Self::KeyOwnerIdentification, Offences>;
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}
@@ -721,7 +736,7 @@ construct_runtime!(
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         // Must be before session.
-        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent(Timestamp)},
+        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent},
 
         Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
         Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},
@@ -800,7 +815,6 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-    pallet_grandpa::ValidateEquivocationReport<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
@@ -880,7 +894,7 @@ impl_runtime_apis! {
             Grandpa::grandpa_authorities()
         }
 
-        fn submit_report_equivocation_extrinsic(
+        fn submit_report_equivocation_unsigned_extrinsic(
             equivocation_proof: fg_primitives::EquivocationProof<
                 <Block as BlockT>::Hash,
                 NumberFor<Block>,
@@ -889,7 +903,7 @@ impl_runtime_apis! {
         ) -> Option<()> {
             let key_owner_proof = key_owner_proof.decode()?;
 
-            Grandpa::submit_report_equivocation_extrinsic(
+            Grandpa::submit_unsigned_equivocation_report(
                 equivocation_proof,
                 key_owner_proof,
             )
@@ -927,6 +941,29 @@ impl_runtime_apis! {
         fn current_epoch_start() -> sp_consensus_babe::SlotNumber {
             Babe::current_epoch_start()
         }
+
+        fn generate_key_ownership_proof(
+            _slot_number: sp_consensus_babe::SlotNumber,
+            authority_id: sp_consensus_babe::AuthorityId,
+        ) -> Option<sp_consensus_babe::OpaqueKeyOwnershipProof> {
+            use codec::Encode;
+
+            Historical::prove((sp_consensus_babe::KEY_TYPE, authority_id))
+                .map(|p| p.encode())
+                .map(sp_consensus_babe::OpaqueKeyOwnershipProof::new)
+        }
+
+        fn submit_report_equivocation_unsigned_extrinsic(
+            equivocation_proof: sp_consensus_babe::EquivocationProof<<Block as BlockT>::Header>,
+            key_owner_proof: sp_consensus_babe::OpaqueKeyOwnershipProof,
+        ) -> Option<()> {
+            let key_owner_proof = key_owner_proof.decode()?;
+
+            Babe::submit_unsigned_equivocation_report(
+                equivocation_proof,
+                key_owner_proof,
+            )
+        }
     }
 
     impl sp_authority_discovery::AuthorityDiscoveryApi<Block> for Runtime {
@@ -951,12 +988,13 @@ impl_runtime_apis! {
             gas_limit: u64,
             input_data: Vec<u8>,
         ) -> ContractExecResult {
-            let exec_result =
-                Contracts::bare_call(origin, dest, value, gas_limit, input_data);
+            let (exec_result, gas_consumed) =
+                Contracts::bare_call(origin, dest.into(), value, gas_limit, input_data);
             match exec_result {
                 Ok(v) => ContractExecResult::Success {
-                    status: v.status,
+                    flags: v.flags.bits(),
                     data: v.data,
+                    gas_consumed: gas_consumed,
                 },
                 Err(_) => ContractExecResult::Error,
             }

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -735,7 +735,7 @@ construct_runtime!(
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
         // Must be before session.
-        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent},
+        Babe: pallet_babe::{Module, Call, Storage, Config, Inherent, ValidateUnsigned},
 
         Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
         Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -481,7 +481,6 @@ impl pallet_contracts::Trait for Runtime {
     type Randomness = RandomnessCollectiveFlip;
     type Currency = Balances;
     type Event = Event;
-    //type Call = Call;
     type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<Runtime>;
     type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Runtime>;
     type RentPayment = ();

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -17,7 +17,7 @@ pallet-cdd-offchain-worker = { path = "../../cdd-offchain-worker", default-featu
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
 pallet-confidential = { path = "../../confidential", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", default-features = false }
 pallet-group = { path = "../../group", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false }
 pallet-multisig = { path = "../../multisig", default-features = false }
@@ -53,28 +53,28 @@ env_logger = "0.7"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", features = ["historical"] }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate/", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6", features = ["historical"] }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate/", default-features = false, tag = "v2.0.0-rc6" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 ink_primitives = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
-test_client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+test_client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.3.5", default-features = false }

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -17,7 +17,7 @@ pallet-cdd-offchain-worker = { path = "../../cdd-offchain-worker", default-featu
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }
 pallet-confidential = { path = "../../confidential", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", default-features = false }
 pallet-group = { path = "../../group", default-features = false }
 pallet-identity = { path = "../../identity", default-features = false }
 pallet-multisig = { path = "../../multisig", default-features = false }
@@ -53,28 +53,28 @@ env_logger = "0.7"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call", features = ["historical"] }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate/", default-features = false, branch = "at-add-dispatch-call" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", features = ["historical"] }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate/", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 ink_primitives = { git = "https://github.com/paritytech/ink", tag = "v2.1.0", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
-test_client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+test_client = { package = "substrate-test-runtime-client", git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [dev-dependencies]
 libsecp256k1 = { version = "0.3.5", default-features = false }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -497,12 +497,14 @@ parameter_types! {
     pub const ExpectedBlockTime: u64 = 1;
 }
 
+use frame_support::traits::KeyOwnerProofSystem;
 use polymesh_runtime_develop::runtime::{Historical, Offences};
 use sp_runtime::KeyTypeId;
-use frame_support::traits::KeyOwnerProofSystem;
 
 impl From<pallet_babe::Call<Test>> for Call {
-    fn from(_: pallet_babe::Call<Test>) -> Self { unimplemented!() }
+    fn from(_: pallet_babe::Call<Test>) -> Self {
+        unimplemented!()
+    }
 }
 
 impl pallet_babe::Trait for Test {
@@ -512,15 +514,14 @@ impl pallet_babe::Trait for Test {
 
     type KeyOwnerProofSystem = ();
     type KeyOwnerProof = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
-            KeyTypeId,
-            pallet_babe::AuthorityId,
-        )>>::Proof;
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::Proof;
     type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
-            KeyTypeId,
-            pallet_babe::AuthorityId,
-        )>>::IdentificationTuple;
-    type HandleEquivocation =
-        pallet_babe::EquivocationHandler<Self::KeyOwnerIdentification, ()>;
+        KeyTypeId,
+        pallet_babe::AuthorityId,
+    )>>::IdentificationTuple;
+    type HandleEquivocation = pallet_babe::EquivocationHandler<Self::KeyOwnerIdentification, ()>;
 }
 
 pallet_staking_reward_curve::build! {

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -263,6 +263,7 @@ impl frame_system::Trait for Test {
     type AccountData = AccountData<Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
+    type SystemWeightInfo = ();
 }
 
 impl CommonTrait for Test {
@@ -300,6 +301,7 @@ impl pallet_session::Trait for Test {
     type ValidatorIdOf = StashOf<Test>;
     type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
     type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Test {
@@ -335,6 +337,7 @@ impl pallet_timestamp::Trait for Test {
     type Moment = u64;
     type OnTimestampSet = ();
     type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 impl group::Trait<group::Instance2> for Test {
@@ -494,10 +497,30 @@ parameter_types! {
     pub const ExpectedBlockTime: u64 = 1;
 }
 
+use polymesh_runtime_develop::runtime::{Historical, Offences};
+use sp_runtime::KeyTypeId;
+use frame_support::traits::KeyOwnerProofSystem;
+
+impl From<pallet_babe::Call<Test>> for Call {
+    fn from(_: pallet_babe::Call<Test>) -> Self { unimplemented!() }
+}
+
 impl pallet_babe::Trait for Test {
     type EpochDuration = EpochDuration;
     type ExpectedBlockTime = ExpectedBlockTime;
     type EpochChangeTrigger = pallet_babe::ExternalTrigger;
+
+    type KeyOwnerProofSystem = ();
+    type KeyOwnerProof = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+            KeyTypeId,
+            pallet_babe::AuthorityId,
+        )>>::Proof;
+    type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+            KeyTypeId,
+            pallet_babe::AuthorityId,
+        )>>::IdentificationTuple;
+    type HandleEquivocation =
+        pallet_babe::EquivocationHandler<Self::KeyOwnerIdentification, ()>;
 }
 
 pallet_staking_reward_curve::build! {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -15,7 +15,6 @@ use frame_support::{
     },
     StorageDoubleMap,
 };
-use frame_system as system;
 use pallet_asset as asset;
 use pallet_balances as balances;
 use pallet_basic_sto as sto;
@@ -222,6 +221,7 @@ impl frame_system::Trait for TestStorage {
     /// independent of the logic of that extrinsics. (Roughly max block weight - average on
     /// initialize cost).
     type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
+    type SystemWeightInfo = ();
 }
 
 parameter_types! {
@@ -251,6 +251,7 @@ impl pallet_timestamp::Trait for TestStorage {
     type Moment = u64;
     type OnTimestampSet = ();
     type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 impl multisig::Trait for TestStorage {
@@ -427,7 +428,6 @@ impl pallet_contracts::Trait for TestStorage {
     type Randomness = Randomness;
     type Currency = Balances;
     type Event = Event;
-    type Call = Call;
     type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<TestStorage>;
     type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<TestStorage>;
     type RentPayment = ();
@@ -558,6 +558,7 @@ impl pallet_session::Trait for TestStorage {
     type SessionHandler = TestSessionHandler;
     type Keys = MockSessionKeys;
     type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = ();
 }
 
 impl dividend::Trait for TestStorage {

--- a/pallets/runtime/tests/src/transaction_payment_test.rs
+++ b/pallets/runtime/tests/src/transaction_payment_test.rs
@@ -30,12 +30,14 @@ pub fn info_from_weight(w: Weight) -> DispatchInfo {
 fn post_info_from_weight(w: Weight) -> PostDispatchInfo {
     PostDispatchInfo {
         actual_weight: Some(w),
+        pays_fee: Pays::Yes,
     }
 }
 
 fn default_post_info() -> PostDispatchInfo {
     PostDispatchInfo {
         actual_weight: None,
+        pays_fee: Pays::Yes,
     }
 }
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -15,22 +15,22 @@ serde = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call"}
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
 
-pallet-session = { features = ["historical"], git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-session = { features = ["historical"], git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
  
 # Optional imports for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", optional = true }
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [features]

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -15,22 +15,22 @@ serde = { version = "1.0.104", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2"}
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-staking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6"}
 
-pallet-session = { features = ["historical"], git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { features = ["historical"], git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
  
 # Optional imports for benchmarking
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2", optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6", optional = true }
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [features]

--- a/pallets/staking/fuzzer/Cargo.toml
+++ b/pallets/staking/fuzzer/Cargo.toml
@@ -17,17 +17,17 @@ honggfuzz = "0.5"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 pallet-staking = { version = "2.0.0-rc4", path = "..", features = ["runtime-benchmarks"] }
 pallet-staking-reward-curve = { version = "2.0.0-rc4",  path = "../reward-curve" }
-pallet-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 pallet-balances = { path = "../../balances" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-io ={ git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-io ={ git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 
 
 [[bin]]

--- a/pallets/staking/fuzzer/Cargo.toml
+++ b/pallets/staking/fuzzer/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 honggfuzz = "0.5"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
-pallet-staking = { version = "2.0.0-rc4", path = "..", features = ["runtime-benchmarks"] }
-pallet-staking-reward-curve = { version = "2.0.0-rc4",  path = "../reward-curve" }
+pallet-staking = { version = "2.0.0-rc6", path = "..", features = ["runtime-benchmarks"] }
+pallet-staking-reward-curve = { version = "2.0.0-rc6",  path = "../reward-curve" }
 pallet-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 pallet-indices = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6" }
 pallet-balances = { path = "../../balances" }

--- a/pallets/staking/fuzzer/Cargo.toml
+++ b/pallets/staking/fuzzer/Cargo.toml
@@ -17,17 +17,17 @@ honggfuzz = "0.5"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 pallet-staking = { version = "2.0.0-rc4", path = "..", features = ["runtime-benchmarks"] }
 pallet-staking-reward-curve = { version = "2.0.0-rc4",  path = "../reward-curve" }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-pallet-indices = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+pallet-session = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+pallet-indices = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 pallet-balances = { path = "../../balances" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-io ={ git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-npos-elections = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-io ={ git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-npos-elections = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2" }
 
 
 [[bin]]

--- a/pallets/staking/reward-curve/Cargo.toml
+++ b/pallets/staking/reward-curve/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro2 = "1.0.9"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default-features = false, branch = "at-add-dispatch-call" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 default = ["std"]

--- a/pallets/staking/reward-curve/Cargo.toml
+++ b/pallets/staking/reward-curve/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro2 = "1.0.9"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 default = ["std"]

--- a/pallets/staking/rpc/Cargo.toml
+++ b/pallets/staking/rpc/Cargo.toml
@@ -10,8 +10,8 @@ serde = { version = "1.0.104", features = ["derive"] }
 jsonrpc-core = "14.0.5"
 jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.5"
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
 
 pallet-staking-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/pallets/staking/rpc/Cargo.toml
+++ b/pallets/staking/rpc/Cargo.toml
@@ -10,8 +10,8 @@ serde = { version = "1.0.104", features = ["derive"] }
 jsonrpc-core = "14.0.5"
 jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.5"
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
 
 pallet-staking-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/pallets/staking/rpc/runtime-api/Cargo.toml
+++ b/pallets/staking/rpc/runtime-api/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Anonymous"]
 edition = "2018"
 
 [dependencies]
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call"}
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  branch = "at-add-dispatch-call"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc5+2"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 serde_json = "1.0.48"

--- a/pallets/staking/rpc/runtime-api/Cargo.toml
+++ b/pallets/staking/rpc/runtime-api/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Anonymous"]
 edition = "2018"
 
 [dependencies]
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2"}
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc5+2"}
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6"}
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false,  tag = "v2.0.0-rc6"}
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 serde_json = "1.0.48"

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -936,7 +936,7 @@ pub trait Trait:
     type ElectionLookahead: Get<Self::BlockNumber>;
 
     /// The overarching call type.
-    type Call: Dispatchable + From<Call<Self>> + IsSubType<Module<Self>, Self> + Clone;
+    type Call: Dispatchable + From<Call<Self>> + IsSubType<Call<Self>> + Clone;
 
     /// Maximum number of balancing iterations to run in the offchain submission.
     ///
@@ -3819,6 +3819,10 @@ where
             <Module<T>>::deposit_event(RawEvent::OldSlashingReportDiscarded(offence_session));
             Ok(())
         }
+    }
+
+    fn is_known_offence(offenders: &[Offender], time_slot: &O::TimeSlot) -> bool {
+        R::is_known_offence(offenders, time_slot)
     }
 }
 

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -318,9 +318,9 @@ use pallet_session::historical;
 use polymesh_common_utilities::{identity::Trait as IdentityTrait, Context};
 use polymesh_primitives::{traits::BlockRewardsReserveCurrency, IdentityId};
 use sp_npos_elections::{
-    build_support_map, evaluate_support, generate_compact_solution_type, is_score_better,
-    seq_phragmen, Assignment, ElectionResult as PrimitiveElectionResult, ElectionScore,
-    ExtendedBalance, SupportMap, VoteWeight, VotingLimit,
+    build_support_map, evaluate_support, generate_solution_type, is_score_better, seq_phragmen,
+    Assignment, ElectionResult as PrimitiveElectionResult, ElectionScore, ExtendedBalance,
+    SupportMap, VoteWeight, VotingLimit,
 };
 use sp_runtime::{
     curve::PiecewiseLinear,
@@ -387,7 +387,10 @@ pub type EraIndex = u32;
 pub type RewardPoint = u32;
 
 // Note: Maximum nomination limit is set here -- 16.
-generate_compact_solution_type!(pub GenericCompactAssignments, 16);
+generate_solution_type!(
+    #[compact]
+    pub struct CompactAssignments::<NominatorIndex, ValidatorIndex, OffchainAccuracy>(16)
+);
 
 /// Information regarding the active era (era in used in session).
 #[derive(Encode, Decode, RuntimeDebug)]
@@ -411,17 +414,19 @@ pub type OffchainAccuracy = PerU16;
 pub type BalanceOf<T> =
     <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
-/// The compact type for election solutions.
-pub type CompactAssignments =
-    GenericCompactAssignments<NominatorIndex, ValidatorIndex, OffchainAccuracy>;
-
 #[cfg(debug_assertions)]
-impl<N, V, O> GenericCompactAssignments<N, V, O> {
-    pub fn push_votes1(&mut self, v: (N, V)) {
+impl CompactAssignments {
+    pub fn push_votes1(&mut self, v: (NominatorIndex, ValidatorIndex)) {
         self.votes1.push(v)
     }
 
-    pub fn get_votes3(&mut self) -> &mut Vec<(N, [(V, O); 2], V)> {
+    pub fn get_votes3(
+        &mut self,
+    ) -> &mut Vec<(
+        NominatorIndex,
+        [(ValidatorIndex, OffchainAccuracy); 2],
+        ValidatorIndex,
+    )> {
         &mut self.votes3
     }
 }

--- a/pallets/statistics/Cargo.toml
+++ b/pallets/statistics/Cargo.toml
@@ -14,21 +14,21 @@ serde_derive = { version = "1.0.112", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Only in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/pallets/statistics/Cargo.toml
+++ b/pallets/statistics/Cargo.toml
@@ -14,21 +14,21 @@ serde_derive = { version = "1.0.112", optional = true, default-features = false}
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Only in STD
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "at-add-dispatch-call", optional = true }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc5+2", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/pallets/transaction-payment/Cargo.toml
+++ b/pallets/transaction-payment/Cargo.toml
@@ -14,11 +14,11 @@ serde = { version = "1.0.104", default-features = false, optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 serde_json = "1.0.56"

--- a/pallets/transaction-payment/Cargo.toml
+++ b/pallets/transaction-payment/Cargo.toml
@@ -14,11 +14,11 @@ serde = { version = "1.0.104", default-features = false, optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 serde_json = "1.0.56"

--- a/pallets/treasury/Cargo.toml
+++ b/pallets/treasury/Cargo.toml
@@ -16,15 +16,15 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [features]
 equalize = []

--- a/pallets/treasury/Cargo.toml
+++ b/pallets/treasury/Cargo.toml
@@ -16,15 +16,15 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [features]
 equalize = []

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
     traits::{Currency, ExistenceRequirement, Imbalance, OnUnbalanced, WithdrawReason},
     weights::{DispatchClass, Pays},
 };
-use frame_system::{self as system, ensure_root, ensure_signed};
+use frame_system::{ensure_root, ensure_signed};
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     constants::TREASURY_MODULE_ID,

--- a/pallets/utility/Cargo.toml
+++ b/pallets/utility/Cargo.toml
@@ -13,12 +13,12 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 
 [features]

--- a/pallets/utility/Cargo.toml
+++ b/pallets/utility/Cargo.toml
@@ -13,12 +13,12 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 
 [features]

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -57,7 +57,6 @@ use frame_support::{
     weights::{DispatchClass, GetDispatchInfo, Weight},
     Parameter,
 };
-use frame_system as system;
 use frame_system::{ensure_root, ensure_signed, RawOrigin};
 use polymesh_common_utilities::{
     balances::CheckCdd, identity::AuthorizationNonce, identity::Trait as IdentityTrait,

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,14 +20,14 @@ blake2 = { version = "0.9.0", default-features = false }
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 hex = { version = "^0.4.0", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,14 +20,14 @@ blake2 = { version = "0.9.0", default-features = false }
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
-sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = { package = "sp-core", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 hex = { version = "^0.4.0", default-features = false }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,14 +17,14 @@ pallet-transaction-payment = { path = "../pallets/transaction-payment", default-
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-core = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-sp-api = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc5+2" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc5+2" }
-sp-rpc = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-core = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc6" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc6" }
+sp-rpc = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 # Others
 jsonrpc-core = "14.0.5"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,14 +17,14 @@ pallet-transaction-payment = { path = "../pallets/transaction-payment", default-
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0" }
-sp-core = {git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-sp-api = { git = 'https://github.com/paritytech/substrate', default-features = false, branch = "at-add-dispatch-call" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate', branch = "at-add-dispatch-call" }
-sp-rpc = { git = 'https://github.com/paritytech/substrate', branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-core = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-std = {git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default-features = false, tag = "v2.0.0-rc5+2" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc5+2" }
+sp-rpc = { git = 'https://github.com/paritytech/substrate', tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 # Others
 jsonrpc-core = "14.0.5"

--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -18,11 +18,11 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc6" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -18,11 +18,11 @@ serde = { version = "1.0.104", optional = true, features = ["derive"] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, branch = "at-add-dispatch-call" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "at-add-dispatch-call" }
+sp-api = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-std = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', default_features = false, tag = "v2.0.0-rc5+2" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0-rc5+2" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,9 +20,9 @@ use crate::service;
 use crate::service::IsAlcyoneNetwork;
 use log::info;
 use polymesh_primitives::Block;
+use sc_cli::{ChainSpec, RuntimeVersion};
 pub use sc_cli::{Result, SubstrateCli};
 use sc_service::config::Role;
-use sc_cli::{ChainSpec, RuntimeVersion};
 
 #[cfg(feature = "runtime-benchmarks")]
 use polymesh_runtime::runtime;
@@ -102,12 +102,12 @@ pub fn run() -> Result<()> {
             if chain_spec.is_alcyone_network() {
                 runtime.run_node_until_exit(|config| match config.role {
                     Role::Light => service::alcyone_new_light(config),
-                    _ => service::alcyone_new_full(config)
+                    _ => service::alcyone_new_full(config),
                 })
             } else {
                 runtime.run_node_until_exit(|config| match config.role {
                     Role::Light => service::general_new_light(config),
-                    _ => service::general_new_full(config)
+                    _ => service::general_new_full(config),
                 })
             }
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,41 +21,42 @@ use crate::service::IsAlcyoneNetwork;
 use log::info;
 use polymesh_primitives::Block;
 pub use sc_cli::{Result, SubstrateCli};
-use sc_executor::NativeExecutionDispatch;
+use sc_service::config::Role;
+use sc_cli::{ChainSpec, RuntimeVersion};
 
 #[cfg(feature = "runtime-benchmarks")]
 use polymesh_runtime::runtime;
 
 impl SubstrateCli for Cli {
-    fn impl_name() -> &'static str {
-        "Polymesh Node"
+    fn impl_name() -> String {
+        "Polymesh Node".into()
     }
 
-    fn impl_version() -> &'static str {
-        env!("CARGO_PKG_VERSION")
+    fn impl_version() -> String {
+        env!("CARGO_PKG_VERSION").into()
     }
 
-    fn description() -> &'static str {
-        env!("CARGO_PKG_DESCRIPTION")
+    fn description() -> String {
+        env!("CARGO_PKG_DESCRIPTION").into()
     }
 
-    fn author() -> &'static str {
-        env!("CARGO_PKG_AUTHORS")
+    fn author() -> String {
+        env!("CARGO_PKG_AUTHORS").into()
     }
 
-    fn support_url() -> &'static str {
-        "https://github.com/PolymathNetwork/polymesh/issues/new"
+    fn support_url() -> String {
+        "https://github.com/PolymathNetwork/polymesh/issues/new".into()
     }
 
     fn copyright_start_year() -> i32 {
         2017
     }
 
-    fn executable_name() -> &'static str {
-        "polymesh"
+    fn executable_name() -> String {
+        "polymesh".into()
     }
 
-    fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+    fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
         Ok(match id {
             "dev" => Box::new(chain_spec::general_development_testnet_config()),
             "local" => Box::new(chain_spec::general_local_testnet_config()),
@@ -70,6 +71,14 @@ impl SubstrateCli for Cli {
                 std::path::PathBuf::from(path),
             )?),
         })
+    }
+
+    fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
+        if chain_spec.is_alcyone_network() {
+            &polymesh_runtime_testnet::runtime::VERSION
+        } else {
+            &polymesh_runtime_develop::runtime::VERSION
+        }
     }
 }
 
@@ -91,17 +100,15 @@ pub fn run() -> Result<()> {
             );
 
             if chain_spec.is_alcyone_network() {
-                runtime.run_node(
-                    service::alcyone_new_light,
-                    service::alcyone_new_full,
-                    service::AlcyoneExecutor::native_version().runtime_version,
-                )
+                runtime.run_node_until_exit(|config| match config.role {
+                    Role::Light => service::alcyone_new_light(config),
+                    _ => service::alcyone_new_full(config)
+                })
             } else {
-                runtime.run_node(
-                    service::general_new_light,
-                    service::general_new_full,
-                    service::GeneralExecutor::native_version().runtime_version,
-                )
+                runtime.run_node_until_exit(|config| match config.role {
+                    Role::Light => service::general_new_light(config),
+                    _ => service::general_new_full(config)
+                })
             }
         }
         Some(Subcommand::Base(subcommand)) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,36 +2,38 @@
 
 pub use crate::chain_spec::{AlcyoneChainSpec, GeneralChainSpec};
 pub use codec::Codec;
+use futures::stream::StreamExt;
+use grandpa::FinalityProofProvider as GrandpaFinalityProofProvider;
+use jsonrpc_pubsub::manager::SubscriptionManager;
 pub use pallet_confidential::native_rng;
+use polymesh_node_rpc as node_rpc;
 pub use polymesh_primitives::{
     AccountId, Balance, Block, BlockNumber, Hash, IdentityId, Index as Nonce, Moment, SecondaryKey,
     Signatory, Ticker,
 };
-use sc_client_api::ExecutorProvider;
-use grandpa::{FinalityProofProvider as GrandpaFinalityProofProvider, StorageAndProofProvider};
 pub use polymesh_runtime_develop;
 pub use polymesh_runtime_testnet;
 use prometheus_endpoint::Registry;
-pub use sc_client_api::{RemoteBackend, backend::Backend};
+use sc_client_api::ExecutorProvider;
+pub use sc_client_api::{backend::Backend, RemoteBackend};
 pub use sc_consensus::LongestChain;
 use sc_executor::native_executor_instance;
 pub use sc_executor::{NativeExecutionDispatch, NativeExecutor};
+use sc_network::{Event, NetworkService};
 pub use sc_service::{
-    config::{Role, DatabaseConfig, PrometheusConfig},
+    config::{DatabaseConfig, PrometheusConfig, Role},
     error::Error as ServiceError,
-    ChainSpec, Configuration, Error, PruningMode, RuntimeGenesis,
-    TFullBackend, TFullCallExecutor, TFullClient, TLightBackend,
-    TLightCallExecutor, TLightClient, TransactionPoolOptions,
+    ChainSpec, Configuration, Error, PruningMode, RuntimeGenesis, TFullBackend, TFullCallExecutor,
+    TFullClient, TLightBackend, TLightCallExecutor, TLightClient, TransactionPoolOptions,
 };
+use sc_service::{RpcHandlers, TaskManager};
 pub use sp_api::{ConstructRuntimeApi, Core as CoreApi, ProvideRuntimeApi, StateBackend};
 pub use sp_consensus::SelectChain;
+use sp_core::traits::BareCryptoStorePtr;
 use sp_inherents::InherentDataProviders;
 pub use sp_runtime::traits::BlakeTwo256;
-use std::sync::Arc;
-use sc_network::{Event, NetworkService};
-use sc_service::{TaskManager, RpcHandlers, ServiceComponents};
-use sp_core::traits::BareCryptoStorePtr;
 use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
 
 pub trait IsAlcyoneNetwork {
     fn is_alcyone_network(&self) -> bool;
@@ -139,8 +141,6 @@ fn set_prometheus_registry(config: &mut Configuration) -> Result<(), ServiceErro
     Ok(())
 }
 
-use polymesh_node_rpc as node_rpc;
-
 type BabeLink = sc_consensus_babe::BabeLink<Block>;
 type IoHandler = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 
@@ -148,35 +148,31 @@ type FullLinkHalf<R, D> = grandpa::LinkHalf<Block, FullClient<R, D>, FullSelectC
 type FullClient<R, E> = sc_service::TFullClient<Block, R, E>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
-type FullGrandpaBlockImport<R, E> = grandpa::GrandpaBlockImport<FullBackend, Block, FullClient<R, E>, FullSelectChain>;
-type FullBabeImportQueue<R, E> = sc_consensus_babe::BabeImportQueue<Block, FullClient<R, E>>;
+type FullGrandpaBlockImport<R, E> =
+    grandpa::GrandpaBlockImport<FullBackend, Block, FullClient<R, E>, FullSelectChain>;
+type FullBabeImportQueue<R, E> = sp_consensus::DefaultImportQueue<Block, FullClient<R, E>>;
 type FullStateBackend = sc_client_api::StateBackendFor<FullBackend, Block>;
 type FullPool<R, E> = sc_transaction_pool::FullPool<Block, FullClient<R, E>>;
-type FullServiceParams<R, E> = sc_service::ServiceParams<
-    Block,
+type FullServiceComponents<R, E, F> = sc_service::PartialComponents<
     FullClient<R, E>,
+    FullBackend,
+    FullSelectChain,
     FullBabeImportQueue<R, E>,
     FullPool<R, E>,
-    IoHandler,
-    FullBackend,
->;
-type FullBabeBlockImport<R, E> = sc_consensus_babe::BabeBlockImport<
-    Block,
-    FullClient<R, E>,
-    FullGrandpaBlockImport<R, E>,
->;
-
-pub fn new_full_params<R, D, E>(
-    config: Configuration,
-) -> Result<
     (
-        FullServiceParams<R, D>,
-        (FullBabeBlockImport<R, D>, FullLinkHalf<R, D>, BabeLink),
+        F,
+        (FullBabeBlockImport<R, E>, FullLinkHalf<R, E>, BabeLink),
         grandpa::SharedVoterState,
-        FullSelectChain,
-        InherentDataProviders,
     ),
-    ServiceError,
+>;
+type FullBabeBlockImport<R, E> =
+    sc_consensus_babe::BabeBlockImport<Block, FullClient<R, E>, FullGrandpaBlockImport<R, E>>;
+
+pub fn new_partial<R, D, E>(
+    config: &mut Configuration,
+) -> Result<
+    FullServiceComponents<R, D, impl Fn(sc_rpc::DenyUnsafe, SubscriptionManager) -> IoHandler>,
+    Error,
 >
 where
     R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
@@ -184,17 +180,16 @@ where
     D: NativeExecutionDispatch + 'static,
     E: RuntimeExtrinsic,
 {
+    set_prometheus_registry(config)?;
+
     let (client, backend, keystore, task_manager) =
         sc_service::new_full_parts::<Block, R, D>(&config)?;
     let client = Arc::new(client);
 
     let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-    let pool_api =
-        sc_transaction_pool::FullChainApi::new(client.clone(), config.prometheus_registry());
     let transaction_pool = sc_transaction_pool::BasicPool::new_full(
         config.transaction_pool.clone(),
-        std::sync::Arc::new(pool_api),
         config.prometheus_registry(),
         task_manager.spawn_handle(),
         client.clone(),
@@ -225,6 +220,7 @@ where
         inherent_data_providers.clone(),
         &task_manager.spawn_handle(),
         config.prometheus_registry(),
+        sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
     )?;
 
     let import_setup = (block_import, grandpa_link, babe_link);
@@ -232,6 +228,7 @@ where
     let (rpc_extensions_builder, rpc_setup) = {
         let (_, grandpa_link, babe_link) = &import_setup;
 
+        let justification_stream = grandpa_link.justification_stream();
         let shared_authority_set = grandpa_link.shared_authority_set().clone();
         let shared_voter_state = grandpa::SharedVoterState::empty();
 
@@ -245,7 +242,7 @@ where
         let select_chain = select_chain.clone();
         let keystore = keystore.clone();
 
-        let rpc_extensions_builder = Box::new(move |deny_unsafe| {
+        let rpc_extensions_builder = move |deny_unsafe, subscriptions| {
             let deps = node_rpc::FullDeps {
                 client: client.clone(),
                 pool: pool.clone(),
@@ -259,55 +256,44 @@ where
                 grandpa: node_rpc::GrandpaDeps {
                     shared_voter_state: shared_voter_state.clone(),
                     shared_authority_set: shared_authority_set.clone(),
+                    justification_stream: justification_stream.clone(),
+                    subscriptions,
                 },
             };
 
             node_rpc::create_full(deps)
-        });
+        };
 
         (rpc_extensions_builder, rpc_setup)
     };
 
-    let provider = client.clone() as Arc<dyn grandpa::StorageAndProofProvider<_, _>>;
-    let finality_proof_provider = Arc::new(grandpa::FinalityProofProvider::new(
-        backend.clone(),
-        provider,
-    ));
-
-    let params = sc_service::ServiceParams {
-        config,
-        backend,
+    Ok(sc_service::PartialComponents {
         client,
-        import_queue,
-        keystore,
+        backend,
         task_manager,
-        rpc_extensions_builder,
-        transaction_pool,
-        block_announce_validator_builder: None,
-        finality_proof_request_builder: None,
-        finality_proof_provider: Some(finality_proof_provider),
-        on_demand: None,
-        remote_blockchain: None,
-    };
-
-    Ok((
-        params,
-        import_setup,
-        rpc_setup,
+        keystore,
         select_chain,
+        import_queue,
+        transaction_pool,
         inherent_data_providers,
-    ))
+        other: (rpc_extensions_builder, import_setup, rpc_setup),
+    })
 }
 
 /// Creates a full service from the configuration.
 pub fn new_full_base<R, D, E, F>(
-	mut config: Configuration,
-	with_startup_data: F,
-) -> Result<(
-	TaskManager, InherentDataProviders, Arc<FullClient<R, D>>,
-	Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
-	Arc<FullPool<R, D>>,
-), ServiceError>
+    mut config: Configuration,
+    with_startup_data: F,
+) -> Result<
+    (
+        TaskManager,
+        InherentDataProviders,
+        Arc<FullClient<R, D>>,
+        Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+        Arc<FullPool<R, D>>,
+    ),
+    ServiceError,
+>
 where
     F: FnOnce(&FullBabeBlockImport<R, D>, &BabeLink),
     R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
@@ -315,183 +301,218 @@ where
     D: NativeExecutionDispatch + 'static,
     E: RuntimeExtrinsic,
 {
-    set_prometheus_registry(&mut config)?;
+    let sc_service::PartialComponents {
+        client,
+        backend,
+        mut task_manager,
+        import_queue,
+        keystore,
+        select_chain,
+        transaction_pool,
+        inherent_data_providers,
+        other: (rpc_extensions_builder, import_setup, rpc_setup),
+    } = new_partial(&mut config)?;
 
-	let (params, import_setup, rpc_setup, select_chain, inherent_data_providers)
-		= new_full_params(config)?;
+    let finality_proof_provider =
+        GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
 
-	let (
-		role, force_authoring, name, enable_grandpa, prometheus_registry,
-		client, transaction_pool, keystore,
-	) = {
-		let sc_service::ServiceParams {
-			config, client, transaction_pool, keystore, ..
-		} = &params;
+    let (network, network_status_sinks, system_rpc_tx, network_starter) =
+        sc_service::build_network(sc_service::BuildNetworkParams {
+            config: &config,
+            client: client.clone(),
+            transaction_pool: transaction_pool.clone(),
+            spawn_handle: task_manager.spawn_handle(),
+            import_queue,
+            on_demand: None,
+            block_announce_validator_builder: None,
+            finality_proof_request_builder: None,
+            finality_proof_provider: Some(finality_proof_provider.clone()),
+        })?;
 
-		(
-			config.role.clone(),
-			config.force_authoring,
-			config.network.node_name.clone(),
-			!config.disable_grandpa,
-			config.prometheus_registry().cloned(),
+    if config.offchain_worker.enabled {
+        sc_service::build_offchain_workers(
+            &config,
+            backend.clone(),
+            task_manager.spawn_handle(),
+            client.clone(),
+            network.clone(),
+        );
+    }
 
-			client.clone(), transaction_pool.clone(), keystore.clone(),
-		)
-	};
+    let role = config.role.clone();
+    let force_authoring = config.force_authoring;
+    let name = config.network.node_name.clone();
+    let enable_grandpa = !config.disable_grandpa;
+    let prometheus_registry = config.prometheus_registry().cloned();
+    let telemetry_connection_sinks = sc_service::TelemetryConnectionSinks::default();
 
-	let ServiceComponents {
-		task_manager, network, telemetry_on_connect_sinks, ..
-	} = sc_service::build(params)?;
+    sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+        config,
+        backend: backend.clone(),
+        client: client.clone(),
+        keystore: keystore.clone(),
+        network: network.clone(),
+        rpc_extensions_builder: Box::new(rpc_extensions_builder),
+        transaction_pool: transaction_pool.clone(),
+        task_manager: &mut task_manager,
+        on_demand: None,
+        remote_blockchain: None,
+        telemetry_connection_sinks: telemetry_connection_sinks.clone(),
+        network_status_sinks,
+        system_rpc_tx,
+    })?;
 
-	let (block_import, grandpa_link, babe_link) = import_setup;
-	let shared_voter_state = rpc_setup;
+    let (block_import, grandpa_link, babe_link) = import_setup;
+    let shared_voter_state = rpc_setup;
 
-	(with_startup_data)(&block_import, &babe_link);
+    (with_startup_data)(&block_import, &babe_link);
 
-	if let sc_service::config::Role::Authority { .. } = &role {
-		let proposer = sc_basic_authorship::ProposerFactory::new(
-			client.clone(),
-			transaction_pool.clone(),
-			prometheus_registry.as_ref(),
-		);
+    if let sc_service::config::Role::Authority { .. } = &role {
+        let proposer = sc_basic_authorship::ProposerFactory::new(
+            client.clone(),
+            transaction_pool.clone(),
+            prometheus_registry.as_ref(),
+        );
 
-		let can_author_with =
-			sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+        let can_author_with =
+            sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
 
-		let babe_config = sc_consensus_babe::BabeParams {
-			keystore: keystore.clone(),
-			client: client.clone(),
-			select_chain,
-			env: proposer,
-			block_import,
-			sync_oracle: network.clone(),
-			inherent_data_providers: inherent_data_providers.clone(),
-			force_authoring,
-			babe_link,
-			can_author_with,
-		};
-
-		let babe = sc_consensus_babe::start_babe(babe_config)?;
-		task_manager.spawn_essential_handle().spawn_blocking("babe-proposer", babe);
-	}
-
-	// Spawn authority discovery module.
-	if matches!(role, Role::Authority{..} | Role::Sentry {..}) {
-		let (sentries, authority_discovery_role) = match role {
-			sc_service::config::Role::Authority { ref sentry_nodes } => (
-				sentry_nodes.clone(),
-				sc_authority_discovery::Role::Authority (
-					keystore.clone(),
-				),
-			),
-			sc_service::config::Role::Sentry {..} => (
-				vec![],
-				sc_authority_discovery::Role::Sentry,
-			),
-			_ => unreachable!("Due to outer matches! constraint; qed.")
+        let babe_config = sc_consensus_babe::BabeParams {
+            keystore: keystore.clone(),
+            client: client.clone(),
+            select_chain,
+            env: proposer,
+            block_import,
+            sync_oracle: network.clone(),
+            inherent_data_providers: inherent_data_providers.clone(),
+            force_authoring,
+            babe_link,
+            can_author_with,
         };
 
-        use futures::stream::StreamExt;
-		let dht_event_stream = network.event_stream("authority-discovery")
-			.filter_map(|e| async move { match e {
-				Event::Dht(e) => Some(e),
-				_ => None,
-			}}).boxed();
-		let authority_discovery = sc_authority_discovery::AuthorityDiscovery::new(
-			client.clone(),
-			network.clone(),
-			sentries,
-			dht_event_stream,
-			authority_discovery_role,
-			prometheus_registry.clone(),
-		);
+        let babe = sc_consensus_babe::start_babe(babe_config)?;
+        task_manager
+            .spawn_essential_handle()
+            .spawn_blocking("babe-proposer", babe);
+    }
 
-		task_manager.spawn_handle().spawn("authority-discovery", authority_discovery);
-	}
+    // Spawn authority discovery module.
+    if matches!(role, Role::Authority{..} | Role::Sentry {..}) {
+        let (sentries, authority_discovery_role) = match role {
+            sc_service::config::Role::Authority { ref sentry_nodes } => (
+                sentry_nodes.clone(),
+                sc_authority_discovery::Role::Authority(keystore.clone()),
+            ),
+            sc_service::config::Role::Sentry { .. } => {
+                (vec![], sc_authority_discovery::Role::Sentry)
+            }
+            _ => unreachable!("Due to outer matches! constraint; qed."),
+        };
 
-	// if the node isn't actively participating in consensus then it doesn't
-	// need a keystore, regardless of which protocol we use below.
-	let keystore = if role.is_authority() {
-		Some(keystore as BareCryptoStorePtr)
-	} else {
-		None
-	};
+        let dht_event_stream = network
+            .event_stream("authority-discovery")
+            .filter_map(|e| async move {
+                match e {
+                    Event::Dht(e) => Some(e),
+                    _ => None,
+                }
+            })
+            .boxed();
+        let (authority_discovery_worker, _service) = sc_authority_discovery::new_worker_and_service(
+            client.clone(),
+            network.clone(),
+            sentries,
+            dht_event_stream,
+            authority_discovery_role,
+            prometheus_registry.clone(),
+        );
 
-	let config = grandpa::Config {
-		// FIXME #1578 make this available through chainspec
-		gossip_duration: std::time::Duration::from_millis(333),
-		justification_period: 512,
-		name: Some(name),
-		observer_enabled: false,
-		keystore,
-		is_authority: role.is_network_authority(),
-	};
+        task_manager
+            .spawn_handle()
+            .spawn("authority-discovery-worker", authority_discovery_worker);
+    }
 
-	if enable_grandpa {
-		// start the full GRANDPA voter
-		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
-		// this point the full voter should provide better guarantees of block
-		// and vote data availability than the observer. The observer has not
-		// been tested extensively yet and having most nodes in a network run it
-		// could lead to finality stalls.
-		let grandpa_config = grandpa::GrandpaParams {
-			config,
-			link: grandpa_link,
-			network: network.clone(),
-			inherent_data_providers: inherent_data_providers.clone(),
-			telemetry_on_connect: Some(telemetry_on_connect_sinks.on_connect_stream()),
-			voting_rule: grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry,
-			shared_voter_state,
-		};
+    // if the node isn't actively participating in consensus then it doesn't
+    // need a keystore, regardless of which protocol we use below.
+    let keystore = if role.is_authority() {
+        Some(keystore as BareCryptoStorePtr)
+    } else {
+        None
+    };
 
-		// the GRANDPA voter task is considered infallible, i.e.
-		// if it fails we take down the service with it.
-		task_manager.spawn_essential_handle().spawn_blocking(
-			"grandpa-voter",
-			grandpa::run_grandpa_voter(grandpa_config)?
-		);
-	} else {
-		grandpa::setup_disabled_grandpa(
-			client.clone(),
-			&inherent_data_providers,
-			network.clone(),
-		)?;
-	}
+    let config = grandpa::Config {
+        // FIXME #1578 make this available through chainspec
+        gossip_duration: std::time::Duration::from_millis(333),
+        justification_period: 512,
+        name: Some(name),
+        observer_enabled: false,
+        keystore,
+        is_authority: role.is_network_authority(),
+    };
 
-	Ok((task_manager, inherent_data_providers, client, network, transaction_pool))
+    if enable_grandpa {
+        // start the full GRANDPA voter
+        // NOTE: non-authorities could run the GRANDPA observer protocol, but at
+        // this point the full voter should provide better guarantees of block
+        // and vote data availability than the observer. The observer has not
+        // been tested extensively yet and having most nodes in a network run it
+        // could lead to finality stalls.
+        let grandpa_config = grandpa::GrandpaParams {
+            config,
+            link: grandpa_link,
+            network: network.clone(),
+            inherent_data_providers: inherent_data_providers.clone(),
+            telemetry_on_connect: Some(telemetry_connection_sinks.on_connect_stream()),
+            voting_rule: grandpa::VotingRulesBuilder::default().build(),
+            prometheus_registry,
+            shared_voter_state,
+        };
+
+        // the GRANDPA voter task is considered infallible, i.e.
+        // if it fails we take down the service with it.
+        task_manager
+            .spawn_essential_handle()
+            .spawn_blocking("grandpa-voter", grandpa::run_grandpa_voter(grandpa_config)?);
+    } else {
+        grandpa::setup_disabled_grandpa(client.clone(), &inherent_data_providers, network.clone())?;
+    }
+
+    network_starter.start_network();
+    Ok((
+        task_manager,
+        inherent_data_providers,
+        client,
+        network,
+        transaction_pool,
+    ))
 }
 
 type TaskResult = Result<TaskManager, ServiceError>;
 
 /// Create a new Alcyone service for a full node.
 pub fn alcyone_new_full(config: Configuration) -> TaskResult {
-    new_full_base::<
-        polymesh_runtime_testnet::RuntimeApi,
-        AlcyoneExecutor,
-        _,
-        _,
-    >(config, |_, _| ()).map(|(task_manager, _, _, _, _)| {
-		task_manager
-    })
+    new_full_base::<polymesh_runtime_testnet::RuntimeApi, AlcyoneExecutor, _, _>(config, |_, _| ())
+        .map(|(task_manager, _, _, _, _)| task_manager)
 }
 
 /// Create a new General node service for a full node.
 pub fn general_new_full(config: Configuration) -> TaskResult {
-    new_full_base::<
-        polymesh_runtime_develop::RuntimeApi,
-        GeneralExecutor,
-        _,
-        _,
-    >(config, |_, _| ()).map(|(task_manager, _, _, _, _)| {
-		task_manager
-    })
+    new_full_base::<polymesh_runtime_develop::RuntimeApi, GeneralExecutor, _, _>(config, |_, _| ())
+        .map(|(task_manager, _, _, _, _)| task_manager)
 }
 
 /// Builds a new object suitable for chain operations.
 pub fn chain_ops<R, D, E>(
     mut config: Configuration,
-) -> Result<(Arc<FullClient<R, D>>, Arc<FullBackend>, FullBabeImportQueue<R, D>, TaskManager), ServiceError>
+) -> Result<
+    (
+        Arc<FullClient<R, D>>,
+        Arc<FullBackend>,
+        FullBabeImportQueue<R, D>,
+        TaskManager,
+    ),
+    ServiceError,
+>
 where
     R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
     R::RuntimeApi: RuntimeApiCollection<E, StateBackend = FullStateBackend>,
@@ -499,8 +520,13 @@ where
     E: RuntimeExtrinsic,
 {
     config.keystore = sc_service::config::KeystoreConfig::InMemory;
-    let (FullServiceParams { client, backend, import_queue, task_manager, .. }, ..)
-        = new_full_params::<R, D, E>(config)?;
+    let FullServiceComponents {
+        client,
+        backend,
+        import_queue,
+        task_manager,
+        ..
+    } = new_partial::<R, D, E>(&mut config)?;
     Ok((client, backend, import_queue, task_manager))
 }
 
@@ -508,97 +534,137 @@ type LightStorage = sc_client_db::light::LightStorage<Block>;
 type LightBackend = sc_light::backend::Backend<LightStorage, polymesh_primitives::BlakeTwo256>;
 type LightClient<R, E> = sc_service::TLightClient<Block, R, E>;
 type LightStateBackend = sc_client_api::StateBackendFor<LightBackend, Block>;
-type LightPool<R, E> = sc_transaction_pool::LightPool<Block, LightClient<R, E>, sc_network::config::OnDemand<Block>>;
+type LightPool<R, E> =
+    sc_transaction_pool::LightPool<Block, LightClient<R, E>, sc_network::config::OnDemand<Block>>;
 
-pub fn new_light_base<R, D, E>(config: Configuration) -> Result<(
-	TaskManager, Arc<RpcHandlers>, Arc<LightClient<R, D>>,
-	Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
-	Arc<LightPool<R, D>>,
-), ServiceError>
+pub fn new_light_base<R, D, E>(
+    config: Configuration,
+) -> Result<
+    (
+        TaskManager,
+        RpcHandlers,
+        Arc<LightClient<R, D>>,
+        Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+        Arc<LightPool<R, D>>,
+    ),
+    ServiceError,
+>
 where
-    //R: ConstructRuntimeApi<Block, LightClient<R, D>> +
     R::RuntimeApi: RuntimeApiCollection<E, StateBackend = LightStateBackend>,
     D: NativeExecutionDispatch + 'static,
     E: RuntimeExtrinsic,
-    //<R::RuntimeApi as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
-    R: Send + Sync + 'static + sp_api::ConstructRuntimeApi<
-        Block,
-        sc_service::TLightClientWithBackend<Block, R, D, LightBackend>,
-    >,
+    R: Send
+        + Sync
+        + 'static
+        + sp_api::ConstructRuntimeApi<
+            Block,
+            sc_service::TLightClientWithBackend<Block, R, D, LightBackend>,
+        >,
 {
-	let (client, backend, keystore, task_manager, on_demand) =
-		sc_service::new_light_parts::<Block, R, D>(&config)?;
+    let (client, backend, keystore, mut task_manager, on_demand) =
+        sc_service::new_light_parts::<Block, R, D>(&config)?;
 
-	let select_chain = sc_consensus::LongestChain::new(backend.clone());
+    let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-	let transaction_pool_api = Arc::new(sc_transaction_pool::LightChainApi::new(
-		client.clone(),
-		on_demand.clone(),
-	));
-	let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
-		config.transaction_pool.clone(),
-		transaction_pool_api,
-		config.prometheus_registry(),
-		task_manager.spawn_handle(),
-	));
+    let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
+        config.transaction_pool.clone(),
+        config.prometheus_registry(),
+        task_manager.spawn_handle(),
+        client.clone(),
+        on_demand.clone(),
+    ));
 
-	let grandpa_block_import = grandpa::light_block_import(
-		client.clone(), backend.clone(), &(client.clone() as Arc<_>),
-		Arc::new(on_demand.checker().clone()),
-	)?;
+    let grandpa_block_import = grandpa::light_block_import(
+        client.clone(),
+        backend.clone(),
+        &(client.clone() as Arc<_>),
+        Arc::new(on_demand.checker().clone()),
+    )?;
 
-	let finality_proof_import = grandpa_block_import.clone();
-	let finality_proof_request_builder =
-		finality_proof_import.create_finality_proof_request_builder();
+    let finality_proof_import = grandpa_block_import.clone();
+    let finality_proof_request_builder =
+        finality_proof_import.create_finality_proof_request_builder();
 
-	let (babe_block_import, babe_link) = sc_consensus_babe::block_import(
-		sc_consensus_babe::Config::get_or_compute(&*client)?,
-		grandpa_block_import,
-		client.clone(),
-	)?;
+    let (babe_block_import, babe_link) = sc_consensus_babe::block_import(
+        sc_consensus_babe::Config::get_or_compute(&*client)?,
+        grandpa_block_import,
+        client.clone(),
+    )?;
 
-	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+    let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-	let import_queue = sc_consensus_babe::import_queue(
-		babe_link,
-		babe_block_import,
-		None,
-		Some(Box::new(finality_proof_import)),
-		client.clone(),
-		select_chain.clone(),
-		inherent_data_providers.clone(),
-		&task_manager.spawn_handle(),
-		config.prometheus_registry(),
-	)?;
+    let import_queue = sc_consensus_babe::import_queue(
+        babe_link,
+        babe_block_import,
+        None,
+        Some(Box::new(finality_proof_import)),
+        client.clone(),
+        select_chain.clone(),
+        inherent_data_providers.clone(),
+        &task_manager.spawn_handle(),
+        config.prometheus_registry(),
+        sp_consensus::NeverCanAuthor,
+    )?;
 
-	// GenesisAuthoritySetProvider is implemented for StorageAndProofProvider
-	let provider = client.clone() as Arc<dyn StorageAndProofProvider<_, _>>;
-	let finality_proof_provider =
-		Arc::new(GrandpaFinalityProofProvider::new(backend.clone(), provider));
+    let finality_proof_provider =
+        GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
 
-	let light_deps = node_rpc::LightDeps {
-		remote_blockchain: backend.remote_blockchain(),
-		fetcher: on_demand.clone(),
-		client: client.clone(),
-		pool: transaction_pool.clone(),
-	};
+    let (network, network_status_sinks, system_rpc_tx, network_starter) =
+        sc_service::build_network(sc_service::BuildNetworkParams {
+            config: &config,
+            client: client.clone(),
+            transaction_pool: transaction_pool.clone(),
+            spawn_handle: task_manager.spawn_handle(),
+            import_queue,
+            on_demand: Some(on_demand.clone()),
+            block_announce_validator_builder: None,
+            finality_proof_request_builder: Some(finality_proof_request_builder),
+            finality_proof_provider: Some(finality_proof_provider),
+        })?;
+    network_starter.start_network();
 
-	let rpc_extensions = node_rpc::create_light(light_deps);
+    if config.offchain_worker.enabled {
+        sc_service::build_offchain_workers(
+            &config,
+            backend.clone(),
+            task_manager.spawn_handle(),
+            client.clone(),
+            network.clone(),
+        );
+    }
 
-	let ServiceComponents { task_manager, rpc_handlers, network, .. } =
-		sc_service::build(sc_service::ServiceParams {
-			block_announce_validator_builder: None,
-			finality_proof_request_builder: Some(finality_proof_request_builder),
-			finality_proof_provider: Some(finality_proof_provider),
-			on_demand: Some(on_demand),
-			remote_blockchain: Some(backend.remote_blockchain()),
-			rpc_extensions_builder: Box::new(sc_service::NoopRpcExtensionBuilder(rpc_extensions)),
-			client: client.clone(),
-			transaction_pool: transaction_pool.clone(),
-			config, import_queue, keystore, backend, task_manager,
-		})?;
+    let light_deps = node_rpc::LightDeps {
+        remote_blockchain: backend.remote_blockchain(),
+        fetcher: on_demand.clone(),
+        client: client.clone(),
+        pool: transaction_pool.clone(),
+    };
 
-    Ok((task_manager, rpc_handlers, client, network, transaction_pool))
+    let rpc_extensions = node_rpc::create_light(light_deps);
+
+    let rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+        on_demand: Some(on_demand),
+        remote_blockchain: Some(backend.remote_blockchain()),
+        rpc_extensions_builder: Box::new(sc_service::NoopRpcExtensionBuilder(rpc_extensions)),
+        client: client.clone(),
+        transaction_pool: transaction_pool.clone(),
+        config,
+        keystore,
+        backend,
+        network_status_sinks,
+        system_rpc_tx,
+        network: network.clone(),
+        telemetry_connection_sinks: sc_service::TelemetryConnectionSinks::default(),
+        task_manager: &mut task_manager,
+    })?;
+
+    Ok((
+        task_manager,
+        rpc_handlers,
+        client,
+        network,
+        transaction_pool,
+    ))
 }
 
 /// Create a new Polymesh service for a light client.

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,32 +2,36 @@
 
 pub use crate::chain_spec::{AlcyoneChainSpec, GeneralChainSpec};
 pub use codec::Codec;
-use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 pub use pallet_confidential::native_rng;
 pub use polymesh_primitives::{
     AccountId, Balance, Block, BlockNumber, Hash, IdentityId, Index as Nonce, Moment, SecondaryKey,
     Signatory, Ticker,
 };
-
+use sc_client_api::ExecutorProvider;
+use grandpa::{FinalityProofProvider as GrandpaFinalityProofProvider, StorageAndProofProvider};
 pub use polymesh_runtime_develop;
 pub use polymesh_runtime_testnet;
 use prometheus_endpoint::Registry;
-pub use sc_client_api::backend::Backend;
+pub use sc_client_api::{RemoteBackend, backend::Backend};
 pub use sc_consensus::LongestChain;
 use sc_executor::native_executor_instance;
 pub use sc_executor::{NativeExecutionDispatch, NativeExecutor};
 pub use sc_service::{
-    config::{DatabaseConfig, PrometheusConfig},
+    config::{Role, DatabaseConfig, PrometheusConfig},
     error::Error as ServiceError,
-    AbstractService, ChainSpec, Configuration, Error, PruningMode, RuntimeGenesis, ServiceBuilder,
-    ServiceBuilderCommand, TFullBackend, TFullCallExecutor, TFullClient, TLightBackend,
+    ChainSpec, Configuration, Error, PruningMode, RuntimeGenesis,
+    TFullBackend, TFullCallExecutor, TFullClient, TLightBackend,
     TLightCallExecutor, TLightClient, TransactionPoolOptions,
 };
 pub use sp_api::{ConstructRuntimeApi, Core as CoreApi, ProvideRuntimeApi, StateBackend};
 pub use sp_consensus::SelectChain;
 use sp_inherents::InherentDataProviders;
 pub use sp_runtime::traits::BlakeTwo256;
-use std::{convert::From, sync::Arc};
+use std::sync::Arc;
+use sc_network::{Event, NetworkService};
+use sc_service::{TaskManager, RpcHandlers, ServiceComponents};
+use sp_core::traits::BareCryptoStorePtr;
+use sp_runtime::traits::Block as BlockT;
 
 pub trait IsAlcyoneNetwork {
     fn is_alcyone_network(&self) -> bool;
@@ -135,472 +139,476 @@ fn set_prometheus_registry(config: &mut Configuration) -> Result<(), ServiceErro
     Ok(())
 }
 
-/// Starts a `ServiceBuilder` for a full service.
-///
-/// Use this macro if you don't actually need the full service, but just the builder in order to
-/// be able to perform chain operations.
-macro_rules! new_full_start {
-    ($config:expr, $runtime:ty, $executor:ty) => {{
-        use std::sync::Arc;
+use polymesh_node_rpc as node_rpc;
 
-        set_prometheus_registry(&mut $config)?;
+type BabeLink = sc_consensus_babe::BabeLink<Block>;
+type IoHandler = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 
-        let mut import_setup = None;
-        let mut rpc_setup = None;
-        let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+type FullLinkHalf<R, D> = grandpa::LinkHalf<Block, FullClient<R, D>, FullSelectChain>;
+type FullClient<R, E> = sc_service::TFullClient<Block, R, E>;
+type FullBackend = sc_service::TFullBackend<Block>;
+type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
+type FullGrandpaBlockImport<R, E> = grandpa::GrandpaBlockImport<FullBackend, Block, FullClient<R, E>, FullSelectChain>;
+type FullBabeImportQueue<R, E> = sc_consensus_babe::BabeImportQueue<Block, FullClient<R, E>>;
+type FullStateBackend = sc_client_api::StateBackendFor<FullBackend, Block>;
+type FullPool<R, E> = sc_transaction_pool::FullPool<Block, FullClient<R, E>>;
+type FullServiceParams<R, E> = sc_service::ServiceParams<
+    Block,
+    FullClient<R, E>,
+    FullBabeImportQueue<R, E>,
+    FullPool<R, E>,
+    IoHandler,
+    FullBackend,
+>;
+type FullBabeBlockImport<R, E> = sc_consensus_babe::BabeBlockImport<
+    Block,
+    FullClient<R, E>,
+    FullGrandpaBlockImport<R, E>,
+>;
 
-        let builder = sc_service::ServiceBuilder::new_full::<
-            polymesh_primitives::Block,
-            $runtime,
-            $executor,
-        >($config)?
-        .with_select_chain(|_config, backend| Ok(sc_consensus::LongestChain::new(backend.clone())))?
-        .with_transaction_pool(|builder| {
-            let pool_api = sc_transaction_pool::FullChainApi::new(builder.client().clone());
-            let pool = sc_transaction_pool::BasicPool::new(
-                builder.config().transaction_pool.clone(),
-                std::sync::Arc::new(pool_api),
-                builder.prometheus_registry(),
-            );
-            Ok(pool)
-        })?
-        .with_import_queue(
-            |_config, client, mut select_chain, _, spawn_task_handle, registry| {
-                let select_chain = select_chain
-                    .take()
-                    .ok_or_else(|| sc_service::Error::SelectChainRequired)?;
-                let (grandpa_block_import, grandpa_link) = grandpa::block_import(
-                    client.clone(),
-                    &(client.clone() as Arc<_>),
-                    select_chain,
-                )?;
-
-                let justification_import = grandpa_block_import.clone();
-
-                let (block_import, babe_link) = sc_consensus_babe::block_import(
-                    sc_consensus_babe::Config::get_or_compute(&*client)?,
-                    grandpa_block_import,
-                    client.clone(),
-                )?;
-
-                let import_queue = sc_consensus_babe::import_queue(
-                    babe_link.clone(),
-                    block_import.clone(),
-                    Some(Box::new(justification_import)),
-                    None,
-                    client,
-                    inherent_data_providers.clone(),
-                    spawn_task_handle,
-                    registry,
-                )?;
-
-                import_setup = Some((block_import, grandpa_link, babe_link));
-                Ok(import_queue)
-            },
-        )?
-        .with_rpc_extensions_builder(|builder| {
-            let grandpa_link = import_setup
-                .as_ref()
-                .map(|s| &s.1)
-                .expect("GRANDPA LinkHalf is present for full services or set up failed; qed.");
-
-            let shared_authority_set = grandpa_link.shared_authority_set().clone();
-            let shared_voter_state = grandpa::SharedVoterState::empty();
-
-            rpc_setup = Some((shared_voter_state.clone()));
-
-            let babe_link = import_setup
-                .as_ref()
-                .map(|s| &s.2)
-                .expect("BabeLink is present for full services or set up failed; qed.");
-
-            let babe_config = babe_link.config().clone();
-            let shared_epoch_changes = babe_link.epoch_changes().clone();
-
-            let client = builder.client().clone();
-            let pool = builder.pool().clone();
-            let select_chain = builder
-                .select_chain()
-                .cloned()
-                .expect("SelectChain is present for full services or set up failed; qed.");
-            let keystore = builder.keystore().clone();
-
-            Ok(move |deny_unsafe| {
-                let deps = polymesh_node_rpc::FullDeps {
-                    client: client.clone(),
-                    pool: pool.clone(),
-                    select_chain: select_chain.clone(),
-                    deny_unsafe,
-                    babe: polymesh_node_rpc::BabeDeps {
-                        babe_config: babe_config.clone(),
-                        shared_epoch_changes: shared_epoch_changes.clone(),
-                        keystore: keystore.clone(),
-                    },
-                    grandpa: polymesh_node_rpc::GrandpaDeps {
-                        shared_voter_state: shared_voter_state.clone(),
-                        shared_authority_set: shared_authority_set.clone(),
-                    },
-                };
-
-                polymesh_node_rpc::create_full(deps)
-            })
-        })?;
-
-        (builder, import_setup, inherent_data_providers, rpc_setup)
-    }};
-}
-
-/// Builds a new service for a full client.
-#[macro_export]
-macro_rules! new_full {
+pub fn new_full_params<R, D, E>(
+    config: Configuration,
+) -> Result<
     (
-        $config:expr,
-        $runtime:ty,
-        $dispatch:ty,
-    ) => {{
-        use sc_network::Event;
-        use sc_client_api::ExecutorProvider;
-        use futures::stream::StreamExt;
-        use sp_core::traits::BareCryptoStorePtr;
+        FullServiceParams<R, D>,
+        (FullBabeBlockImport<R, D>, FullLinkHalf<R, D>, BabeLink),
+        grandpa::SharedVoterState,
+        FullSelectChain,
+        InherentDataProviders,
+    ),
+    ServiceError,
+>
+where
+    R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
+    R::RuntimeApi: RuntimeApiCollection<E, StateBackend = FullStateBackend>,
+    D: NativeExecutionDispatch + 'static,
+    E: RuntimeExtrinsic,
+{
+    let (client, backend, keystore, task_manager) =
+        sc_service::new_full_parts::<Block, R, D>(&config)?;
+    let client = Arc::new(client);
 
+    let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-        let (
-            role,
-            force_authoring,
-            name,
-            disable_grandpa,
-        ) = (
-            $config.role.clone(),
-            $config.force_authoring,
-            $config.network.node_name.clone(),
-            $config.disable_grandpa,
-        );
+    let pool_api =
+        sc_transaction_pool::FullChainApi::new(client.clone(), config.prometheus_registry());
+    let transaction_pool = sc_transaction_pool::BasicPool::new_full(
+        config.transaction_pool.clone(),
+        std::sync::Arc::new(pool_api),
+        config.prometheus_registry(),
+        task_manager.spawn_handle(),
+        client.clone(),
+    );
 
-        let _is_authority = role.is_authority();
-        let _db_path = match $config.database.path() {
-            Some(path) => std::path::PathBuf::from(path),
-            None => return Err("Starting a Polkadot service with a custom database isn't supported".to_string().into()),
-        };
-        //let authority_discovery_enabled = $authority_discovery_enabled;
-        //let slot_duration = $slot_duration;
+    let (grandpa_block_import, grandpa_link) = grandpa::block_import(
+        client.clone(),
+        &(client.clone() as Arc<_>),
+        select_chain.clone(),
+    )?;
+    let justification_import = grandpa_block_import.clone();
 
-        let (builder, mut import_setup, inherent_data_providers, mut rpc_setup) =
-            new_full_start!($config, $runtime, $dispatch);
+    let (block_import, babe_link) = sc_consensus_babe::block_import(
+        sc_consensus_babe::Config::get_or_compute(&*client)?,
+        grandpa_block_import,
+        client.clone(),
+    )?;
 
-        let service = builder
-            .with_finality_proof_provider(|client, backend| {
-                let provider = client as Arc<dyn grandpa::StorageAndProofProvider<_, _>>;
-                Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, provider)) as _)
-            })?
-            .build_full()?;
+    let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-        let (block_import, grandpa_link, babe_link) = import_setup.take()
-            .expect("Link Half and Block Import are present for Full Services or setup failed before. qed");
+    let import_queue = sc_consensus_babe::import_queue(
+        babe_link.clone(),
+        block_import.clone(),
+        Some(Box::new(justification_import)),
+        None,
+        client.clone(),
+        select_chain.clone(),
+        inherent_data_providers.clone(),
+        &task_manager.spawn_handle(),
+        config.prometheus_registry(),
+    )?;
 
-        let shared_voter_state = rpc_setup.take()
-            .expect("The SharedVoterState is present for Full Services or setup failed before. qed");
+    let import_setup = (block_import, grandpa_link, babe_link);
 
-            if let sc_service::config::Role::Authority { .. } = &role {
-                let proposer = sc_basic_authorship::ProposerFactory::new(
-                    service.client(),
-                    service.transaction_pool(),
-                    service.prometheus_registry().as_ref(),
-                );
+    let (rpc_extensions_builder, rpc_setup) = {
+        let (_, grandpa_link, babe_link) = &import_setup;
 
-                let client = service.client();
-                let select_chain = service.select_chain()
-                    .ok_or(sc_service::Error::SelectChainRequired)?;
+        let shared_authority_set = grandpa_link.shared_authority_set().clone();
+        let shared_voter_state = grandpa::SharedVoterState::empty();
 
-                let can_author_with =
-                    sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+        let rpc_setup = shared_voter_state.clone();
 
-                let babe_config = sc_consensus_babe::BabeParams {
-                    keystore: service.keystore(),
-                    client,
-                    select_chain,
-                    env: proposer,
-                    block_import,
-                    sync_oracle: service.network(),
-                    inherent_data_providers: inherent_data_providers.clone(),
-                    force_authoring,
-                    babe_link,
-                    can_author_with,
-                };
+        let babe_config = babe_link.config().clone();
+        let shared_epoch_changes = babe_link.epoch_changes().clone();
 
-                let babe = sc_consensus_babe::start_babe(babe_config)?;
-                service.spawn_essential_task_handle().spawn_blocking("babe-proposer", babe);
-            }
+        let client = client.clone();
+        let pool = transaction_pool.clone();
+        let select_chain = select_chain.clone();
+        let keystore = keystore.clone();
 
-            // Spawn authority discovery module.
-            if matches!(role, sc_service::config::Role::Authority{..} | sc_service::config::Role::Sentry {..}) {
-                let (sentries, authority_discovery_role) = match role {
-                    sc_service::config::Role::Authority { ref sentry_nodes } => (
-                        sentry_nodes.clone(),
-                        sc_authority_discovery::Role::Authority (
-                            service.keystore(),
-                        ),
-                    ),
-                    sc_service::config::Role::Sentry {..} => (
-                        vec![],
-                        sc_authority_discovery::Role::Sentry,
-                    ),
-                    _ => unreachable!("Due to outer matches! constraint; qed.")
-                };
-
-                let network = service.network();
-                let dht_event_stream = network.event_stream("authority-discovery").filter_map(|e| async move { match e {
-                    Event::Dht(e) => Some(e),
-                    _ => None,
-                }}).boxed();
-                let authority_discovery = sc_authority_discovery::AuthorityDiscovery::new(
-                    service.client(),
-                    network,
-                    sentries,
-                    dht_event_stream,
-                    authority_discovery_role,
-                    service.prometheus_registry(),
-                );
-
-                service.spawn_task_handle().spawn("authority-discovery", authority_discovery);
-            }
-
-            // if the node isn't actively participating in consensus then it doesn't
-            // need a keystore, regardless of which protocol we use below.
-            let keystore = if role.is_authority() {
-                Some(service.keystore() as BareCryptoStorePtr)
-            } else {
-                None
+        let rpc_extensions_builder = Box::new(move |deny_unsafe| {
+            let deps = node_rpc::FullDeps {
+                client: client.clone(),
+                pool: pool.clone(),
+                select_chain: select_chain.clone(),
+                deny_unsafe,
+                babe: node_rpc::BabeDeps {
+                    babe_config: babe_config.clone(),
+                    shared_epoch_changes: shared_epoch_changes.clone(),
+                    keystore: keystore.clone(),
+                },
+                grandpa: node_rpc::GrandpaDeps {
+                    shared_voter_state: shared_voter_state.clone(),
+                    shared_authority_set: shared_authority_set.clone(),
+                },
             };
 
-            let config = grandpa::Config {
-                // FIXME #1578 make this available through chainspec
-                gossip_duration: std::time::Duration::from_millis(333),
-                justification_period: 512,
-                name: Some(name),
-                observer_enabled: false,
-                keystore,
-                is_authority: role.is_network_authority(),
-            };
+            node_rpc::create_full(deps)
+        });
 
-            let enable_grandpa = !disable_grandpa;
-            if enable_grandpa {
-                // start the full GRANDPA voter
-                // NOTE: non-authorities could run the GRANDPA observer protocol, but at
-                // this point the full voter should provide better guarantees of block
-                // and vote data availability than the observer. The observer has not
-                // been tested extensively yet and having most nodes in a network run it
-                // could lead to finality stalls.
-                let grandpa_config = grandpa::GrandpaParams {
-                    config,
-                    link: grandpa_link,
-                    network: service.network(),
-                    inherent_data_providers: inherent_data_providers.clone(),
-                    telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
-                    voting_rule: grandpa::VotingRulesBuilder::default().build(),
-                    prometheus_registry: service.prometheus_registry(),
-                    shared_voter_state,
-                };
+        (rpc_extensions_builder, rpc_setup)
+    };
 
-                // the GRANDPA voter task is considered infallible, i.e.
-                // if it fails we take down the service with it.
-                service.spawn_essential_task_handle().spawn_blocking(
-                    "grandpa-voter",
-                    grandpa::run_grandpa_voter(grandpa_config)?
-                );
-            } else {
-                grandpa::setup_disabled_grandpa(
-                    service.client(),
-                    &inherent_data_providers,
-                    service.network(),
-                )?;
-            }
+    let provider = client.clone() as Arc<dyn grandpa::StorageAndProofProvider<_, _>>;
+    let finality_proof_provider = Arc::new(grandpa::FinalityProofProvider::new(
+        backend.clone(),
+        provider,
+    ));
 
-            Ok((service, inherent_data_providers))
-        }};
+    let params = sc_service::ServiceParams {
+        config,
+        backend,
+        client,
+        import_queue,
+        keystore,
+        task_manager,
+        rpc_extensions_builder,
+        transaction_pool,
+        block_announce_validator_builder: None,
+        finality_proof_request_builder: None,
+        finality_proof_provider: Some(finality_proof_provider),
+        on_demand: None,
+        remote_blockchain: None,
+    };
+
+    Ok((
+        params,
+        import_setup,
+        rpc_setup,
+        select_chain,
+        inherent_data_providers,
+    ))
 }
+
+/// Creates a full service from the configuration.
+pub fn new_full_base<R, D, E, F>(
+	mut config: Configuration,
+	with_startup_data: F,
+) -> Result<(
+	TaskManager, InherentDataProviders, Arc<FullClient<R, D>>,
+	Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+	Arc<FullPool<R, D>>,
+), ServiceError>
+where
+    F: FnOnce(&FullBabeBlockImport<R, D>, &BabeLink),
+    R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
+    R::RuntimeApi: RuntimeApiCollection<E, StateBackend = FullStateBackend>,
+    D: NativeExecutionDispatch + 'static,
+    E: RuntimeExtrinsic,
+{
+    set_prometheus_registry(&mut config)?;
+
+	let (params, import_setup, rpc_setup, select_chain, inherent_data_providers)
+		= new_full_params(config)?;
+
+	let (
+		role, force_authoring, name, enable_grandpa, prometheus_registry,
+		client, transaction_pool, keystore,
+	) = {
+		let sc_service::ServiceParams {
+			config, client, transaction_pool, keystore, ..
+		} = &params;
+
+		(
+			config.role.clone(),
+			config.force_authoring,
+			config.network.node_name.clone(),
+			!config.disable_grandpa,
+			config.prometheus_registry().cloned(),
+
+			client.clone(), transaction_pool.clone(), keystore.clone(),
+		)
+	};
+
+	let ServiceComponents {
+		task_manager, network, telemetry_on_connect_sinks, ..
+	} = sc_service::build(params)?;
+
+	let (block_import, grandpa_link, babe_link) = import_setup;
+	let shared_voter_state = rpc_setup;
+
+	(with_startup_data)(&block_import, &babe_link);
+
+	if let sc_service::config::Role::Authority { .. } = &role {
+		let proposer = sc_basic_authorship::ProposerFactory::new(
+			client.clone(),
+			transaction_pool.clone(),
+			prometheus_registry.as_ref(),
+		);
+
+		let can_author_with =
+			sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+
+		let babe_config = sc_consensus_babe::BabeParams {
+			keystore: keystore.clone(),
+			client: client.clone(),
+			select_chain,
+			env: proposer,
+			block_import,
+			sync_oracle: network.clone(),
+			inherent_data_providers: inherent_data_providers.clone(),
+			force_authoring,
+			babe_link,
+			can_author_with,
+		};
+
+		let babe = sc_consensus_babe::start_babe(babe_config)?;
+		task_manager.spawn_essential_handle().spawn_blocking("babe-proposer", babe);
+	}
+
+	// Spawn authority discovery module.
+	if matches!(role, Role::Authority{..} | Role::Sentry {..}) {
+		let (sentries, authority_discovery_role) = match role {
+			sc_service::config::Role::Authority { ref sentry_nodes } => (
+				sentry_nodes.clone(),
+				sc_authority_discovery::Role::Authority (
+					keystore.clone(),
+				),
+			),
+			sc_service::config::Role::Sentry {..} => (
+				vec![],
+				sc_authority_discovery::Role::Sentry,
+			),
+			_ => unreachable!("Due to outer matches! constraint; qed.")
+        };
+
+        use futures::stream::StreamExt;
+		let dht_event_stream = network.event_stream("authority-discovery")
+			.filter_map(|e| async move { match e {
+				Event::Dht(e) => Some(e),
+				_ => None,
+			}}).boxed();
+		let authority_discovery = sc_authority_discovery::AuthorityDiscovery::new(
+			client.clone(),
+			network.clone(),
+			sentries,
+			dht_event_stream,
+			authority_discovery_role,
+			prometheus_registry.clone(),
+		);
+
+		task_manager.spawn_handle().spawn("authority-discovery", authority_discovery);
+	}
+
+	// if the node isn't actively participating in consensus then it doesn't
+	// need a keystore, regardless of which protocol we use below.
+	let keystore = if role.is_authority() {
+		Some(keystore as BareCryptoStorePtr)
+	} else {
+		None
+	};
+
+	let config = grandpa::Config {
+		// FIXME #1578 make this available through chainspec
+		gossip_duration: std::time::Duration::from_millis(333),
+		justification_period: 512,
+		name: Some(name),
+		observer_enabled: false,
+		keystore,
+		is_authority: role.is_network_authority(),
+	};
+
+	if enable_grandpa {
+		// start the full GRANDPA voter
+		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
+		// this point the full voter should provide better guarantees of block
+		// and vote data availability than the observer. The observer has not
+		// been tested extensively yet and having most nodes in a network run it
+		// could lead to finality stalls.
+		let grandpa_config = grandpa::GrandpaParams {
+			config,
+			link: grandpa_link,
+			network: network.clone(),
+			inherent_data_providers: inherent_data_providers.clone(),
+			telemetry_on_connect: Some(telemetry_on_connect_sinks.on_connect_stream()),
+			voting_rule: grandpa::VotingRulesBuilder::default().build(),
+			prometheus_registry,
+			shared_voter_state,
+		};
+
+		// the GRANDPA voter task is considered infallible, i.e.
+		// if it fails we take down the service with it.
+		task_manager.spawn_essential_handle().spawn_blocking(
+			"grandpa-voter",
+			grandpa::run_grandpa_voter(grandpa_config)?
+		);
+	} else {
+		grandpa::setup_disabled_grandpa(
+			client.clone(),
+			&inherent_data_providers,
+			network.clone(),
+		)?;
+	}
+
+	Ok((task_manager, inherent_data_providers, client, network, transaction_pool))
+}
+
+type TaskResult = Result<TaskManager, ServiceError>;
 
 /// Create a new Alcyone service for a full node.
-pub fn alcyone_new_full(
-    mut config: Configuration,
-) -> Result<
-    impl AbstractService<
-        Block = Block,
-        RuntimeApi = polymesh_runtime_testnet::RuntimeApi,
-        Backend = TFullBackend<Block>,
-    >,
-    ServiceError,
-> {
-    new_full!(
-        config,
+pub fn alcyone_new_full(config: Configuration) -> TaskResult {
+    new_full_base::<
         polymesh_runtime_testnet::RuntimeApi,
         AlcyoneExecutor,
-    )
-    .map(|(service, _)| service)
+        _,
+        _,
+    >(config, |_, _| ()).map(|(task_manager, _, _, _, _)| {
+		task_manager
+    })
 }
 
 /// Create a new General node service for a full node.
-pub fn general_new_full(
-    mut config: Configuration,
-) -> Result<
-    impl AbstractService<
-        Block = Block,
-        RuntimeApi = polymesh_runtime_develop::RuntimeApi,
-        Backend = TFullBackend<Block>,
-    >,
-    ServiceError,
-> {
-    new_full!(
-        config,
+pub fn general_new_full(config: Configuration) -> TaskResult {
+    new_full_base::<
         polymesh_runtime_develop::RuntimeApi,
         GeneralExecutor,
-    )
-    .map(|(service, _)| service)
+        _,
+        _,
+    >(config, |_, _| ()).map(|(task_manager, _, _, _, _)| {
+		task_manager
+    })
 }
 
 /// Builds a new object suitable for chain operations.
-pub fn chain_ops<Runtime, Dispatch, Extrinsic>(
+pub fn chain_ops<R, D, E>(
     mut config: Configuration,
-) -> Result<impl ServiceBuilderCommand<Block = Block>, ServiceError>
+) -> Result<(Arc<FullClient<R, D>>, Arc<FullBackend>, FullBabeImportQueue<R, D>, TaskManager), ServiceError>
 where
-    Runtime:
-        ConstructRuntimeApi<Block, TFullClient<Block, Runtime, Dispatch>> + Send + Sync + 'static,
-    Runtime::RuntimeApi: RuntimeApiCollection<
-        Extrinsic,
-        StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
-    >,
-    Dispatch: NativeExecutionDispatch + 'static,
-    Extrinsic: RuntimeExtrinsic,
-    <Runtime::RuntimeApi as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    R: ConstructRuntimeApi<Block, FullClient<R, D>> + Send + Sync + 'static,
+    R::RuntimeApi: RuntimeApiCollection<E, StateBackend = FullStateBackend>,
+    D: NativeExecutionDispatch + 'static,
+    E: RuntimeExtrinsic,
 {
     config.keystore = sc_service::config::KeystoreConfig::InMemory;
-    Ok(new_full_start!(config, Runtime, Dispatch).0)
+    let (FullServiceParams { client, backend, import_queue, task_manager, .. }, ..)
+        = new_full_params::<R, D, E>(config)?;
+    Ok((client, backend, import_queue, task_manager))
 }
 
-/// Builds a new service for a light client.
-#[macro_export]
-macro_rules! new_light {
-    ($config:expr, $runtime:ty, $dispatch:ty) => {{
-        set_prometheus_registry(&mut $config)?;
-        let inherent_data_providers = InherentDataProviders::new();
+type LightStorage = sc_client_db::light::LightStorage<Block>;
+type LightBackend = sc_light::backend::Backend<LightStorage, polymesh_primitives::BlakeTwo256>;
+type LightClient<R, E> = sc_service::TLightClient<Block, R, E>;
+type LightStateBackend = sc_client_api::StateBackendFor<LightBackend, Block>;
+type LightPool<R, E> = sc_transaction_pool::LightPool<Block, LightClient<R, E>, sc_network::config::OnDemand<Block>>;
 
-        ServiceBuilder::new_light::<Block, $runtime, $dispatch>($config)?
-            .with_select_chain(|_, backend| {
-                Ok(sc_consensus::LongestChain::new(backend.clone()))
-            })?
-            .with_transaction_pool(|builder| {
-                let fetcher = builder.fetcher()
-                    .ok_or_else(|| "Trying to start light transaction pool without active fetcher")?;
-                let pool_api = sc_transaction_pool::LightChainApi::new(
-                    builder.client().clone(),
-                    fetcher,
-                );
-                let pool = sc_transaction_pool::BasicPool::with_revalidation_type(
-                    builder.config().transaction_pool.clone(),
-                    Arc::new(pool_api),
-                    builder.prometheus_registry(),
-                    sc_transaction_pool::RevalidationType::Light,
-                );
-                Ok(pool)
-            })?
-            .with_import_queue_and_fprb(|
-                _config,
-                client,
-                backend,
-                fetcher,
-                _select_chain,
-                _,
-                spawn_task_handle,
-                registry,
-            | {
-                let fetch_checker = fetcher
-                    .map(|fetcher| fetcher.checker().clone())
-                    .ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-                let grandpa_block_import = grandpa::light_block_import(
-                    client.clone(), backend, &(client.clone() as Arc<_>), Arc::new(fetch_checker)
-                )?;
+pub fn new_light_base<R, D, E>(config: Configuration) -> Result<(
+	TaskManager, Arc<RpcHandlers>, Arc<LightClient<R, D>>,
+	Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+	Arc<LightPool<R, D>>,
+), ServiceError>
+where
+    //R: ConstructRuntimeApi<Block, LightClient<R, D>> +
+    R::RuntimeApi: RuntimeApiCollection<E, StateBackend = LightStateBackend>,
+    D: NativeExecutionDispatch + 'static,
+    E: RuntimeExtrinsic,
+    //<R::RuntimeApi as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    R: Send + Sync + 'static + sp_api::ConstructRuntimeApi<
+        Block,
+        sc_service::TLightClientWithBackend<Block, R, D, LightBackend>,
+    >,
+{
+	let (client, backend, keystore, task_manager, on_demand) =
+		sc_service::new_light_parts::<Block, R, D>(&config)?;
 
-                let finality_proof_import = grandpa_block_import.clone();
-                let finality_proof_request_builder =
-                    finality_proof_import.create_finality_proof_request_builder();
+	let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-                let (babe_block_import, babe_link) = sc_consensus_babe::block_import(
-                    sc_consensus_babe::Config::get_or_compute(&*client)?,
-                    grandpa_block_import,
-                    client.clone(),
-                )?;
+	let transaction_pool_api = Arc::new(sc_transaction_pool::LightChainApi::new(
+		client.clone(),
+		on_demand.clone(),
+	));
+	let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
+		config.transaction_pool.clone(),
+		transaction_pool_api,
+		config.prometheus_registry(),
+		task_manager.spawn_handle(),
+	));
 
-                // FIXME: pruning task isn't started since light client doesn't do `AuthoritySetup`.
-                let import_queue = sc_consensus_babe::import_queue(
-                    babe_link,
-                    babe_block_import,
-                    None,
-                    Some(Box::new(finality_proof_import)),
-                    client,
-                    inherent_data_providers.clone(),
-                    spawn_task_handle,
-                    registry,
-                )?;
+	let grandpa_block_import = grandpa::light_block_import(
+		client.clone(), backend.clone(), &(client.clone() as Arc<_>),
+		Arc::new(on_demand.checker().clone()),
+	)?;
 
-                Ok((import_queue, finality_proof_request_builder))
-            })?
-            .with_finality_proof_provider(|client, backend| {
-                let provider = client as Arc<dyn grandpa::StorageAndProofProvider<_, _>>;
-                Ok(Arc::new(grandpa::FinalityProofProvider::new(backend, provider)) as _)
-            })?
-            .with_rpc_extensions(|builder| {
-                let fetcher = builder.fetcher()
-                    .ok_or_else(|| "Trying to start node RPC without active fetcher")?;
-                let remote_blockchain = builder.remote_backend()
-                    .ok_or_else(|| "Trying to start node RPC without active remote blockchain")?;
+	let finality_proof_import = grandpa_block_import.clone();
+	let finality_proof_request_builder =
+		finality_proof_import.create_finality_proof_request_builder();
 
-                let light_deps = polymesh_node_rpc::LightDeps {
-                    remote_blockchain,
-                    fetcher,
-                    client: builder.client().clone(),
-                    pool: builder.pool(),
-                };
-                Ok(polymesh_node_rpc::create_light(light_deps))
-            })?
-            .build_light()
-    }}
+	let (babe_block_import, babe_link) = sc_consensus_babe::block_import(
+		sc_consensus_babe::Config::get_or_compute(&*client)?,
+		grandpa_block_import,
+		client.clone(),
+	)?;
+
+	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+
+	let import_queue = sc_consensus_babe::import_queue(
+		babe_link,
+		babe_block_import,
+		None,
+		Some(Box::new(finality_proof_import)),
+		client.clone(),
+		select_chain.clone(),
+		inherent_data_providers.clone(),
+		&task_manager.spawn_handle(),
+		config.prometheus_registry(),
+	)?;
+
+	// GenesisAuthoritySetProvider is implemented for StorageAndProofProvider
+	let provider = client.clone() as Arc<dyn StorageAndProofProvider<_, _>>;
+	let finality_proof_provider =
+		Arc::new(GrandpaFinalityProofProvider::new(backend.clone(), provider));
+
+	let light_deps = node_rpc::LightDeps {
+		remote_blockchain: backend.remote_blockchain(),
+		fetcher: on_demand.clone(),
+		client: client.clone(),
+		pool: transaction_pool.clone(),
+	};
+
+	let rpc_extensions = node_rpc::create_light(light_deps);
+
+	let ServiceComponents { task_manager, rpc_handlers, network, .. } =
+		sc_service::build(sc_service::ServiceParams {
+			block_announce_validator_builder: None,
+			finality_proof_request_builder: Some(finality_proof_request_builder),
+			finality_proof_provider: Some(finality_proof_provider),
+			on_demand: Some(on_demand),
+			remote_blockchain: Some(backend.remote_blockchain()),
+			rpc_extensions_builder: Box::new(sc_service::NoopRpcExtensionBuilder(rpc_extensions)),
+			client: client.clone(),
+			transaction_pool: transaction_pool.clone(),
+			config, import_queue, keystore, backend, task_manager,
+		})?;
+
+    Ok((task_manager, rpc_handlers, client, network, transaction_pool))
 }
 
 /// Create a new Polymesh service for a light client.
-pub fn alcyone_new_light(
-    mut config: Configuration,
-) -> Result<
-    impl AbstractService<
-        Block = Block,
-        RuntimeApi = polymesh_runtime_testnet::RuntimeApi,
-        Backend = TLightBackend<Block>,
-        SelectChain = LongestChain<TLightBackend<Block>, Block>,
-        CallExecutor = TLightCallExecutor<Block, AlcyoneExecutor>,
-    >,
-    ServiceError,
-> {
-    new_light!(
-        config,
-        polymesh_runtime_testnet::RuntimeApi,
-        AlcyoneExecutor
-    )
+pub fn alcyone_new_light(config: Configuration) -> TaskResult {
+    new_light_base::<polymesh_runtime_testnet::RuntimeApi, AlcyoneExecutor, _>(config)
+        .map(|(task_manager, _, _, _, _)| task_manager)
 }
 
 /// Create a new Polymesh service for a light client.
-pub fn general_new_light(
-    mut config: Configuration,
-) -> Result<
-    impl AbstractService<
-        Block = Block,
-        RuntimeApi = polymesh_runtime_develop::RuntimeApi,
-        Backend = TLightBackend<Block>,
-        SelectChain = LongestChain<TLightBackend<Block>, Block>,
-        CallExecutor = TLightCallExecutor<Block, GeneralExecutor>,
-    >,
-    ServiceError,
-> {
-    new_light!(
-        config,
-        polymesh_runtime_develop::RuntimeApi,
-        GeneralExecutor
-    )
+pub fn general_new_light(config: Configuration) -> TaskResult {
+    new_light_base::<polymesh_runtime_develop::RuntimeApi, GeneralExecutor, _>(config)
+        .map(|(task_manager, _, _, _, _)| task_manager)
 }


### PR DESCRIPTION
**Bumps our reference of substrate to rc5+2 in the first two commits and then further bumps to rc6.**

This PR intends to be minimal, only bumping cargo references and fixing the fallout that ensues.
Notably, it does not pull any code changes in substrate to our copied-in pallets.
Thereby, the potential for storage changes is reduced and code review is eased.
If we want to bump those pallets, we can do so incrementally, at our option.

**Review notes:**
- I recommend reviewing the whole PR at once, but separating cargo-side changes (`.lock`, `.toml`) from rust-side changes (`.rs`).

**TODO:**
- [x] ~Patch in `at-add-dispatch-call`.~ Decided per meeting to skip this.
    - [x] ~Update PRs for submodules.~
- [x] Review whether any storage changes slipped in. PR Range:
    - https://github.com/paritytech/substrate/pulls?q=is%3Apr+is%3Amerged+label%3AB7-runtimenoteworthy+merged%3A2020-06-25..2020-08-21