### PR TITLE
Move to `develop` cryptography branch, and generalise scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,10 +1125,11 @@ dependencies = [
 [[package]]
 name = "cryptography"
 version = "0.1.0"
-source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=master#dc249f0417168a67569000aefea2ed930b7cfd73"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=develop#26099bbd103fb5529f739b6717006b015f143eea"
 dependencies = [
  "blake2",
  "bulletproofs",
+ "byteorder 1.3.4",
  "criterion",
  "curve25519-dalek 2.1.0",
  "failure",
@@ -1142,7 +1143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.8.2",
- "sp-std 2.0.0-rc4",
+ "sp-std",
  "zeroize",
 ]
 
@@ -1544,7 +1545,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-storage",
 ]
 
@@ -1577,7 +1578,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-tracing",
 ]
 
@@ -1589,7 +1590,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -1613,7 +1614,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-tracing",
 ]
 
@@ -1662,7 +1663,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -1677,7 +1678,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -3738,7 +3739,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -3758,7 +3759,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4000,7 +4001,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4017,7 +4018,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-authority-discovery",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4032,7 +4033,7 @@ dependencies = [
  "sp-authorship",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4056,7 +4057,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -4080,7 +4081,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
  "substrate-test-runtime-client",
 ]
@@ -4096,7 +4097,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4121,7 +4122,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-serializer",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4142,7 +4143,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4159,7 +4160,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4181,7 +4182,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4204,7 +4205,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4231,7 +4232,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4251,7 +4252,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-sandbox",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "wasmi-validation",
 ]
 
@@ -4262,7 +4263,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4293,7 +4294,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4309,7 +4310,7 @@ dependencies = [
  "sp-finality-tracker",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4331,7 +4332,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4351,7 +4352,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4369,7 +4370,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
@@ -4384,7 +4385,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4407,7 +4408,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
  "substrate-test-runtime-client",
 ]
@@ -4428,7 +4429,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4447,7 +4448,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4463,7 +4464,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4481,7 +4482,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4496,7 +4497,7 @@ dependencies = [
  "serde",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4510,7 +4511,7 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4534,7 +4535,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4552,7 +4553,7 @@ dependencies = [
  "polymesh-primitives",
  "serde",
  "sp-arithmetic",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4569,7 +4570,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4611,7 +4612,7 @@ dependencies = [
  "parity-scale-codec",
  "safe-mix",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4630,7 +4631,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-trie",
 ]
 
@@ -4654,7 +4655,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-serializer",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4680,7 +4681,7 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -4739,7 +4740,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
@@ -4754,7 +4755,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4771,7 +4772,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -4789,7 +4790,7 @@ dependencies = [
  "sp-api",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4810,7 +4811,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4825,7 +4826,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -4842,7 +4843,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -5297,7 +5298,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "substrate-test-runtime-client",
 ]
 
@@ -5351,7 +5352,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -5388,7 +5389,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -5461,7 +5462,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder-runner",
@@ -5539,7 +5540,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder-runner",
@@ -5605,7 +5606,7 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "substrate-test-runtime-client",
  "substrate-test-utils",
 ]
@@ -6499,7 +6500,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-storage",
  "sp-transaction-pool",
  "sp-trie",
@@ -7606,7 +7607,7 @@ dependencies = [
  "derive_more",
  "log",
  "sp-core",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-wasm-interface",
 ]
 
@@ -7621,7 +7622,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-version",
 ]
 
@@ -7646,7 +7647,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7659,7 +7660,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-debug-derive",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7671,7 +7672,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7682,7 +7683,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7694,7 +7695,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7741,7 +7742,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-trie",
  "sp-utils",
  "sp-version",
@@ -7759,7 +7760,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -7778,7 +7779,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -7800,7 +7801,7 @@ dependencies = [
  "schnorrkel",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7837,7 +7838,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-storage",
  "substrate-bip39",
  "tiny-bip39",
@@ -7873,7 +7874,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-storage",
 ]
 
@@ -7890,7 +7891,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7900,7 +7901,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7912,7 +7913,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-core",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -7930,7 +7931,7 @@ dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
  "sp-state-machine",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
