### PR TITLE
MESH-1243: add `migrate::migrate_double_map_keys`

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -123,7 +123,7 @@ use frame_support::{
     ensure,
     traits::{ChangeMembers, Currency, InitializeMembers},
     weights::{DispatchClass, GetDispatchInfo, Pays, Weight},
-    Blake2_128Concat, ReversibleStorageHasher, StorageDoubleMap, StorageHasher,
+    Blake2_128Concat, StorageDoubleMap,
 };
 use frame_system::{self as system, ensure_root, ensure_signed};
 
@@ -258,33 +258,18 @@ decl_module! {
             // Rename "master" to "primary".
             <CddAuthForPrimaryKeyRotation>::put(<CddAuthForMasterKeyRotation>::take());
 
-            use polymesh_primitives::{identity_claim::IdentityClaimOld, migrate::migrate_map};
+            use polymesh_primitives::identity_claim::IdentityClaimOld;
+            use polymesh_primitives::migrate::{migrate_map, migrate_double_map_keys};
             migrate_map::<IdentityClaimOld>(b"Identity", b"Claims");
 
             // Covert old scopes to new scopes
-            use frame_support::migration::{StorageIterator, put_storage_value};
-            let old_map = StorageIterator::<IdentityClaim>::new(b"Identity", b"Claims")
-                .drain().
-                collect::<Vec<(Vec<u8>, IdentityClaim)>>();
-
-            for (raw_key, value) in old_map.iter() {
-                let mut unhashed_key = Blake2_128Concat::reverse(&raw_key);
-                if let Ok(k1) = Claim1stKey::decode(&mut unhashed_key) {
-                    let mut raw_k2 = Blake2_128Concat::reverse(unhashed_key);
-                    if let Ok(k2) = Claim2ndKeyOld::decode(&mut raw_k2) {
-                        let k2 = Claim2ndKey {
-                            issuer: k2.issuer,
-                            scope: k2.scope.map(|did| Scope::Identity(did)),
-                        };
-                        let mut k1_hashed = k1.using_encoded(Blake2_128Concat::hash);
-                        let mut k2_hashed = k2.using_encoded(Blake2_128Concat::hash);
-                        let mut key = Vec::new();
-                        key.append(&mut k1_hashed);
-                        key.append(&mut k2_hashed);
-                        put_storage_value(b"Identity", b"Claims", &key, value);
-                    }
-                }
-            }
+            migrate_double_map_keys::<IdentityClaim, Blake2_128Concat, _, _, _, _, _>(
+                b"Identity", b"Claims",
+                |k1: Claim1stKey, k2: Claim2ndKeyOld| (
+                    k1,
+                    Claim2ndKey { issuer: k2.issuer, scope: k2.scope.map(Scope::Identity) }
+                )
+            );
 
             // It's gonna be alot, so lets pretend its 0 anyways.
             0


### PR DESCRIPTION
This could be made more efficient by e.g., avoiding the decoding of `V`.
I've implemented the simpler idea for now though.

If we constrain `H` to `Blake2_128Concat` in a different function, then `_, _, _, _, _` will not be needed.