### PR TITLE
Schema: fix `Vote`'s definition due to changes

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -782,13 +782,7 @@
                 "ProposalNotFound": "Vec<u8>"
             }
         },
-        "Vote": {
-            "_enum": {
-                "None": "",
-                "Yes": "Balance",
-                "No": "Balance"
-            }
-        },
+        "Vote": "(bool, Balance)",
         "VoteByPip": {
             "pip": "PipId",
             "vote": "Vote"


### PR DESCRIPTION
Defined as:
```rust
pub struct Vote<Balance>(
    /// `true` if there's agreement.
    pub bool,
    /// How strongly do they feel about it?
    pub Balance,
);
```