### PR TITLE
MESH-1262: Infer `Proposer<_>` from `origin` on `Pips::propose`.

### DIFF
--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -675,14 +675,13 @@ decl_module! {
         #[weight = (1_850_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn propose(
             origin,
-            proposer: Proposer<T::AccountId>,
             proposal: Box<T::Proposal>,
             deposit: BalanceOf<T>,
             url: Option<Url>,
             description: Option<PipDescription>,
         ) -> DispatchResult {
-            // 1. Ensure it's really the `proposer`.
-            Self::ensure_signed_by(origin, &proposer)?;
+            // 1. Infer the proposer from `origin`.
+            let proposer = Self::ensure_infer_proposer(origin)?;
 
             let did = Self::current_did_or_missing()?;
 
@@ -1153,27 +1152,27 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-    /// Ensure that `origin` represents a signed extrinsic (i.e. transaction)
-    /// and confirms that the account is the same as the given `proposer`.
+    /// Ensure that `origin` represents one of:
+    /// - a signed extrinsic (i.e. transaction), and infer the account id, as a community proposer.
+    /// - a committee, where the committee is also inferred.
     ///
-    /// For example, if `proposer` denotes a committee,
-    /// then `origin` is checked against the committee's origin.
+    /// Returns the inferred proposer.
     ///
     /// # Errors
-    /// * `BadOrigin` unless the checks above pass.
-    fn ensure_signed_by(origin: T::Origin, proposer: &Proposer<T::AccountId>) -> DispatchResult {
-        match proposer {
-            Proposer::Community(acc) => {
-                ensure!(acc == &ensure_signed(origin)?, DispatchError::BadOrigin)
-            }
-            Proposer::Committee(Committee::Technical) => {
-                T::TechnicalCommitteeVMO::ensure_origin(origin)?;
-            }
-            Proposer::Committee(Committee::Upgrade) => {
-                T::UpgradeCommitteeVMO::ensure_origin(origin)?;
-            }
-        }
-        Ok(())
+    /// * `BadOrigin` if not a signed extrinsic.
+    fn ensure_infer_proposer(
+        origin: T::Origin,
+    ) -> Result<Proposer<T::AccountId>, sp_runtime::traits::BadOrigin> {
+        ensure_signed(origin.clone())
+            .map(Proposer::Community)
+            .or_else(|_| {
+                T::TechnicalCommitteeVMO::ensure_origin(origin.clone())
+                    .map(|_| Committee::Technical)
+                    .or_else(|_| {
+                        T::UpgradeCommitteeVMO::ensure_origin(origin).map(|_| Committee::Upgrade)
+                    })
+                    .map(Proposer::Committee)
+            })
     }
 
     /// Returns the current identity or emits `MissingCurrentIdentity`.
@@ -1181,7 +1180,8 @@ impl<T: Trait> Module<T> {
         Context::current_identity::<Identity<T>>().ok_or_else(|| Error::<T>::MissingCurrentIdentity)
     }
 
-    /// Ensure that proposer is owner of the proposal which must be in the cool off period.
+    /// Ensure that the proposer inferred via `origin` is the owner of the proposal,
+    /// which must be in the cool off period.
     ///
     /// # Errors
     /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
@@ -1192,7 +1192,8 @@ impl<T: Trait> Module<T> {
     ) -> Result<Proposer<T::AccountId>, DispatchError> {
         // 1. Only owner can act on proposal.
         let pip = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-        Self::ensure_signed_by(origin, &pip.proposer)?;
+        let proposer = Self::ensure_infer_proposer(origin)?;
+        ensure!(proposer == pip.proposer, DispatchError::BadOrigin);
 
         // 2. Check that the proposal is pending.
         Self::is_proposal_state(id, ProposalState::Pending)?;

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    committee_test::{root, set_members},
+    committee_test::{gc_vmo, root, set_members},
     storage::{
         fast_forward_blocks, get_identity_id, register_keyring_account, Call, EventTest,
         TestStorage,
@@ -125,14 +125,7 @@ fn proposal(
     let before = Pips::pip_id_sequence();
     let active = Pips::active_pip_count();
     let signer = signer.clone();
-    let result = Pips::propose(
-        signer,
-        proposer.clone(),
-        Box::new(proposal),
-        deposit,
-        url,
-        desc,
-    );
+    let result = Pips::propose(signer, Box::new(proposal), deposit, url, desc);
     let add = result.map_or(0, |_| 1);
     if let Ok(_) = result {
         assert_last_event!(Event::ProposalCreated(_, _, id, ..), *id == before);
@@ -140,6 +133,7 @@ fn proposal(
             Pips::committee_pips().contains(&before),
             matches!(proposer, Proposer::Committee(_))
         );
+        assert_eq!(&Pips::proposals(before).unwrap().proposer, proposer);
     }
     assert_eq!(Pips::pip_id_sequence(), before + add);
     assert_eq!(Pips::active_pip_count(), active + add);
@@ -154,9 +148,14 @@ fn standard_proposal(
     proposal(signer, proposer, make_proposal(42), deposit, None, None)
 }
 
+const THE_COMMITTEE: Proposer<Public> = Proposer::Committee(pallet_pips::Committee::Upgrade);
+
 fn committee_proposal(deposit: u128) -> DispatchResult {
-    let prop_committee = Proposer::Committee(pallet_pips::Committee::Technical);
-    standard_proposal(&root(), &prop_committee, deposit)
+    standard_proposal(
+        &pallet_committee::Origin::<TestStorage, committee::Instance4>::Members(0, 0).into(),
+        &THE_COMMITTEE,
+        deposit,
+    )
 }
 
 fn alice_proposal(deposit: u128) -> DispatchResult {
@@ -306,8 +305,7 @@ fn min_deposit_works() {
         // Committees are exempt from min deposit.
         assert_ok!(committee_proposal(0));
         assert_state(1, false, ProposalState::Pending);
-        let prop_committee = Proposer::Committee(pallet_pips::Committee::Technical);
-        assert_eq!(Pips::proposals(1).unwrap().proposer, prop_committee);
+        assert_eq!(Pips::proposals(1).unwrap().proposer, THE_COMMITTEE);
         assert_vote_details(1, VotingResult::default(), vec![], vec![]);
     })
 }
@@ -389,7 +387,7 @@ fn default_enactment_period_works_community() {
             assert_ok!(Pips::set_default_enactment_period(root(), period));
             let block_at_approval = System::block_number();
             assert_ok!(Pips::enact_snapshot_results(
-                root(),
+                gc_vmo(),
                 vec![(last_id, SnapshotResult::Approve)]
             ));
             let expected = Pips::pip_to_schedule(last_id).unwrap();
@@ -417,7 +415,7 @@ fn default_enactment_period_works_committee() {
             fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
             assert_ok!(Pips::set_default_enactment_period(root(), period));
             let block_at_approval = System::block_number();
-            assert_ok!(Pips::approve_committee_proposal(root(), last_id));
+            assert_ok!(Pips::approve_committee_proposal(gc_vmo(), last_id));
             let expected = Pips::pip_to_schedule(last_id).unwrap();
             assert!(Pips::execution_schedule(expected).contains(&last_id));
             assert_eq!(expected, block_at_approval + period);
@@ -441,7 +439,7 @@ fn skip_limit_works() {
 
         let snap = || Pips::snapshot(alice.signer()).unwrap();
         let count = |n| Pips::set_max_pip_skip_count(root(), n).unwrap();
-        let commit = || Pips::enact_snapshot_results(root(), vec![(0, SnapshotResult::Skip)]);
+        let commit = || Pips::enact_snapshot_results(gc_vmo(), vec![(0, SnapshotResult::Skip)]);
 
         assert_ok!(alice_proposal(0));
 
@@ -936,7 +934,7 @@ fn approve_committee_proposal_not_pending() {
         let alice = User::new(AccountKeyring::Alice);
         set_members(vec![alice.did]);
 
-        let acp_bad_state = |id| assert_bad_state!(Pips::approve_committee_proposal(root(), id));
+        let acp_bad_state = |id| assert_bad_state!(Pips::approve_committee_proposal(gc_vmo(), id));
         acp_bad_state(cancelled_proposal());
         acp_bad_state(rejected_proposal());
         acp_bad_state(executed_community_proposal(&alice.signer()));
@@ -949,7 +947,7 @@ fn approve_committee_proposal_not_pending() {
 fn approve_committee_proposal_no_such_proposal() {
     ExtBuilder::default().build().execute_with(|| {
         System::set_block_number(1);
-        assert_no_pip!(Pips::approve_committee_proposal(root(), 0));
+        assert_no_pip!(Pips::approve_committee_proposal(gc_vmo(), 0));
     });
 }
 
@@ -961,7 +959,7 @@ fn approve_committee_proposal_on_cool_off() {
         assert_ok!(committee_proposal(0));
         assert!(Pips::proposals(0).unwrap().cool_off_until > System::block_number());
         assert_noop!(
-            Pips::approve_committee_proposal(root(), 0),
+            Pips::approve_committee_proposal(gc_vmo(), 0),
             Error::ProposalOnCoolOffPeriod,
         );
     });
@@ -975,7 +973,7 @@ fn approve_committee_proposal_not_by_committee() {
         assert_ok!(alice_proposal(0));
         fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
         assert_noop!(
-            Pips::approve_committee_proposal(root(), 0),
+            Pips::approve_committee_proposal(gc_vmo(), 0),
             Error::NotByCommittee,
         );
     });
@@ -1019,27 +1017,27 @@ fn only_gc_majority_stuff() {
         assert_bad_origin!(Pips::enact_snapshot_results(bob.signer(), vec![]));
         assert_bad_origin!(Pips::enact_snapshot_results(charlie.signer(), vec![]));
 
-        // Root can reject.
+        // VMO can reject.
         assert_ok!(Pips::set_prune_historical_pips(root(), false));
-        assert_ok!(Pips::reject_proposal(root(), id));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), id));
         assert_eq!(Pips::pip_id_sequence(), 1);
         assert_eq!(Pips::active_pip_count(), 0);
         assert_state(id, false, ProposalState::Rejected);
-        // Root can also prune.
-        assert_ok!(Pips::prune_proposal(root(), id));
+        // VMO can also prune.
+        assert_ok!(Pips::prune_proposal(gc_vmo(), id));
         assert_eq!(Pips::proposals(id), None);
-        // Root can also `approve_committee_proposal`.
+        // VMO can also `approve_committee_proposal`.
         let id = Pips::pip_id_sequence();
         assert_ok!(committee_proposal(0));
-        assert_ok!(Pips::approve_committee_proposal(root(), id));
-        assert_ok!(Pips::reject_proposal(root(), id));
-        assert_ok!(Pips::prune_proposal(root(), id));
-        // Root can also `enact_snapshot_results`.
+        assert_ok!(Pips::approve_committee_proposal(gc_vmo(), id));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), id));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), id));
+        // VMO can also `enact_snapshot_results`.
         let id = Pips::pip_id_sequence();
         assert_ok!(alice_proposal(0));
         assert_ok!(Pips::snapshot(bob.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(id, SnapshotResult::Reject)]
         ));
 