@@ -7956,7 +7957,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-npos-elections-compact",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8017,7 +8018,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8029,7 +8030,7 @@ dependencies = [
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
@@ -8056,7 +8057,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -8080,7 +8081,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8090,7 +8091,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8116,11 +8117,6 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate?branch=at-add-dispatch-call#b161460bf73e4cc73e29b8e01ab0323bb3d95e84"
-
-[[package]]
-name = "sp-std"
 version = "2.0.0-rc6"
 source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87b9d2b47a2907c9b51ae1e252362c3"
 
@@ -8134,7 +8130,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "sp-debug-derive",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8147,7 +8143,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "wasm-timer",
 ]
 
@@ -8185,7 +8181,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "sp-core",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "trie-db",
  "trie-root",
 ]
@@ -8211,7 +8207,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0-rc6",
+ "sp-std",
 ]
 
 [[package]]
@@ -8221,7 +8217,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v2.0.0-rc6#be8bb186d87
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "wasmi",
 ]
 
@@ -8438,7 +8434,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "sp-session",
- "sp-std 2.0.0-rc6",
+ "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime-interface = { git = "https://github.com/paritytech/substrate", defaul
 # Crypto
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", default-features = false, optional = true }
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "master", default-features = false }
+cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
 curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
 bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "main", default-features = false, features = ["zeroize"] }
 

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -30,7 +30,7 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-fe
 # Only in STD
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", optional = true }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", tag = "v2.0.0-rc6", default-features = false, optional = true  }
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "master", default-features = false, optional = true }
+cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false, optional = true }
 
 [features]
 equalize = []

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -38,7 +38,7 @@ pallet-utility = { path = "../../utility", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 
 # Crypto
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "master", default-features = false }
+cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
 
 # Runtime
 polymesh-runtime-develop = { path = "../develop" }

--- a/pallets/runtime/tests/src/confidential_test.rs
+++ b/pallets/runtime/tests/src/confidential_test.rs
@@ -142,7 +142,7 @@ fn scope_claims_we() {
     ));
 
     // 2. Investor adds its Confidential Scope claims.
-    let scope_claim = InvestorZKProofData::make_scope_claim(&ticker.as_slice(), &investor);
+    let scope_claim = InvestorZKProofData::make_scope_claim(&st_id.as_slice(), &investor);
     let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
 
     let inv_1_proof = InvestorZKProofData::new(&inv_did_1, &investor, &st_id);
@@ -238,7 +238,8 @@ fn scope_claims_we() {
         None,
     ));
 
-    let corrupted_scope_claim = InvestorZKProofData::make_scope_claim(&st2_id.as_slice(), &investor);
+    let corrupted_scope_claim =
+        InvestorZKProofData::make_scope_claim(&st2_id.as_slice(), &investor);
     let corrupted_scope_id = compute_scope_id(&corrupted_scope_claim)
         .compress()
         .to_bytes()

--- a/pallets/runtime/tests/src/confidential_test.rs
+++ b/pallets/runtime/tests/src/confidential_test.rs
@@ -142,7 +142,7 @@ fn scope_claims_we() {
     ));
 
     // 2. Investor adds its Confidential Scope claims.
-    let scope_claim = InvestorZKProofData::make_scope_claim(&st_id, &investor);
+    let scope_claim = InvestorZKProofData::make_scope_claim(&ticker.as_slice(), &investor);
     let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
 
     let inv_1_proof = InvestorZKProofData::new(&inv_did_1, &investor, &st_id);
@@ -238,7 +238,7 @@ fn scope_claims_we() {
         None,
     ));
 
