### PR TITLE
MESH-1281: Fix `expiry` type in schema (Pips & Committee votes)

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -525,7 +525,7 @@
             "description": "Option<PipDescription>",
             "created_at": "BlockNumber",
             "transaction_version": "u32",
-            "expiry": "Option<BlockNumber>"
+            "expiry": "MaybeBlock"
         },
         "Proposer": {
             "_enum": {
@@ -570,7 +570,7 @@
             "ayes": "Vec<(IdentityId, Balance)>",
             "nays": "Vec<(IdentityId, Balance)>",
             "end": "BlockNumber",
-            "expiry": "Option<BlockNumber>"
+            "expiry": "MaybeBlock"
         },
         "PipId": "u32",
         "ProposalState": {


### PR DESCRIPTION
Forgot to update the schema when the types changed during the PR.