@@ -1081,10 +1079,10 @@ fn cannot_reject_no_such_proposal() {
         // Rejecting PIP that doesn't exist errors.
         assert_eq!(Pips::pip_id_sequence(), 0);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_no_pip!(Pips::reject_proposal(root(), 0));
+        assert_no_pip!(Pips::reject_proposal(gc_vmo(), 0));
         assert_eq!(Pips::pip_id_sequence(), 0);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_no_pip!(Pips::prune_proposal(root(), 0));
+        assert_no_pip!(Pips::prune_proposal(gc_vmo(), 0));
         assert_eq!(Pips::pip_id_sequence(), 0);
         assert_eq!(Pips::active_pip_count(), 0);
     });
@@ -1109,7 +1107,7 @@ fn scheduled_proposal(signer: &Origin, deposit: u128) -> PipId {
     fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
     assert_ok!(Pips::snapshot(signer.clone()));
     assert_ok!(Pips::enact_snapshot_results(
-        root(),
+        gc_vmo(),
         vec![(next_id, SnapshotResult::Approve)]
     ));
     assert_state(next_id, false, ProposalState::Scheduled);
@@ -1142,7 +1140,7 @@ fn failed_community_proposal(user: User, bad_id: PipId) -> PipId {
     fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
     assert_ok!(Pips::snapshot(user.signer()));
     assert_ok!(Pips::enact_snapshot_results(
-        root(),
+        gc_vmo(),
         vec![(next_id, SnapshotResult::Approve)]
     ));
     assert_state(next_id, false, ProposalState::Scheduled);
@@ -1157,7 +1155,7 @@ fn rejected_proposal() -> PipId {
     let next_id = Pips::pip_id_sequence();
     assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
     let active = Pips::active_pip_count();
-    assert_ok!(Pips::reject_proposal(root(), next_id));
+    assert_ok!(Pips::reject_proposal(gc_vmo(), next_id));
     assert_state(next_id, true, ProposalState::Rejected);
     assert_eq!(Pips::active_pip_count(), active - 1);
     assert_eq!(Pips::pip_id_sequence(), next_id + 1);
@@ -1174,7 +1172,7 @@ fn cannot_reject_incorrect_state() {
         let bob = User::new(AccountKeyring::Bob);
         set_members(vec![bob.did]);
 
-        let reject_bad_state = |id| assert_bad_state!(Pips::reject_proposal(root(), id));
+        let reject_bad_state = |id| assert_bad_state!(Pips::reject_proposal(gc_vmo(), id));
         // Cannot reject cancelled, executed, failed, and rejected:
         let cancelled_id = cancelled_proposal();
         reject_bad_state(cancelled_id);
@@ -1218,7 +1216,7 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_balance(alice.acc(), init_bal, 0);
         assert_eq!(Pips::pip_id_sequence(), 1);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 0));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), 0));
         assert_balance(alice.acc(), init_bal, 0);
         assert_pruned(0);
 
