### PR TITLE
MESH-1252 & MESH-1253

### DIFF
--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -491,8 +491,8 @@ decl_event!(
         /// (gc_did, pip_id, new_skip_count)
         PipSkipped(IdentityId, PipId, SkippedCount),
         /// Results (e.g., approved, rejected, and skipped), were enacted for some PIPs.
-        /// (gc_did, skipped_pips_with_new_count, rejected_pips, approved_pips)
-        SnapshotResultsEnacted(IdentityId, Vec<(PipId, SkippedCount)>, Vec<PipId>, Vec<PipId>),
+        /// (gc_did, snapshot_id_opt, skipped_pips_with_new_count, rejected_pips, approved_pips)
+        SnapshotResultsEnacted(IdentityId, Option<SnapshotId>, Vec<(PipId, SkippedCount)>, Vec<PipId>, Vec<PipId>),
     }
 );
 
@@ -1081,7 +1081,8 @@ decl_module! {
                     Self::schedule_pip_for_execution(GC_DID, pip_id);
                 }
 
-                let event = RawEvent::SnapshotResultsEnacted(GC_DID, to_bump_skipped, to_reject, to_approve);
+                let id = Self::snapshot_metadata().map(|m| m.id);
+                let event = RawEvent::SnapshotResultsEnacted(GC_DID, id, to_bump_skipped, to_reject, to_approve);
                 Self::deposit_event(event);
 
                 Ok(())

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -1852,6 +1852,10 @@ fn enact_snapshot_results_works() {
             root(),
             vec![(1, SnapshotResult::Approve)]
         ));
+        assert_last_event!(
+            Event::SnapshotResultsEnacted(_, Some(1), a, b, c),
+            a.is_empty() && b.is_empty() && c == &[1]
+        );
         assert_state(1, false, ProposalState::Scheduled);
         assert_eq!(Pips::snapshot_queue(), mk_queue(&[3]));
 
@@ -1859,7 +1863,7 @@ fn enact_snapshot_results_works() {
         assert_ok!(Pips::clear_snapshot(user.signer()));
         assert_ok!(Pips::enact_snapshot_results(root(), vec![]));
         assert_last_event!(
-            Event::SnapshotResultsEnacted(_, a, b, c),
+            Event::SnapshotResultsEnacted(_, None, a, b, c),
             a.is_empty() && b.is_empty() && c.is_empty()
         )
     });

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -17,8 +17,8 @@ use pallet_balances as balances;
 use pallet_committee as committee;
 use pallet_group as group;
 use pallet_pips::{
-    self as pips, DepositInfo, Pip, PipDescription, ProposalState, Proposer, RawEvent as Event,
-    SnapshotMetadata, SnapshotResult, SnapshottedPip, Url, Vote, VotingResult,
+    self as pips, DepositInfo, Pip, PipDescription, PipsMetadata, ProposalState, Proposer,
+    RawEvent as Event, SnapshotMetadata, SnapshotResult, SnapshottedPip, Url, Vote, VotingResult,
 };
 use pallet_treasury as treasury;
 use polymesh_common_utilities::pip::PipId;
@@ -494,7 +494,7 @@ fn assert_votes(id: PipId, owner: Public, amount: u128) {
 #[test]
 fn proposal_details_are_correct() {
     ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
+        System::set_block_number(42);
 
         let alice = User::new(AccountKeyring::Alice).balance(300);
 
@@ -525,10 +525,13 @@ fn proposal_details_are_correct() {
             System::block_number() + Pips::proposal_cool_off_period()
         );
 
-        let meta = Pips::proposal_metadata(0).unwrap();
-        assert_eq!(meta.id, 0);
-        assert_eq!(meta.url, Some(proposal_url));
-        assert_eq!(meta.description, Some(proposal_desc));
+        let expected = PipsMetadata {
+            id: 0,
+            created_at: 42,
+            url: Some(proposal_url),
+            description: Some(proposal_desc),
+        };
+        assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
 
         assert_balance(alice.acc(), 300, 60);
         assert_votes(0, alice.acc(), 60);
@@ -610,11 +613,20 @@ fn amend_proposal_works() {
         assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
         let signer = Origin::signed(AccountKeyring::Alice.public());
         let url = Some("https:://example.com".into());
-        let desc = Some("foo bar baz".into());
-        assert_ok!(Pips::amend_proposal(signer, 0, url.clone(), desc.clone()));
-        let meta = Pips::proposal_metadata(0).unwrap();
-        assert_eq!(meta.url, url);
-        assert_eq!(meta.description, desc);
+        let description = Some("foo bar baz".into());
+        assert_ok!(Pips::amend_proposal(
+            signer,
+            0,
+            url.clone(),
+            description.clone()
+        ));
+        let expected = PipsMetadata {
+            id: 0,
+            created_at: 1,
+            url,
+            description,
+        };
+        assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
     });
 }
 

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -503,7 +503,8 @@
         "PipsMetadata": {
             "id": "PipId",
             "url": "Option<Url>",
-            "description": "Option<PipDescription>"
+            "description": "Option<PipDescription>",
+            "created_at": "BlockNumber"
         },
         "Proposer": {
             "_enum": {


### PR DESCRIPTION
- MESH-1253: Add `created_at: BlockNumber` to `PipsMetadata`
- MESH-1252: Add `SnapshotId` to `SnapshotResultsEnacted`

As requested by @pabloruiz55.