-    let corrupted_scope_claim = InvestorZKProofData::make_scope_claim(&st2_id, &investor);
+    let corrupted_scope_claim = InvestorZKProofData::make_scope_claim(&st2_id.as_slice(), &investor);
     let corrupted_scope_id = compute_scope_id(&corrupted_scope_claim)
         .compress()
         .to_bytes()

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -750,7 +750,7 @@ pub fn provide_scope_claim(
     let proof: InvestorZKProofData = InvestorZKProofData::new(&claim_to, &investor_uid, &scope);
     let cdd_claim = InvestorZKProofData::make_cdd_claim(&claim_to, &investor_uid);
     let cdd_id = compute_cdd_id(&cdd_claim).compress().to_bytes().into();
-    let scope_claim = InvestorZKProofData::make_scope_claim(&scope, &investor_uid);
+    let scope_claim = InvestorZKProofData::make_scope_claim(&scope.as_slice(), &investor_uid);
     let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
 
     let signed_claim_to = Origin::signed(Identity::did_records(claim_to).primary_key);

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -391,7 +391,8 @@
                 "Jurisdiction": "",
                 "Exempted": "",
                 "Blocked": "",
-                "NoType": ""
+                "InvestorUniqueness": "",
+                "NoData": ""
             }
         },
         "IdentityClaim": {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -12,7 +12,7 @@ polymesh-primitives-derive = { path = "../primitives_derive", default-features =
 serde = { version = "1.0.104", optional = true, default-features = false, features = ["derive"] }
 
 # Crypto
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "master", default-features = false }
+cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
 curve25519-dalek = { version = "2", default-features = false, features = ["nightly"] }
 schnorrkel = { version = "0.9.1", default-features = false }
 blake2 = { version = "0.9.0", default-features = false }

--- a/primitives/src/investor_zkproof_data.rs
+++ b/primitives/src/investor_zkproof_data.rs
@@ -35,19 +35,16 @@ impl InvestorZKProofData {
     }
 
     /// Returns the CDD claim of the given `investor_did` and `investor_uid`.
-    pub fn make_cdd_claim(investor_did: &IdentityId, investor_unique_id: &InvestorUid) -> CddClaimData {
-        CddClaimData::new(
-            &investor_did.to_bytes(),
-            &investor_unique_id.to_bytes()
-        )
+    pub fn make_cdd_claim(
+        investor_did: &IdentityId,
+        investor_unique_id: &InvestorUid,
+    ) -> CddClaimData {
+        CddClaimData::new(&investor_did.to_bytes(), &investor_unique_id.to_bytes())
     }
 
     /// Returns the Scope claim of the given `ticker` and `investor_uid`.
     pub fn make_scope_claim(scope: &[u8], investor_unique_id: &InvestorUid) -> ScopeClaimData {
-        ScopeClaimData::new(
-            scope,
-            &investor_unique_id.to_bytes()
-        )
+        ScopeClaimData::new(scope, &investor_unique_id.to_bytes())
     }
 
     /// Returns the message used for testing the proof.

--- a/primitives/src/investor_zkproof_data.rs
+++ b/primitives/src/investor_zkproof_data.rs
@@ -1,10 +1,9 @@
-use crate::{scalar_blake2_from_bytes, IdentityId, InvestorUid, Ticker};
+use crate::{IdentityId, InvestorUid, Ticker};
 use cryptography::claim_proofs::{
-    build_scope_claim_proof_data, CDDClaimData, ProofKeyPair, ScopeClaimData,
+    build_scope_claim_proof_data, CddClaimData, ProofKeyPair, ScopeClaimData,
 };
 
 use blake2::{Blake2s, Digest};
-use curve25519_dalek::scalar::Scalar;
 use schnorrkel::Signature;
 
 use codec::{Decode, Encode, Error as CodecError, Input, Output};
@@ -22,46 +21,40 @@ impl InvestorZKProofData {
     pub fn new(did: &IdentityId, investor: &InvestorUid, ticker: &Ticker) -> Self {
         // Create CDD Claim and Scope claim.
         let cdd_claim = Self::make_cdd_claim(did, investor);
-        let scope_claim = Self::make_scope_claim(ticker, investor);
+        let scope_claim = Self::make_scope_claim(ticker.as_slice(), investor);
 
         // Create the scope claim proof
         let sc_proof = build_scope_claim_proof_data(&cdd_claim, &scope_claim);
         let pair = ProofKeyPair::from(sc_proof);
 
         // Generate the message and its ID match proof.
-        let message = Self::make_message(did, ticker);
+        let message = Self::make_message(did, ticker.as_slice());
         let proof = pair.generate_id_match_proof(&message[..]);
 
         Self(proof)
     }
 
     /// Returns the CDD claim of the given `investor_did` and `investor_uid`.
-    pub fn make_cdd_claim(investor_did: &IdentityId, investor_uid: &InvestorUid) -> CDDClaimData {
-        let investor_did = Scalar::from_bits(investor_did.to_bytes());
-        let investor_unique_id = scalar_blake2_from_bytes(&investor_uid);
-
-        CDDClaimData {
-            investor_did,
-            investor_unique_id,
-        }
+    pub fn make_cdd_claim(investor_did: &IdentityId, investor_unique_id: &InvestorUid) -> CddClaimData {
+        CddClaimData::new(
+            &investor_did.to_bytes(),
+            &investor_unique_id.to_bytes()
+        )
     }
 
     /// Returns the Scope claim of the given `ticker` and `investor_uid`.
-    pub fn make_scope_claim(ticker: &Ticker, investor_uid: &InvestorUid) -> ScopeClaimData {
-        let scope_did = scalar_blake2_from_bytes(ticker.as_slice());
-        let investor_unique_id = scalar_blake2_from_bytes(&investor_uid);
-
-        ScopeClaimData {
-            scope_did,
-            investor_unique_id,
-        }
+    pub fn make_scope_claim(scope: &[u8], investor_unique_id: &InvestorUid) -> ScopeClaimData {
+        ScopeClaimData::new(
+            scope,
+            &investor_unique_id.to_bytes()
+        )
     }
 
     /// Returns the message used for testing the proof.
-    pub fn make_message(investor_did: &IdentityId, ticker: &Ticker) -> [u8; 32] {
+    pub fn make_message(investor_did: &IdentityId, scope: &[u8]) -> [u8; 32] {
         Blake2s::default()
             .chain(investor_did)
-            .chain(ticker.as_slice())
+            .chain(scope)
             .finalize()
             .into()
     }

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,4 +1,4 @@
-use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope, Ticker};
+use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope};
 use cryptography::claim_proofs::ProofPublicKey;
 use curve25519_dalek::ristretto::CompressedRistretto;
 
@@ -55,7 +55,7 @@ impl ValidProofOfInvestor {
 mod tests {
     use super::*;
     use crate::proposition::{exists, Proposition};
-    use crate::{Claim, Context, InvestorUid, InvestorZKProofData};
+    use crate::{Claim, Context, InvestorUid, InvestorZKProofData, Ticker};
     use cryptography::claim_proofs::{compute_cdd_id, compute_scope_id};
     use sp_std::convert::{From, TryFrom};
 

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,6 +1,4 @@
-use crate::{
-    CddId, Claim, IdentityId, InvestorZKProofData, Scope,
-};
+use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope};
 use cryptography::claim_proofs::ProofPublicKey;
 use curve25519_dalek::ristretto::CompressedRistretto;
 
@@ -19,15 +17,15 @@ impl ValidProofOfInvestor {
             Claim::InvestorUniqueness(Scope::Ticker(ticker), scope_id, cdd_id) => {
                 let message = InvestorZKProofData::make_message(id, ticker.as_slice());
                 Self::verify_proof(cdd_id, id, scope_id, ticker.as_slice(), proof, &message)
-            },
+            }
             Claim::InvestorUniqueness(Scope::Identity(identity), scope_id, cdd_id) => {
                 let message = InvestorZKProofData::make_message(id, &identity.to_bytes());
                 Self::verify_proof(cdd_id, id, scope_id, &identity.to_bytes(), proof, &message)
-            },
+            }
             Claim::InvestorUniqueness(Scope::Custom(scope), scope_id, cdd_id) => {
                 let message = InvestorZKProofData::make_message(id, &scope);
                 Self::verify_proof(cdd_id, id, scope_id, &scope, proof, &message)
-            },
+            }
             _ => false,
         }
     }
@@ -88,7 +86,8 @@ mod tests {
             InvestorZKProofData::new(&investor_id, &investor_uid, &asset_ticker);
         let cdd_claim = InvestorZKProofData::make_cdd_claim(&investor_id, &investor_uid);
         let cdd_id = compute_cdd_id(&cdd_claim).compress().to_bytes().into();
-        let scope_claim = InvestorZKProofData::make_scope_claim(&asset_ticker.as_slice(), &investor_uid);
+        let scope_claim =
+            InvestorZKProofData::make_scope_claim(&asset_ticker.as_slice(), &investor_uid);
         let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
 
         let claim = Claim::InvestorUniqueness(Scope::Ticker(asset_ticker), scope_id, cdd_id);

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,8 +1,8 @@
 use crate::{
-    scalar_blake2_from_bytes, CddId, Claim, IdentityId, InvestorZKProofData, Scope, Ticker,
+    CddId, Claim, IdentityId, InvestorZKProofData, Scope,
 };
 use cryptography::claim_proofs::ProofPublicKey;
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+use curve25519_dalek::ristretto::CompressedRistretto;
 
 // ZKProofs claims
 // =========================================================
@@ -17,9 +17,17 @@ impl ValidProofOfInvestor {
     pub fn evaluate_claim(claim: &Claim, id: &IdentityId, proof: &InvestorZKProofData) -> bool {
         match claim {
             Claim::InvestorUniqueness(Scope::Ticker(ticker), scope_id, cdd_id) => {
-                let message = InvestorZKProofData::make_message(id, ticker);
-                Self::verify_proof(cdd_id, id, scope_id, ticker, proof, &message)
-            }
+                let message = InvestorZKProofData::make_message(id, ticker.as_slice());
+                Self::verify_proof(cdd_id, id, scope_id, ticker.as_slice(), proof, &message)
+            },
+            Claim::InvestorUniqueness(Scope::Identity(identity), scope_id, cdd_id) => {
+                let message = InvestorZKProofData::make_message(id, &identity.to_bytes());
+                Self::verify_proof(cdd_id, id, scope_id, &identity.to_bytes(), proof, &message)
+            },
+            Claim::InvestorUniqueness(Scope::Custom(scope), scope_id, cdd_id) => {
+                let message = InvestorZKProofData::make_message(id, &scope);
+                Self::verify_proof(cdd_id, id, scope_id, &scope, proof, &message)
+            },
             _ => false,
         }
     }
@@ -27,24 +35,20 @@ impl ValidProofOfInvestor {
     /// It double check that `proof` matches with the rest of the parameters.
     fn verify_proof(
         cdd_id_raw: &CddId,
-        investor_raw: &IdentityId,
+        investor: &IdentityId,
         scope_id_raw: &IdentityId,
-        ticker: &Ticker,
+        scope: &[u8],
         proof: &InvestorZKProofData,
         message: impl AsRef<[u8]>,
     ) -> bool {
-        let investor = Scalar::from_bits(investor_raw.to_bytes());
-        let scope_did = scalar_blake2_from_bytes(ticker.as_slice());
-
         if let Some(cdd_id) = CompressedRistretto::from_slice(cdd_id_raw.as_slice()).decompress() {
             if let Some(scope_id) =
                 CompressedRistretto::from_slice(scope_id_raw.as_bytes()).decompress()
             {
-                let verifier = ProofPublicKey::new(cdd_id, investor, scope_id, scope_did);
+                let verifier = ProofPublicKey::new(cdd_id, &investor.to_bytes(), scope_id, scope);
                 return verifier.verify_id_match_proof(message.as_ref(), &proof.0);
             }
         }
-
         false
     }
 }
@@ -84,7 +88,7 @@ mod tests {
             InvestorZKProofData::new(&investor_id, &investor_uid, &asset_ticker);
         let cdd_claim = InvestorZKProofData::make_cdd_claim(&investor_id, &investor_uid);
         let cdd_id = compute_cdd_id(&cdd_claim).compress().to_bytes().into();
-        let scope_claim = InvestorZKProofData::make_scope_claim(&asset_ticker, &investor_uid);
+        let scope_claim = InvestorZKProofData::make_scope_claim(&asset_ticker.as_slice(), &investor_uid);
         let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
 
         let claim = Claim::InvestorUniqueness(Scope::Ticker(asset_ticker), scope_id, cdd_id);

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,4 +1,4 @@
-use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope};
+use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope, Ticker};
 use cryptography::claim_proofs::ProofPublicKey;
 use curve25519_dalek::ristretto::CompressedRistretto;
 


### PR DESCRIPTION
- use `develop` branch from cryptography repo
- pass bytes to confidential identity library rather than scalars
- generalise proof scopes
- fix for claim type schema