@@ -1232,7 +1230,7 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_eq!(Pips::active_pip_count(), 1);
         assert_ok!(Pips::snapshot(bob.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(1, SnapshotResult::Approve)]
         ));
         assert_state(1, false, ProposalState::Scheduled);
@@ -1242,7 +1240,7 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_state(1, false, ProposalState::Executed);
         assert_balance(alice.acc(), init_bal, 0);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 1));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), 1));
         assert_balance(alice.acc(), init_bal, 0);
         assert_pruned(1);
 
@@ -1260,7 +1258,7 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_eq!(Pips::active_pip_count(), 1);
         assert_ok!(Pips::snapshot(bob.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(2, SnapshotResult::Approve)]
         ));
         assert_state(2, false, ProposalState::Scheduled);
@@ -1270,7 +1268,7 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_state(2, false, ProposalState::Failed);
         assert_balance(alice.acc(), init_bal, 0);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 2));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), 2));
         assert_balance(alice.acc(), init_bal, 0);
         assert_pruned(2);
 
@@ -1279,11 +1277,11 @@ fn can_prune_states_that_cannot_be_rejected() {
         assert_balance(alice.acc(), init_bal, 400);
         assert_eq!(Pips::pip_id_sequence(), 4);
         assert_eq!(Pips::active_pip_count(), 1);
-        assert_ok!(Pips::reject_proposal(root(), 3));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), 3));
         assert_balance(alice.acc(), init_bal, 0);
         assert_state(3, false, ProposalState::Rejected);
         assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 3));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), 3));
         assert_balance(alice.acc(), init_bal, 0);
         assert_pruned(4);
     });
@@ -1304,7 +1302,7 @@ fn cannot_prune_active() {
         // Now remove that PIP and check that funds are back.
         assert_ok!(Pips::set_prune_historical_pips(root(), false));
         assert_state(0, false, ProposalState::Pending);
-        assert_bad_state!(Pips::prune_proposal(root(), 0));
+        assert_bad_state!(Pips::prune_proposal(gc_vmo(), 0));
         assert_eq!(Pips::pip_id_sequence(), 1);
         assert_eq!(Pips::active_pip_count(), 1);
         assert_balance(alice.acc(), init_bal, 50);
@@ -1316,12 +1314,12 @@ fn cannot_prune_active() {
         // Schedule the PIP.
         assert_ok!(Pips::snapshot(alice.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(1, SnapshotResult::Approve)]
         ));
         assert_state(1, false, ProposalState::Scheduled);
         // Now remove that PIP and check that funds are back.
-        assert_bad_state!(Pips::prune_proposal(root(), 1));
+        assert_bad_state!(Pips::prune_proposal(gc_vmo(), 1));
         assert_eq!(Pips::pip_id_sequence(), 2);
         assert_eq!(Pips::active_pip_count(), 2);
         assert_balance(alice.acc(), init_bal, 50 + 60);
@@ -1351,7 +1349,7 @@ fn reject_proposal_works() {
         // Now remove that PIP and check that funds are back.
         assert_ok!(Pips::set_prune_historical_pips(root(), false));
         assert_state(0, false, ProposalState::Pending);
-        assert_ok!(Pips::reject_proposal(root(), 0));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), 0));
         assert_eq!(Pips::pip_id_sequence(), 1);
         assert_eq!(Pips::active_pip_count(), 0);
         assert_eq!(
@@ -1385,13 +1383,13 @@ fn reject_proposal_works() {
         // Schedule the PIP.
         assert_ok!(Pips::snapshot(alice.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(1, SnapshotResult::Approve)]
         ));
         assert_state(1, false, ProposalState::Scheduled);
 
         // Now remove that PIP and check that funds are back.
-        assert_ok!(Pips::reject_proposal(root(), 1));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), 1));
         assert_eq!(Pips::pip_id_sequence(), 2);
         assert_eq!(Pips::active_pip_count(), 0);
         assert_eq!(
@@ -1426,7 +1424,7 @@ fn reject_proposal_will_unsnapshot() {
         assert_ok!(alice_proposal(0));
         assert_ok!(Pips::snapshot(alice.signer()));
         assert_eq!(Pips::snapshot_queue()[0].id, 0);
-        assert_ok!(Pips::reject_proposal(root(), 0));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), 0));
         assert_eq!(Pips::snapshot_queue(), vec![]);
     });
 }
@@ -1445,7 +1443,7 @@ fn reject_proposal_will_unschedule() {
         let check = |id: PipId| {
             let scheduled_at = Pips::pip_to_schedule(id).unwrap();
             assert_eq!(Pips::execution_schedule(scheduled_at), vec![id]);
-            assert_ok!(Pips::reject_proposal(root(), id));
+            assert_ok!(Pips::reject_proposal(gc_vmo(), id));
             assert_eq!(Pips::pip_to_schedule(id), None);
             assert_eq!(Pips::execution_schedule(scheduled_at), Vec::<PipId>::new());
         };
@@ -1454,14 +1452,14 @@ fn reject_proposal_will_unschedule() {
         assert_ok!(alice_proposal(0));
         assert_ok!(Pips::snapshot(alice.signer()));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(0, SnapshotResult::Approve)]
         ));
         check(0);
 
         // Test committee method.
         assert_ok!(committee_proposal(0));
-        assert_ok!(Pips::approve_committee_proposal(root(), 1));
+        assert_ok!(Pips::approve_committee_proposal(gc_vmo(), 1));
         check(1);
     });
 }
@@ -1475,7 +1473,7 @@ fn reschedule_execution_only_release_coordinator() {
         let bob = User::new(AccountKeyring::Bob);
         let charlie = User::new(AccountKeyring::Charlie);
         set_members(vec![alice.did, bob.did, charlie.did]);
-        assert_ok!(Committee::set_release_coordinator(root(), charlie.did));
+        assert_ok!(Committee::set_release_coordinator(gc_vmo(), charlie.did));
 
         assert_bad_origin!(Pips::reschedule_execution(root(), 0, None));
         assert_bad_origin!(Pips::reschedule_execution(alice.signer(), 0, None));
@@ -1497,7 +1495,7 @@ fn reschedule_execution_only_release_coordinator() {
 fn init_rc() -> Origin {
     let user = User::new(AccountKeyring::Alice);
     set_members(vec![user.did]);
-    assert_ok!(Committee::set_release_coordinator(root(), user.did));
+    assert_ok!(Committee::set_release_coordinator(gc_vmo(), user.did));
     user.signer()
 }
 
@@ -1519,8 +1517,8 @@ fn reschedule_execution_not_scheduled() {
         let id = Pips::pip_id_sequence();
         assert_ok!(alice_proposal(0));
         assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-        assert_ok!(Pips::reject_proposal(root(), id));
-        assert_ok!(Pips::prune_proposal(root(), id));
+        assert_ok!(Pips::reject_proposal(gc_vmo(), id));
+        assert_ok!(Pips::prune_proposal(gc_vmo(), id));
         let id = cancelled_proposal();
         assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
         let id = rejected_proposal();
@@ -1745,12 +1743,12 @@ fn enact_snapshot_results_input_too_large() {
 
         assert_ok!(Pips::snapshot(user.signer()));
         assert_noop!(
-            Pips::enact_snapshot_results(root(), vec![(0, SnapshotResult::Skip)]),
+            Pips::enact_snapshot_results(gc_vmo(), vec![(0, SnapshotResult::Skip)]),
             Error::SnapshotResultTooLarge,
         );
         assert_noop!(
             Pips::enact_snapshot_results(
-                root(),
+                gc_vmo(),
                 vec![(0, SnapshotResult::Reject), (1, SnapshotResult::Approve)]
             ),
             Error::SnapshotResultTooLarge,
@@ -1760,7 +1758,7 @@ fn enact_snapshot_results_input_too_large() {
         assert_ok!(Pips::snapshot(user.signer()));
         assert_noop!(
             Pips::enact_snapshot_results(
-                root(),
+                gc_vmo(),
                 vec![
                     (0, SnapshotResult::Reject),
                     (1, SnapshotResult::Approve),
@@ -1787,12 +1785,12 @@ fn enact_snapshot_results_id_mismatch() {
         assert_ok!(alice_proposal(0));
         assert_ok!(Pips::snapshot(user.signer()));
         assert_noop!(
-            Pips::enact_snapshot_results(root(), vec![(1, SnapshotResult::Skip)]),
+            Pips::enact_snapshot_results(gc_vmo(), vec![(1, SnapshotResult::Skip)]),
             Error::SnapshotIdMismatch,
         );
         assert_noop!(
             Pips::enact_snapshot_results(
-                root(),
+                gc_vmo(),
                 vec![(0, SnapshotResult::Reject), (2, SnapshotResult::Approve)]
             ),
             Error::SnapshotIdMismatch,
@@ -1829,7 +1827,7 @@ fn enact_snapshot_results_works() {
         assert_eq!(Pips::snapshot_queue(), mk_queue(&[2, 1, 0]));
         assert_eq!(Pips::pip_skip_count(1), 0);
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![
                 (0, SnapshotResult::Reject),
                 (1, SnapshotResult::Skip),
@@ -1849,7 +1847,7 @@ fn enact_snapshot_results_works() {
         assert_ok!(Pips::snapshot(user.signer()));
         assert_eq!(Pips::snapshot_queue(), mk_queue(&[3, 1]));
         assert_ok!(Pips::enact_snapshot_results(
-            root(),
+            gc_vmo(),
             vec![(1, SnapshotResult::Approve)]
         ));
         assert_last_event!(
@@ -1861,7 +1859,7 @@ fn enact_snapshot_results_works() {
 
         // Cleared queue + enacting zero-length results => noop.
         assert_ok!(Pips::clear_snapshot(user.signer()));
-        assert_ok!(Pips::enact_snapshot_results(root(), vec![]));
+        assert_ok!(Pips::enact_snapshot_results(gc_vmo(), vec![]));
         assert_last_event!(
             Event::SnapshotResultsEnacted(_, None, a, b, c),
             a.is_empty() && b.is_empty() && c.is_empty()

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -5378,7 +5378,6 @@ fn voting_for_pip_overlays_with_staking() {
     type Pips = pallet_pips::Module<Test>;
     type Error = pallet_pips::Error<Test>;
     use crate::staking::mock::Call;
-    use pallet_pips::Proposer;
 
     ExtBuilder::default().build().execute_with(|| {
         System::set_block_number(1);
@@ -5395,8 +5394,7 @@ fn voting_for_pip_overlays_with_staking() {
         let alice_proposal = |deposit: u128| {
             let signer = Origin::signed(alice_acc);
             let proposal = Box::new(Call::Pips(pallet_pips::Call::set_min_proposal_deposit(0)));
-            let proposer = Proposer::Community(alice_acc);
-            Pips::propose(signer, proposer, proposal, deposit, None, None)
+            Pips::propose(signer, proposal, deposit, None, None)
         };
 
         // Bond all but 10.

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -50,6 +50,7 @@ use smallvec::smallvec;
 use sp_core::{
     crypto::{key_types, Pair as PairTrait},
     sr25519::{Pair, Public},
+    u32_trait::{_1, _2},
     H256,
 };
 use sp_runtime::{
@@ -76,7 +77,12 @@ impl From<UintAuthorityId> for MockSessionKeys {
 }
 
 impl_outer_origin! {
-    pub enum Origin for TestStorage {}
+    pub enum Origin for TestStorage {
+        committee Instance1 <T>,
+        committee DefaultInstance <T>,
+        committee Instance3 <T>,
+        committee Instance4 <T>
+    }
 }
 
 impl_outer_dispatch! {
@@ -353,20 +359,17 @@ impl group::Trait<group::Instance2> for TestStorage {
 
 pub type CommitteeOrigin<T, I> = committee::RawOrigin<<T as frame_system::Trait>::AccountId, I>;
 
-impl<I> From<CommitteeOrigin<TestStorage, I>> for Origin {
-    fn from(_co: CommitteeOrigin<TestStorage, I>) -> Origin {
-        Origin::from(frame_system::RawOrigin::Root)
-    }
-}
-
 parameter_types! {
     pub const MotionDuration: BlockNumber = 0u64;
 }
 
+/// Voting majority origin for `Instance`.
+type VMO<Instance> = committee::EnsureProportionAtLeast<_1, _2, AccountId, Instance>;
+
 impl committee::Trait<committee::Instance1> for TestStorage {
     type Origin = Origin;
     type Proposal = Call;
-    type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
+    type CommitteeOrigin = VMO<committee::Instance1>;
     type Event = Event;
     type MotionDuration = MotionDuration;
 }
@@ -562,10 +565,10 @@ impl dividend::Trait for TestStorage {
 impl pips::Trait for TestStorage {
     type Currency = balances::Module<Self>;
     type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
-    type VotingMajorityOrigin = frame_system::EnsureRoot<AccountId>;
+    type VotingMajorityOrigin = VMO<committee::Instance1>;
     type GovernanceCommittee = Committee;
-    type TechnicalCommitteeVMO = frame_system::EnsureRoot<AccountId>;
-    type UpgradeCommitteeVMO = frame_system::EnsureRoot<AccountId>;
+    type TechnicalCommitteeVMO = VMO<committee::Instance3>;
+    type UpgradeCommitteeVMO = VMO<committee::Instance4>;
     type Treasury = treasury::Module<Self>;
     type Event = Event;
 }

--- a/scripts/cli/tests/11_governance_management.js
+++ b/scripts/cli/tests/11_governance_management.js
@@ -26,14 +26,13 @@ async function main() {
   await sendTx(alice, api.tx.staking.bond(bob.publicKey, 20000, "Staked"));
 
   // Create a PIP which is then amended.
-  const proposer = { "Community": bob.address };
   const setLimit = api.tx.pips.setActivePipLimit(42);
-  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "first"));
+  await sendTx(bob, api.tx.pips.propose(setLimit, 10000000000, "google.com", "first"));
   await sendTx(bob, api.tx.pips.amendProposal(0, "www.facebook.com", null));
 
   // Create a PIP, but first remove the cool-off period.
   await sendTx(alice, api.tx.sudo.sudo(api.tx.pips.setProposalCoolOffPeriod(0)));
-  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "second"));
+  await sendTx(bob, api.tx.pips.propose(setLimit, 10000000000, "google.com", "second"));
 
   // GC needs some funds to use.
   await reqImports.distributePolyBatch(api, [govCommittee1, govCommittee2], reqImports.transfer_amount, alice);


### PR DESCRIPTION
Also tightens various pips and committee tests to work with committee majority origins instead of faking it with `root()`.