### PR TITLE
Remove governance v2 from tooling branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances 0.1.0",
+ "pallet-committee",
  "pallet-group",
  "pallet-identity",
  "pallet-timestamp",

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -195,7 +195,7 @@ use sp_runtime::{
 };
 use sp_std::{cmp, convert::Infallible, fmt::Debug, mem, prelude::*, result};
 
-pub use polymesh_common_utilities::traits::balances::{LockableCurrencyExt, Trait};
+pub use polymesh_common_utilities::traits::balances::Trait;
 
 pub type Event<T> = polymesh_common_utilities::traits::balances::Event<T>;
 
@@ -1118,16 +1118,17 @@ where
         if amount.is_zero() || reasons.is_none() {
             return;
         }
-        let new_lock = BalanceLock {
+        let mut new_lock = Some(BalanceLock {
             id,
             amount,
             reasons: reasons.into(),
-        };
-        let mut locks = Self::locks(who);
-        if let Some(pos) = locks.iter().position(|l| l.id == id) {
-            locks[pos] = new_lock;
-        } else {
-            locks.push(new_lock);
+        });
+        let mut locks = Self::locks(who)
+            .into_iter()
+            .filter_map(|l| if l.id == id { new_lock.take() } else { Some(l) })
+            .collect::<Vec<_>>();
+        if let Some(lock) = new_lock {
+            locks.push(lock)
         }
         Self::update_locks(who, &locks[..]);
     }
@@ -1143,18 +1144,27 @@ where
         if amount.is_zero() || reasons.is_none() {
             return;
         }
-        let reasons = reasons.into();
-        let mut locks = Self::locks(who);
-        if let Some(pos) = locks.iter().position(|l| l.id == id) {
-            let slot = &mut locks[pos];
-            slot.amount = slot.amount.max(amount);
-            slot.reasons = slot.reasons | reasons;
-        } else {
-            locks.push(BalanceLock {
-                id,
-                amount,
-                reasons,
-            });
+        let mut new_lock = Some(BalanceLock {
+            id,
+            amount,
+            reasons: reasons.into(),
+        });
+        let mut locks = Self::locks(who)
+            .into_iter()
+            .filter_map(|l| {
+                if l.id == id {
+                    new_lock.take().map(|nl| BalanceLock {
+                        id: l.id,
+                        amount: l.amount.max(nl.amount),
+                        reasons: l.reasons | nl.reasons,
+                    })
+                } else {
+                    Some(l)
+                }
+            })
+            .collect::<Vec<_>>();
+        if let Some(lock) = new_lock {
+            locks.push(lock)
         }
         Self::update_locks(who, &locks[..]);
     }
@@ -1163,64 +1173,6 @@ where
         let mut locks = Self::locks(who);
         locks.retain(|l| l.id != id);
         Self::update_locks(who, &locks[..]);
-    }
-}
-
-impl<T: Trait> LockableCurrencyExt<T::AccountId> for Module<T>
-where
-    T::Balance: MaybeSerializeDeserialize + Debug,
-{
-    fn reduce_lock(id: LockIdentifier, who: &T::AccountId, amount: T::Balance) -> DispatchResult {
-        if amount.is_zero() {
-            return Ok(());
-        }
-        let mut locks = Self::locks(who);
-        locks
-            .iter()
-            .position(|l| l.id == id)
-            .and_then(|p| {
-                let slot = &mut locks[p].amount;
-                let new = slot.checked_sub(&amount).map(|n| *slot = n);
-                if slot.is_zero() {
-                    locks.swap_remove(p);
-                }
-                new
-            })
-            .ok_or(Error::<T>::InsufficientBalance)?;
-        Self::update_locks(who, &locks[..]);
-        Ok(())
-    }
-
-    fn increase_lock(
-        id: LockIdentifier,
-        who: &T::AccountId,
-        amount: T::Balance,
-        reasons: WithdrawReasons,
-        check_sum: impl FnOnce(T::Balance) -> DispatchResult,
-    ) -> DispatchResult {
-        if amount.is_zero() || reasons.is_none() {
-            return Ok(());
-        }
-        let reasons = reasons.into();
-        let mut locks = Self::locks(who);
-        check_sum(if let Some(pos) = locks.iter().position(|l| l.id == id) {
-            let slot = &mut locks[pos];
-            slot.amount = slot
-                .amount
-                .checked_add(&amount)
-                .ok_or(Error::<T>::Overflow)?;
-            slot.reasons = slot.reasons | reasons;
-            slot.amount
-        } else {
-            locks.push(BalanceLock {
-                id,
-                amount,
-                reasons,
-            });
-            amount
-        })?;
-        Self::update_locks(who, &locks[..]);
-        Ok(())
     }
 }
 

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -67,7 +67,7 @@ use frame_system::{self as system, ensure_signed};
 use pallet_identity as identity;
 use polymesh_common_utilities::{
     governance_group::GovernanceGroupTrait,
-    group::{GroupTrait, InactiveMember, MemberCount},
+    group::{GroupTrait, InactiveMember},
     identity::{IdentityTrait, Trait as IdentityModuleTrait},
     Context, SystematicIssuers, GC_DID,
 };
@@ -78,6 +78,9 @@ use sp_std::{prelude::*, vec};
 
 /// Simple index type for proposal counting.
 pub type ProposalIndex = u32;
+
+/// The number of committee members
+pub type MemberCount = u32;
 
 /// The committee trait.
 pub trait Trait<I>: frame_system::Trait + IdentityModuleTrait {

--- a/pallets/common/src/traits/balances.rs
+++ b/pallets/common/src/traits/balances.rs
@@ -21,10 +21,10 @@ use polymesh_primitives_derive::SliceU8StrongTyped;
 use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
-    dispatch::{DispatchError, DispatchResult},
+    dispatch::DispatchError,
     traits::{
-        BalanceStatus as Status, ExistenceRequirement, Get, LockIdentifier, LockableCurrency,
-        OnUnbalanced, StoredMap, WithdrawReason, WithdrawReasons,
+        BalanceStatus as Status, ExistenceRequirement, Get, OnUnbalanced, StoredMap,
+        WithdrawReason, WithdrawReasons,
     },
 };
 use frame_system::{self as system};
@@ -169,25 +169,4 @@ pub trait BalancesTrait<A, B, NI> {
 pub trait CheckCdd<AccountId> {
     fn check_key_cdd(key: &AccountId) -> bool;
     fn get_key_cdd_did(key: &AccountId) -> Option<IdentityId>;
-}
-
-/// Additional functionality atop `LockableCurrency` allowing a local,
-/// per-id, stacking layer atop the overlay.
-pub trait LockableCurrencyExt<AccountId>: LockableCurrency<AccountId> {
-    /// Reduce the locked amount under `id` for `who`.
-    /// If less than `amount` was locked, then `InsufficientBalance` is raised.
-    /// If the whole locked amount is reduced, then the lock is removed.
-    fn reduce_lock(id: LockIdentifier, who: &AccountId, amount: Self::Balance) -> DispatchResult;
-
-    /// Increase the locked amount under `id` for `who` or raises `Overflow`.
-    /// If there's no lock already, it will be made, unless `amount.is_zero()`.
-    /// Before committing to storage, `check_sum` is called with the lock total,
-    /// allowing the transaction to be aborted.
-    fn increase_lock(
-        id: LockIdentifier,
-        who: &AccountId,
-        amount: Self::Balance,
-        reasons: WithdrawReasons,
-        check_sum: impl FnOnce(Self::Balance) -> DispatchResult,
-    ) -> DispatchResult;
 }

--- a/pallets/common/src/traits/group.rs
+++ b/pallets/common/src/traits/group.rs
@@ -28,9 +28,6 @@ use sp_std::{
     vec::Vec,
 };
 
-/// The number of group members.
-pub type MemberCount = u32;
-
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 pub struct InactiveMember<Moment> {
     pub id: IdentityId,
@@ -83,11 +80,6 @@ pub trait Trait<I>: frame_system::Trait + pallet_timestamp::Trait + IdentityTrai
     /// The overarching event type.
     type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;
 
-    /// Required origin for changing the active limit.
-    /// It's recommended that e.g., in case of a committee,
-    /// this be an origin that cannot be formed through a committee majority.
-    type LimitOrigin: EnsureOrigin<<Self as frame_system::Trait>::Origin>;
-
     /// Required origin for adding a member (though can always be Root).
     type AddOrigin: EnsureOrigin<<Self as frame_system::Trait>::Origin>;
 
@@ -129,8 +121,6 @@ decl_event!(
         /// The membership was reset; see the transaction for who the new set is.
         /// caller DID, List of new members.
         MembersReset(IdentityId, Vec<IdentityId>),
-        /// The limit of how many active members there can be concurrently was changed.
-        ActiveLimitChanged(IdentityId, MemberCount, MemberCount),
         /// Phantom member, never used.
         Dummy(sp_std::marker::PhantomData<(AccountId, Event)>),
     }

--- a/pallets/common/src/traits/pip.rs
+++ b/pallets/common/src/traits/pip.rs
@@ -13,5 +13,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-/// Polymesh Improvement Proposal (PIP) id.
+/// Mesh Improvement Proposal id. Used offchain.
 pub type PipId = u32;
+
+/// Utility maker used to link `Call` type, defined at `Runtime` level, from inside any module.
+pub trait EnactProposalMaker<Origin, Call> {
+    /// Checks if `id` is a valid PIP identifier.
+    fn is_pip_id_valid(id: PipId) -> bool;
+
+    /// It creates the call to enactment the Pip given by `id`.
+    fn enact_referendum_call(id: PipId) -> Call;
+
+    /// It creates the call to reject the Pip, given by `id`.
+    fn reject_referendum_call(id: PipId) -> Call;
+}

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -77,7 +77,7 @@
 use pallet_identity as identity;
 pub use polymesh_common_utilities::{
     group::{GroupTrait, InactiveMember, RawEvent, Trait},
-    Context, SystematicIssuers,
+    Context, SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::IdentityId;
 

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -76,8 +76,8 @@
 
 use pallet_identity as identity;
 pub use polymesh_common_utilities::{
-    group::{GroupTrait, InactiveMember, MemberCount, RawEvent, Trait},
-    Context, GC_DID,
+    group::{GroupTrait, InactiveMember, RawEvent, Trait},
+    Context, SystematicIssuers,
 };
 use polymesh_primitives::IdentityId;
 
@@ -101,8 +101,6 @@ decl_storage! {
         pub ActiveMembers get(fn active_members) config(): Vec<IdentityId>;
         /// The current "inactive" membership, stored as an ordered Vec.
         pub InactiveMembers get(fn inactive_members): Vec<InactiveMember<T::Moment>>;
-        /// Limit of how many "active" members there can be.
-        pub ActiveMembersLimit get(fn active_members_limit) config(): u32;
     }
     add_extra_genesis {
         config(phantom): sp_std::marker::PhantomData<(T, I)>;
@@ -110,7 +108,6 @@ decl_storage! {
             use frame_support::traits::InitializeMembers;
 
             let mut members = config.active_members.clone();
-            assert!(members.len() as MemberCount <= config.active_members_limit);
             members.sort();
             T::MembershipInitialized::initialize_members(&members);
             <ActiveMembers<I>>::put(members);
@@ -126,17 +123,6 @@ decl_module! {
         type Error = Error<T, I>;
 
         fn deposit_event() = default;
-
-        /// Change this group's limit for how many concurrent active members they may be.
-        ///
-        /// # Arguments
-        /// * `limit` - the numer of active members there may be concurrently.
-        #[weight = (100_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn set_active_members_limit(origin, limit: MemberCount) {
-            T::LimitOrigin::ensure_origin(origin)?;
-            let old = <ActiveMembersLimit<I>>::mutate(|slot| core::mem::replace(slot, limit));
-            Self::deposit_event(RawEvent::ActiveLimitChanged(GC_DID, limit, old));
-        }
 
         /// Disables a member at specific moment.
         ///
@@ -177,7 +163,6 @@ decl_module! {
             let mut members = <ActiveMembers<I>>::get();
             let location = members.binary_search(&who).err().ok_or(Error::<T, I>::DuplicateMember)?;
             members.insert(location, who);
-            Self::ensure_within_active_members_limit(&members)?;
             <ActiveMembers<I>>::put(&members);
 
             T::MembershipChanged::change_members_sorted(&[who], &[], &members[..]);
@@ -241,8 +226,6 @@ decl_module! {
         pub fn reset_members(origin, members: Vec<IdentityId>) {
             T::ResetOrigin::ensure_origin(origin)?;
 
-            Self::ensure_within_active_members_limit(&members)?;
-
             let mut new_members = members.clone();
             new_members.sort();
             <ActiveMembers<I>>::mutate(|m| {
@@ -302,22 +285,11 @@ decl_error! {
         /// Last member of the committee can not quit.
         LastMemberCannotQuit,
         /// Missing current DID
-        MissingCurrentIdentity,
-        /// The limit for the number of concurrent active members for this group has been exceeded.
-        ActiveMembersLimitExceeded,
+        MissingCurrentIdentity
     }
 }
 
 impl<T: Trait<I>, I: Instance> Module<T, I> {
-    /// Ensure that updating the active set to `members` will not exceed the set limit.
-    fn ensure_within_active_members_limit(members: &[IdentityId]) -> DispatchResult {
-        ensure!(
-            members.len() as MemberCount <= Self::active_members_limit(),
-            Error::<T, I>::ActiveMembersLimitExceeded
-        );
-        Ok(())
-    }
-
     /// Returns the current "active members" and any "valid member" whose revocation time-stamp is
     /// in the future.
     pub fn get_valid_members() -> Vec<IdentityId> {

--- a/pallets/pips/Cargo.toml
+++ b/pallets/pips/Cargo.toml
@@ -13,6 +13,7 @@ pallet-group = { path = "../group", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-balances = { path = "../balances", default-features = false }
 pallet-treasury = { path = "../treasury", default-features = false }
+pallet-committee = { path = "../committee", default-features = false  }
 
 # General
 serde = { version = "1.0.104", default-features = false }
@@ -55,5 +56,6 @@ std = [
 	"pallet-balances/std",
 	"pallet-group/std",
 	"pallet-identity/std",
+	"pallet-committee/std",
 	"pallet-treasury/std",
 ]

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -94,7 +94,7 @@ use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     ensure,
     storage::IterableStorageMap,
-    traits::{Currency, EnsureOrigin, LockIdentifier, WithdrawReasons},
+    traits::{Currency, EnsureOrigin, LockableCurrency, ReservableCurrency},
     weights::{DispatchClass, Pays, Weight},
 };
 use frame_system::{self as system, ensure_signed};
@@ -115,12 +115,8 @@ use polymesh_primitives_derive::VecU8StrongTyped;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
-use sp_runtime::traits::{
-    BlakeTwo256, CheckedAdd, CheckedSub, Dispatchable, Hash, Saturating, Zero,
-};
+use sp_runtime::traits::{BlakeTwo256, CheckedAdd, Dispatchable, Hash, Saturating, Zero};
 use sp_std::{convert::From, prelude::*};
-
-const PIPS_LOCK_ID: LockIdentifier = *b"pips    ";
 
 /// Balance
 type BalanceOf<T> =
@@ -682,8 +678,9 @@ decl_module! {
                 // Pre conditions: caller must have min balance.
                 ensure!(deposit >= Self::min_proposal_deposit(), Error::<T>::IncorrectDeposit);
 
-               // Lock the deposit.
-               Self::increase_lock(proposer, deposit)?;
+                // Reserve the minimum deposit.
+                <T as Trait>::Currency::reserve(&proposer, deposit)
+                    .map_err(|_| Error::<T>::InsufficientDeposit)?;
             } else {
                 // Committee PIPs cannot have a deposit.
                 ensure!(deposit.is_zero(), Error::<T>::NotFromCommunity);
@@ -845,9 +842,9 @@ decl_module! {
                 // 4. Reserve the deposit, or refund if needed.
                 let curr_deposit = Self::deposits(id, &voter).amount;
                 if deposit < curr_deposit {
-                    Self::reduce_lock(&voter, curr_deposit - deposit)?;
+                    <T as Trait>::Currency::unreserve(&voter, curr_deposit - deposit);
                 } else {
-                    Self::increase_lock(&voter, deposit - curr_deposit)?;
+                    <T as Trait>::Currency::reserve(&voter, deposit - curr_deposit).map_err(|_| Error::<T>::InsufficientDeposit)?;
                 }
                 // 5. Save the vote.
                 Self::unsafe_vote(id, voter.clone(), Vote(aye_or_nay, deposit))
@@ -1217,8 +1214,8 @@ impl<T: Trait> Module<T> {
     fn refund_proposal(did: IdentityId, id: PipId) {
         let total_refund =
             <Deposits<T>>::iter_prefix_values(id).fold(0.into(), |acc, depo_info| {
-                Self::reduce_lock(&depo_info.owner, depo_info.amount).unwrap();
-                depo_info.amount.saturating_add(acc)
+                let amount = <T as Trait>::Currency::unreserve(&depo_info.owner, depo_info.amount);
+                amount.saturating_add(acc)
             });
         <Deposits<T>>::remove_prefix(id);
         Self::deposit_event(RawEvent::ProposalRefund(did, id, total_refund));
@@ -1334,29 +1331,6 @@ impl<T: Trait> Module<T> {
 }
 
 impl<T: Trait> Module<T> {
-    /// Increase `acc`'s locked deposit for all PIPs by `amount`,
-    /// or fail if there's not enough free balance after adding `amount` to lock.
-    fn increase_lock(acc: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
-        <T as Trait>::Currency::increase_lock(
-            PIPS_LOCK_ID,
-            acc,
-            amount,
-            WithdrawReasons::all(),
-            |sum| {
-                <T as Trait>::Currency::free_balance(acc)
-                    .checked_sub(&sum)
-                    .ok_or(Error::<T>::InsufficientDeposit.into())
-                    .map(drop)
-            },
-        )
-    }
-
-    /// Reduce `acc`'s locked deposit for all PIPs by `amount`,
-    /// or fail if `amount` hasn't been locked for PIPs.
-    fn reduce_lock(acc: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
-        <T as Trait>::Currency::reduce_lock(PIPS_LOCK_ID, acc, amount)
-    }
-
     /// Retrieve votes for a proposal represented by PipId `id`.
     pub fn get_votes(id: PipId) -> VoteCount<BalanceOf<T>>
     where

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -94,7 +94,7 @@ use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     ensure,
     storage::IterableStorageMap,
-    traits::{Currency, EnsureOrigin, Get, LockIdentifier, WithdrawReasons},
+    traits::{Currency, EnsureOrigin, LockIdentifier, WithdrawReasons},
     weights::{DispatchClass, Pays, Weight},
 };
 use frame_system::{self as system, ensure_signed};
@@ -119,7 +119,6 @@ use sp_runtime::traits::{
     BlakeTwo256, CheckedAdd, CheckedSub, Dispatchable, Hash, Saturating, Zero,
 };
 use sp_std::{convert::From, prelude::*};
-use sp_version::RuntimeVersion;
 
 const PIPS_LOCK_ID: LockIdentifier = *b"pips    ";
 
@@ -212,12 +211,6 @@ pub struct PipsMetadata<T: Trait> {
     pub description: Option<PipDescription>,
     /// The block when the PIP was made.
     pub created_at: T::BlockNumber,
-    /// Assuming the runtime has a given `rv: RuntimeVersion` at the point of `Pips::propose`,
-    /// then this field contains `rv.transaction_version`.
-    ///
-    /// Currently, this is only used for off-chain purposes to highlight any differences
-    /// in the proposal's transaction version from the current one.
-    pub transaction_version: u32,
 }
 
 /// For keeping track of proposal being voted on.
@@ -721,7 +714,6 @@ decl_module! {
                 created_at,
                 url: url.clone(),
                 description: description.clone(),
-                transaction_version: <T::Version as Get<RuntimeVersion>>::get().transaction_version,
             };
             <ProposalMetadata<T>>::insert(id, proposal_metadata);
 

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -675,13 +675,14 @@ decl_module! {
         #[weight = (1_850_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn propose(
             origin,
+            proposer: Proposer<T::AccountId>,
             proposal: Box<T::Proposal>,
             deposit: BalanceOf<T>,
             url: Option<Url>,
             description: Option<PipDescription>,
         ) -> DispatchResult {
-            // 1. Infer the proposer from `origin`.
-            let proposer = Self::ensure_infer_proposer(origin)?;
+            // 1. Ensure it's really the `proposer`.
+            Self::ensure_signed_by(origin, &proposer)?;
 
             let did = Self::current_did_or_missing()?;
 
@@ -1152,27 +1153,27 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-    /// Ensure that `origin` represents one of:
-    /// - a signed extrinsic (i.e. transaction), and infer the account id, as a community proposer.
-    /// - a committee, where the committee is also inferred.
+    /// Ensure that `origin` represents a signed extrinsic (i.e. transaction)
+    /// and confirms that the account is the same as the given `proposer`.
     ///
-    /// Returns the inferred proposer.
+    /// For example, if `proposer` denotes a committee,
+    /// then `origin` is checked against the committee's origin.
     ///
     /// # Errors
-    /// * `BadOrigin` if not a signed extrinsic.
-    fn ensure_infer_proposer(
-        origin: T::Origin,
-    ) -> Result<Proposer<T::AccountId>, sp_runtime::traits::BadOrigin> {
-        ensure_signed(origin.clone())
-            .map(Proposer::Community)
-            .or_else(|_| {
-                T::TechnicalCommitteeVMO::ensure_origin(origin.clone())
-                    .map(|_| Committee::Technical)
-                    .or_else(|_| {
-                        T::UpgradeCommitteeVMO::ensure_origin(origin).map(|_| Committee::Upgrade)
-                    })
-                    .map(Proposer::Committee)
-            })
+    /// * `BadOrigin` unless the checks above pass.
+    fn ensure_signed_by(origin: T::Origin, proposer: &Proposer<T::AccountId>) -> DispatchResult {
+        match proposer {
+            Proposer::Community(acc) => {
+                ensure!(acc == &ensure_signed(origin)?, DispatchError::BadOrigin)
+            }
+            Proposer::Committee(Committee::Technical) => {
+                T::TechnicalCommitteeVMO::ensure_origin(origin)?;
+            }
+            Proposer::Committee(Committee::Upgrade) => {
+                T::UpgradeCommitteeVMO::ensure_origin(origin)?;
+            }
+        }
+        Ok(())
     }
 
     /// Returns the current identity or emits `MissingCurrentIdentity`.
@@ -1180,8 +1181,7 @@ impl<T: Trait> Module<T> {
         Context::current_identity::<Identity<T>>().ok_or_else(|| Error::<T>::MissingCurrentIdentity)
     }
 
-    /// Ensure that the proposer inferred via `origin` is the owner of the proposal,
-    /// which must be in the cool off period.
+    /// Ensure that proposer is owner of the proposal which must be in the cool off period.
     ///
     /// # Errors
     /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
@@ -1192,8 +1192,7 @@ impl<T: Trait> Module<T> {
     ) -> Result<Proposer<T::AccountId>, DispatchError> {
         // 1. Only owner can act on proposal.
         let pip = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-        let proposer = Self::ensure_infer_proposer(origin)?;
-        ensure!(proposer == pip.proposer, DispatchError::BadOrigin);
+        Self::ensure_signed_by(origin, &pip.proposer)?;
 
         // 2. Check that the proposal is pending.
         Self::is_proposal_state(id, ProposalState::Pending)?;

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -141,19 +141,13 @@ pub struct PipDescription(pub Vec<u8>);
 /// Represents a proposal
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Pip<T: Trait> {
+pub struct Pip<Proposal> {
     /// The proposal's unique id.
     pub id: PipId,
     /// The proposal being voted on.
-    pub proposal: T::Proposal,
+    pub proposal: Proposal,
     /// The latest state
     pub state: ProposalState,
-    /// The issuer of `propose`.
-    pub proposer: Proposer<T::AccountId>,
-    /// The block until which the PIP is cooling off.
-    /// During the period, the `proposer` can amend details.
-    /// After the period, people can vote on community PIPs.
-    pub cool_off_until: T::BlockNumber,
 }
 
 /// A result of execution of get_votes.
@@ -202,13 +196,18 @@ pub enum Proposer<AccountId> {
 /// Represents a proposal metadata
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct PipsMetadata {
+pub struct PipsMetadata<T: Trait> {
+    /// They creator
+    pub proposer: Proposer<T::AccountId>,
     /// The proposal's unique id.
     pub id: PipId,
     /// The proposal url for proposal discussion.
     pub url: Option<Url>,
     /// The proposal description.
     pub description: Option<PipDescription>,
+    /// This proposal allows any changes
+    /// During Cool-off period, proposal owner can amend any PIP detail or cancel the entire
+    pub cool_off_until: T::BlockNumber,
 }
 
 /// For keeping track of proposal being voted on.
@@ -277,9 +276,6 @@ pub struct DepositInfo<AccountId, Balance> {
     pub amount: Balance,
 }
 
-/// ID of the taken snapshot in a sequence.
-pub type SnapshotId = u32;
-
 /// A snapshot's metadata, containing when it was created and who triggered it.
 /// The priority queue is stored separately (see `SnapshottedPip`).
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
@@ -289,8 +285,6 @@ pub struct SnapshotMetadata<T: Trait> {
     pub created_at: T::BlockNumber,
     /// Who triggered this snapshot? Should refer to someone in the GC.
     pub made_by: T::AccountId,
-    /// Unique ID of this snapshot.
-    pub id: SnapshotId,
 }
 
 /// A PIP in the snapshot's priority queue for consideration by the GC.
@@ -379,14 +373,11 @@ decl_storage! {
         /// Proposals so far. id can be used to keep track of PIPs off-chain.
         PipIdSequence get(fn pip_id_sequence): u32;
 
-        /// Snapshots so far. id can be used to keep track of snapshots off-chain.
-        SnapshotIdSequence get(fn snapshot_id_sequence): u32;
-
         /// Total count of current pending or scheduled PIPs.
         ActivePipCount get(fn active_pip_count): u32;
 
         /// The metadata of the active proposals.
-        pub ProposalMetadata get(fn proposal_metadata): map hasher(twox_64_concat) PipId => Option<PipsMetadata>;
+        pub ProposalMetadata get(fn proposal_metadata): map hasher(twox_64_concat) PipId => Option<PipsMetadata<T>>;
 
         /// Those who have locked a deposit.
         /// proposal (id, proposer) -> deposit
@@ -394,7 +385,7 @@ decl_storage! {
 
         /// Actual proposal for a given id, if it's current.
         /// proposal id -> proposal
-        pub Proposals get(fn proposals): map hasher(twox_64_concat) PipId => Option<Pip<T>>;
+        pub Proposals get(fn proposals): map hasher(twox_64_concat) PipId => Option<Pip<T::Proposal>>;
 
         /// PolymeshVotes on a given proposal, if it is ongoing.
         /// proposal id -> vote count
@@ -424,10 +415,6 @@ decl_storage! {
         /// The number of times a certain PIP has been skipped.
         /// Once a (configurable) threshhold is exceeded, a PIP cannot be skipped again.
         pub PipSkipCount get(fn pip_skip_count): map hasher(twox_64_concat) PipId => SkippedCount;
-
-        /// All existing PIPs where the proposer is a committee.
-        /// This list is a cache of all ids in `Proposals` with `Proposer::Committee(_)`.
-        pub CommitteePips get(fn committee_pips): Vec<PipId>;
     }
 }
 
@@ -484,9 +471,9 @@ decl_event!(
         /// (id, total amount)
         ProposalRefund(IdentityId, PipId, Balance),
         /// The snapshot was cleared.
-        SnapshotCleared(IdentityId, SnapshotId),
+        SnapshotCleared(IdentityId),
         /// A new snapshot was taken.
-        SnapshotTaken(IdentityId, SnapshotId),
+        SnapshotTaken(IdentityId),
         /// A PIP in the snapshot queue was skipped.
         /// (gc_did, pip_id, new_skip_count)
         PipSkipped(IdentityId, PipId, SkippedCount),
@@ -708,21 +695,21 @@ decl_module! {
             // 4. Construct and add PIP to storage.
             let id = Self::next_pip_id();
             ActivePipCount::mutate(|count| *count += 1);
+            let cool_off_until = <system::Module<T>>::block_number() + Self::proposal_cool_off_period();
             let proposal_metadata = PipsMetadata {
+                proposer: proposer.clone(),
                 id,
                 url: url.clone(),
                 description: description.clone(),
+                cool_off_until: cool_off_until,
             };
-            ProposalMetadata::insert(id, proposal_metadata);
+            <ProposalMetadata<T>>::insert(id, proposal_metadata);
 
             let proposal_data = Self::reportable_proposal_data(&*proposal);
-            let cool_off_until = <system::Module<T>>::block_number() + Self::proposal_cool_off_period();
             let pip = Pip {
                 id,
                 proposal: *proposal,
                 state: ProposalState::Pending,
-                proposer: proposer.clone(),
-                cool_off_until,
             };
             <Proposals<T>>::insert(id, pip);
 
@@ -741,8 +728,6 @@ decl_module! {
                         debug::error!("The counters of voting (id={}) have an overflow during the 1st vote", id);
                         vote_error
                     })?;
-            } else {
-                CommitteePips::append(id);
             }
 
             // 6. Emit the event.
@@ -777,7 +762,7 @@ decl_module! {
             let current_did = Self::current_did_or_missing()?;
 
             // 2. Update proposal metadata.
-            ProposalMetadata::mutate(id, |meta| {
+            <ProposalMetadata<T>>::mutate(id, |meta| {
                 if let Some(meta) = meta {
                     meta.url = url.clone();
                     meta.description = description.clone();
@@ -832,11 +817,11 @@ decl_module! {
         #[weight = 1_000_000_000]
         pub fn vote(origin, id: PipId, aye_or_nay: bool, deposit: BalanceOf<T>) {
             let voter = ensure_signed(origin)?;
-            let pip = Self::proposals(id)
+            let meta = Self::proposal_metadata(id)
                 .ok_or_else(|| Error::<T>::NoSuchProposal)?;
 
             // 1. Proposal must be from the community.
-            let proposer = match pip.proposer {
+            let proposer = match meta.proposer {
                 Proposer::Committee(_) => return Err(Error::<T>::NotFromCommunity.into()),
                 Proposer::Community(p) => p,
             };
@@ -848,7 +833,7 @@ decl_module! {
             } else {
                 // 2b. Only proposer can vote during PIP's cool-off period.
                 let curr_block_number = <system::Module<T>>::block_number();
-                ensure!(pip.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
+                ensure!(meta.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
             }
 
             // 3. Proposal must be pending.
@@ -894,10 +879,10 @@ decl_module! {
             Self::is_proposal_state(id, ProposalState::Pending)?;
 
             // 3. Proposal must not be cooling-off and must be by committee.
-            let pip = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
+            let meta = Self::proposal_metadata(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
             let curr_block_number = <system::Module<T>>::block_number();
-            ensure!(pip.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
-            ensure!(matches!(pip.proposer, Proposer::Committee(_)), Error::<T>::NotByCommittee);
+            ensure!(meta.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
+            ensure!(matches!(meta.proposer, Proposer::Committee(_)), Error::<T>::NotByCommittee);
 
             // 4. All is good, schedule PIP for execution.
             Self::schedule_pip_for_execution(GC_DID, id);
@@ -986,15 +971,12 @@ decl_module! {
             let did = Context::current_identity_or::<Identity<T>>(&actor)?;
             ensure!(T::GovernanceCommittee::is_member(&did), Error::<T>::NotACommitteeMember);
 
-            if let Some(meta) = <SnapshotMeta<T>>::get() {
-                // 2. Clear the snapshot.
-                <SnapshotMeta<T>>::kill();
-                <SnapshotQueue<T>>::kill();
+            // 2. Clear the snapshot.
+            <SnapshotMeta<T>>::kill();
+            <SnapshotQueue<T>>::kill();
 
-                // 3. Emit event.
-                Self::deposit_event(RawEvent::SnapshotCleared(did, meta.id));
-            }
-
+            // 3. Emit event.
+            Self::deposit_event(RawEvent::SnapshotCleared(did));
             Ok(())
         }
 
@@ -1013,11 +995,16 @@ decl_module! {
             // 2. Fetch intersection of pending && non-cooling PIPs and aggregate their votes.
             let created_at = <system::Module<T>>::block_number();
             let mut queue = <Proposals<T>>::iter_values()
-                // Only keep non-cooling pending community PIPs.
+                // Only keep pending PIPs.
                 .filter(|pip| matches!(pip.state, ProposalState::Pending))
-                .filter(|pip| matches!(pip.proposer, Proposer::Community(_)))
-                .filter(|pip| pip.cool_off_until <= created_at)
                 .map(|pip| pip.id)
+                // Only keep community PIPs not cooling-off.
+                .filter(|id| {
+                    <ProposalMetadata<T>>::get(id)
+                        .filter(|meta| meta.cool_off_until <= created_at)
+                        .filter(|meta| matches!(meta.proposer, Proposer::Community(_)))
+                        .is_some()
+                })
                 // Aggregate the votes; `true` denotes a positive sign.
                 .map(|id| {
                     let VotingResult { ayes_stake, nays_stake, .. } = <ProposalResult<T>>::get(id);
@@ -1048,12 +1035,11 @@ decl_module! {
             });
 
             // 4. Commit the new snapshot.
-            let id = SnapshotIdSequence::mutate(|id| mem::replace(id, *id + 1));
-            <SnapshotMeta<T>>::set(Some(SnapshotMetadata { created_at, made_by, id }));
+            <SnapshotMeta<T>>::set(Some(SnapshotMetadata { created_at, made_by }));
             <SnapshotQueue<T>>::set(queue);
 
             // 5. Emit event.
-            Self::deposit_event(RawEvent::SnapshotTaken(did, id));
+            Self::deposit_event(RawEvent::SnapshotTaken(did));
             Ok(())
         }
 
@@ -1186,8 +1172,8 @@ impl<T: Trait> Module<T> {
         id: PipId,
     ) -> Result<Proposer<T::AccountId>, DispatchError> {
         // 1. Only owner can act on proposal.
-        let pip = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-        Self::ensure_signed_by(origin, &pip.proposer)?;
+        let meta = Self::proposal_metadata(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
+        Self::ensure_signed_by(origin, &meta.proposer)?;
 
         // 2. Check that the proposal is pending.
         Self::is_proposal_state(id, ProposalState::Pending)?;
@@ -1195,11 +1181,11 @@ impl<T: Trait> Module<T> {
         // 3. Proposal is *ONLY* alterable during its cool-off period.
         let curr_block_number = <system::Module<T>>::block_number();
         ensure!(
-            pip.cool_off_until > curr_block_number,
+            meta.cool_off_until > curr_block_number,
             Error::<T>::ProposalIsImmutable
         );
 
-        Ok(pip.proposer)
+        Ok(meta.proposer)
     }
 
     /// Runs the following procedure:
@@ -1253,7 +1239,7 @@ impl<T: Trait> Module<T> {
     /// Remove the PIP with `id` from the snapshot if it is there.
     fn maybe_unsnapshot_pip(id: PipId, state: ProposalState) {
         if let ProposalState::Pending = state {
-            let cool_until = Self::proposals(id).unwrap().cool_off_until;
+            let cool_until = <ProposalMetadata<T>>::get(id).unwrap().cool_off_until;
             if cool_until <= <system::Module<T>>::block_number()
                 && <SnapshotMeta<T>>::get()
                     .filter(|m| cool_until <= m.created_at)
@@ -1277,10 +1263,7 @@ impl<T: Trait> Module<T> {
         if prune {
             <ProposalResult<T>>::remove(id);
             <ProposalVotes<T>>::remove_prefix(id);
-            ProposalMetadata::remove(id);
-            if let Some(Proposer::Committee(_)) = Self::proposals(id).map(|p| p.proposer) {
-                CommitteePips::mutate(|list| list.retain(|&i| i != id));
-            }
+            <ProposalMetadata<T>>::remove(id);
             <Proposals<T>>::remove(id);
             PipSkipCount::remove(id);
         }
@@ -1393,16 +1376,16 @@ impl<T: Trait> Module<T> {
 
     /// Retrieve proposals made by `proposer`.
     pub fn proposed_by(proposer: Proposer<T::AccountId>) -> Vec<PipId> {
-        <Proposals<T>>::iter()
-            .filter(|(_, pip)| pip.proposer == proposer)
-            .map(|(_, pip)| pip.id)
+        <ProposalMetadata<T>>::iter()
+            .filter(|(_, meta)| meta.proposer == proposer)
+            .map(|(_, meta)| meta.id)
             .collect()
     }
 
     /// Retrieve proposals `address` voted on
     pub fn voted_on(address: T::AccountId) -> Vec<PipId> {
-        <Proposals<T>>::iter()
-            .filter_map(|(_, pip)| Self::proposal_vote(pip.id, &address).map(|_| pip.id))
+        <ProposalMetadata<T>>::iter()
+            .filter_map(|(_, meta)| Self::proposal_vote(meta.id, &address).map(|_| meta.id))
             .collect::<Vec<_>>()
     }
 
@@ -1410,11 +1393,11 @@ impl<T: Trait> Module<T> {
     pub fn voting_history_by_address(
         who: T::AccountId,
     ) -> HistoricalVotingByAddress<Vote<BalanceOf<T>>> {
-        <Proposals<T>>::iter()
-            .filter_map(|(_, pip)| {
+        <ProposalMetadata<T>>::iter()
+            .filter_map(|(_, meta)| {
                 Some(VoteByPip {
-                    pip: pip.id,
-                    vote: Self::proposal_vote(pip.id, &who)?,
+                    pip: meta.id,
+                    vote: Self::proposal_vote(meta.id, &who)?,
                 })
             })
             .collect::<Vec<_>>()

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -15,80 +15,54 @@
 
 //! # Pips Module
 //!
-//! Polymesh Improvement Proposals (PIPs) are dispatchables that can be `propose`d for execution.
-//! These PIPs can either be proposed by a committee, or they can be proposed by a community member,
-//! in which case they can `vote`d on by all POLYX token holders.
-//! Once created, a proposal first enters a cool-off period, during which it can be amended
-//! (via `amend_proposal` and `vote`) or cancelled (via `cancel_proposal`) but not approved.
-//! During cool-off, only the PIPs proposer can use `vote`.
-//!
-//! Voting, or rather "signalling", which currently scales linearly with POLX,
-//! in this system is used to direct the Governance Councils (GCs)
-//! attention by moving proposals up and down a review queue, specific to community proposals.
-//!
-//! From time to time, the GC will take a `snapshot` of this queue,
-//! meet and review PIPs, and reject, approve, or skip the proposal (via `enact_snapshot_results`).
-//! Any approved PIPs from this snapshot will then be scheduled,
-//! in order of signal value, to be executed automatically on the blockchain.
-//! However, using `reschedule_proposal`, a special Release Coordinator (RC), a member of the GC,
-//! can reschedule approved PIPs at will, except for a PIP to replace the RC.
-//! Once no longer relevant, the snapshot can be cleared by the GC through `clear_snapshot`.
-//!
-//! As aforementioned, the GC can skip a PIP, which will increments its "skipped count".
-//! Should a configurable limit for the skipped count be exceeded, a PIP can no longer be skipped.
-//!
-//! Committee proposals, as noted before, do not enter the snapshot or receive votes.
-//! However, the GC can at any moment approve such a PIP via `approve_committee_proposal`.
-//!
-//! Should the GC want to reject an active (scheduled or pending) proposal,
-//! they can do so at any time using `reject_proposal`.
-//! For garbage collection purposes, it is also possible to use `prune_proposal`,
-//! which will, without any restrictions on its state, remove the PIP's storage.
-//!
+//! Polymesh Improvement Proposals (PIPs) are proposals (ballots) that can be proposed and voted on
+//! by all POLYX token holders. If a ballot passes this community token holder vote it is then passed to the
+//! governance council to ratify (or reject).
+//! - minimum of 5,000 POLYX needs to be staked by the proposer of the ballot
+//! in order to create a new ballot.
+//! - minimum of 100,000 POLYX (quorum) needs to vote in favour of the ballot in order for the
+//! ballot to be considered by the governing committee.
+//! - ballots run for 1 week
+//! - a simple majority is needed to pass the ballot so that it heads for the
+//! next stage (governing committee)
 //!
 //! ## Overview
 //!
 //! The Pips module provides functions for:
 //!
-//! - Proposing and amending PIPs
-//! - Signalling (voting) on them for adjusting priority in the review queue
-//! - Taking and clearing snapshots of the queue
-//! - Approving, rejecting, skipping, and rescheduling PIPs
+//! - Creating Mesh Improvement Proposals
+//! - Voting on Mesh Improvement Proposals
+//! - Governance committee to ratify or reject proposals
 //!
 //! ## Interface
 //!
 //! ### Dispatchable Functions
 //!
-//! #### Configuration changes
-//!
 //! - `set_prune_historical_pips` change whether historical PIPs are pruned
 //! - `set_min_proposal_deposit` change min deposit to create a proposal
+//! - `set_quorum_threshold` change stake required to make a proposal into a referendum
+//! - `set_proposal_duration` change duration in blocks for which proposal stays active
 //! - `set_proposal_cool_off_period` change duration in blocks for which a proposal can be amended
-//! - `set_default_enactment_period` change the period after enactment after which the proposal is executed
-//! - `set_max_pip_skip_count` change the maximum times a PIP can be skipped
-//! - `set_active_pip_limit` change the maximum number of concurrently active PIPs
-//!
-//! #### Other
-//!
-//! - `propose` - token holders can propose a new PIP.
+//! - `set_default_enact_period` change the period after enactment after which the proposal is executed
+//! - `propose` - token holders can propose a new ballot.
 //! - `amend_proposal` - allows the creator of a proposal to amend the proposal details
 //! - `cancel_proposal` - allows the creator of a proposal to cancel the proposal
-//! - `vote` - token holders, including the PIP's proposer, can vote on a PIP.
-//! - `approve_committee_proposal` - allows the GC to approve a committee proposal
-//! - `reject_proposal` - reject an active proposal and refund deposits
-//! - `prune_proposal` - prune all storage associated with proposal and refund deposits
-//! - `reschedule_execution` - release coordinator can reschedule a PIPs execution
-//! - `clear_snapshot` - clears the snapshot
-//! - `snapshot` - takes a new snapshot of the review queue
-//! - `enact_snapshot_results` - enters results (approve, reject, and skip) for PIPs in snapshot
+//! - `bond_additional_deposit` - allows the creator of a proposal to bond additional POLYX to it
+//! - `unbond_deposit` - allows the creator of a proposal to unbond POLYX from it
+//! - `vote` - Token holders can vote on a ballot.
+//! - `kill_proposal` - close a proposal and refund all deposits
+//! - `fast_track_proposal` - move a proposal to a referendum stage
+//! - `emergency_referendum` - create an emergency referndum, bypassing the token holder vote
+//! - `reject_referendum` - reject a referendum which will be closed without executing
+//! - `override_referendum_enactment_period` - release coordinator can reschedule a referendum
+//! - `enact_referendum` committee calls to execute a referendum
 //!
 //! ### Public Functions
 //!
-//! - `end_block` - executes scheduled proposals
+//! - `end_block` - processes pending proposals and referendums
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use core::mem;
 use frame_support::{
     debug, decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
@@ -96,6 +70,7 @@ use frame_support::{
     storage::IterableStorageMap,
     traits::{Currency, EnsureOrigin, LockableCurrency, ReservableCurrency},
     weights::{DispatchClass, Pays, Weight},
+    Parameter,
 };
 use frame_system::{self as system, ensure_signed};
 use pallet_identity as identity;
@@ -104,18 +79,17 @@ use polymesh_common_utilities::{
     constants::PIP_MAX_REPORTING_SIZE,
     identity::Trait as IdentityTrait,
     protocol_fee::{ChargeProtocolFee, ProtocolOp},
-    traits::{
-        balances::LockableCurrencyExt, governance_group::GovernanceGroupTrait, group::GroupTrait,
-        pip::PipId,
-    },
+    traits::{governance_group::GovernanceGroupTrait, group::GroupTrait, pip::PipId},
     with_transaction, CommonTrait, Context, GC_DID,
 };
-use polymesh_primitives::IdentityId;
+use polymesh_primitives::{Beneficiary, IdentityId};
 use polymesh_primitives_derive::VecU8StrongTyped;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
-use sp_runtime::traits::{BlakeTwo256, CheckedAdd, Dispatchable, Hash, Saturating, Zero};
+use sp_runtime::traits::{
+    BlakeTwo256, CheckedAdd, CheckedSub, Dispatchable, Hash, Saturating, Zero,
+};
 use sp_std::{convert::From, prelude::*};
 
 /// Balance
@@ -137,13 +111,15 @@ pub struct PipDescription(pub Vec<u8>);
 /// Represents a proposal
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Pip<Proposal> {
+pub struct Pip<Proposal, Balance> {
     /// The proposal's unique id.
     pub id: PipId,
     /// The proposal being voted on.
     pub proposal: Proposal,
     /// The latest state
     pub state: ProposalState,
+    /// Beneficiaries of this Pips
+    pub beneficiaries: Option<Vec<Beneficiary<Balance>>>,
 }
 
 /// A result of execution of get_votes.
@@ -171,32 +147,15 @@ pub enum ProposalData {
     Proposal(Vec<u8>),
 }
 
-/// The various sorts of committees that can make a PIP.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
-pub enum Committee {
-    /// The technical committee.
-    Technical,
-    /// The upgrade committee tends to propose chain upgrades.
-    Upgrade,
-}
-
-/// The proposer of a certain PIP.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
-pub enum Proposer<AccountId> {
-    /// The proposer is of the community.
-    Community(AccountId),
-    /// The proposer is a committee.
-    Committee(Committee),
-}
-
 /// Represents a proposal metadata
-#[derive(Encode, Decode, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub struct PipsMetadata<T: Trait> {
-    /// They creator
-    pub proposer: Proposer<T::AccountId>,
+    /// The creator
+    pub proposer: T::AccountId,
     /// The proposal's unique id.
     pub id: PipId,
+    /// When voting will end.
+    pub end: T::BlockNumber,
     /// The proposal url for proposal discussion.
     pub url: Option<Url>,
     /// The proposal description.
@@ -209,7 +168,7 @@ pub struct PipsMetadata<T: Trait> {
 /// For keeping track of proposal being voted on.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct VotingResult<Balance> {
+pub struct VotingResult<Balance: Parameter> {
     /// The current set of voters that approved with their stake.
     pub ayes_count: u32,
     pub ayes_stake: Balance,
@@ -218,15 +177,19 @@ pub struct VotingResult<Balance> {
     pub nays_stake: Balance,
 }
 
-/// A "vote" or "signal" on a PIP to move it up or down the review queue.
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode)]
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-pub struct Vote<Balance>(
-    /// `true` if there's agreement.
-    pub bool,
-    /// How strongly do they feel about it?
-    pub Balance,
-);
+pub enum Vote<Balance> {
+    None,
+    Yes(Balance),
+    No(Balance),
+}
+
+impl<Balance> Default for Vote<Balance> {
+    fn default() -> Self {
+        Vote::None
+    }
+}
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
@@ -239,21 +202,18 @@ pub type HistoricalVotingByAddress<VoteType> = Vec<VoteByPip<VoteType>>;
 pub type HistoricalVotingById<AccountId, VoteType> =
     Vec<(AccountId, HistoricalVotingByAddress<VoteType>)>;
 
-/// The state a PIP is in.
 #[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ProposalState {
-    /// Proposal is created and either in the cool-down period or open to voting.
+    /// Proposal is created and either in the cool-down period or open to voting
     Pending,
-    /// Proposal is cancelled by its owner.
+    /// Proposal is cancelled by its owner
     Cancelled,
-    /// Proposal was rejected by the GC.
+    /// Proposal was killed by the GC
+    Killed,
+    /// Proposal failed to pass by a community vote
     Rejected,
-    /// Proposal has been approved by the GC and scheduled for execution.
-    Scheduled,
-    /// Proposal execution was attempted by failed.
-    Failed,
-    /// Proposal was successfully executed.
-    Executed,
+    /// Proposal has moved to referendum stage
+    Referendum,
 }
 
 impl Default for ProposalState {
@@ -262,54 +222,59 @@ impl Default for ProposalState {
     }
 }
 
+#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum ReferendumState {
+    /// Pending GC ratification
+    Pending,
+    /// Execution of this PIP is scheduled, i.e. it needs to wait its enactment period.
+    Scheduled,
+    /// Rejected by the GC
+    Rejected,
+    /// It has been executed, but execution failed.
+    Failed,
+    /// It has been successfully executed.
+    Executed,
+}
+
+#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum ReferendumType {
+    /// Referendum pushed by GC (fast-tracked)
+    FastTracked,
+    /// Referendum created by GC
+    Emergency,
+    /// Created through a community vote
+    Community,
+}
+
+/// Properties of a referendum
+#[derive(Encode, Decode, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Referendum<T: Trait> {
+    /// The proposal's unique id.
+    pub id: PipId,
+    /// Current state of this Referendum.
+    pub state: ReferendumState,
+    /// The type of the referendum
+    pub referendum_type: ReferendumType,
+    /// Enactment period.
+    pub enactment_period: T::BlockNumber,
+}
+
 /// Information about deposit.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct DepositInfo<AccountId, Balance> {
+pub struct DepositInfo<AccountId, Balance>
+where
+    AccountId: Default,
+    Balance: Default,
+{
     /// Owner of the deposit.
     pub owner: AccountId,
     /// Amount. It can be updated during the cool off period.
     pub amount: Balance,
 }
-
-/// A snapshot's metadata, containing when it was created and who triggered it.
-/// The priority queue is stored separately (see `SnapshottedPip`).
-#[derive(Encode, Decode, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
-pub struct SnapshotMetadata<T: Trait> {
-    /// The block when the snapshot was made.
-    pub created_at: T::BlockNumber,
-    /// Who triggered this snapshot? Should refer to someone in the GC.
-    pub made_by: T::AccountId,
-}
-
-/// A PIP in the snapshot's priority queue for consideration by the GC.
-#[derive(Encode, Decode, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
-pub struct SnapshottedPip<T: Trait> {
-    /// Identifies the PIP this refers to.
-    pub id: PipId,
-    /// Weight of the proposal in the snapshot's priority queue.
-    /// Higher weights come before lower weights.
-    /// The `bool` denotes the sign, where `true` siginfies a positive number.
-    pub weight: (bool, BalanceOf<T>),
-}
-
-/// A result to enact for one or many PIPs in the snapshot queue.
-// This type is only here due to `enact_snapshot_results`.
-#[derive(codec::Encode, codec::Decode, Copy, Clone, PartialEq, Eq, Debug)]
-pub enum SnapshotResult {
-    /// Approve the PIP and move it to the execution queue.
-    Approve,
-    /// Reject the PIP, removing it from future consideration.
-    Reject,
-    /// Skip the PIP, bumping the `skipped_count`,
-    /// or fail if the threshold for maximum skips is exceeded.
-    Skip,
-}
-
-/// The number of times a PIP has been skipped.
-pub type SkippedCount = u8;
 
 type Identity<T> = identity::Module<T>;
 
@@ -318,9 +283,8 @@ pub trait Trait:
     frame_system::Trait + pallet_timestamp::Trait + IdentityTrait + CommonTrait
 {
     /// Currency type for this module.
-    // TODO(centril): Remove `ReservableCurrency` bound once `on_runtime_upgrade` is nixed.
-    type Currency: LockableCurrencyExt<Self::AccountId, Moment = Self::BlockNumber>
-        + frame_support::traits::ReservableCurrency<Self::AccountId>;
+    type Currency: ReservableCurrency<Self::AccountId>
+        + LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 
     /// Origin for proposals.
     type CommitteeOrigin: EnsureOrigin<Self::Origin>;
@@ -330,12 +294,6 @@ pub trait Trait:
 
     /// Committee
     type GovernanceCommittee: GovernanceGroupTrait<<Self as pallet_timestamp::Trait>::Moment>;
-
-    /// Voting majority origin for Technical Committee.
-    type TechnicalCommitteeVMO: EnsureOrigin<Self::Origin>;
-
-    /// Voting majority origin for Upgrade Committee.
-    type UpgradeCommitteeVMO: EnsureOrigin<Self::Origin>;
 
     type Treasury: TreasuryTrait<<Self as CommonTrait>::Balance>;
 
@@ -349,31 +307,26 @@ decl_storage! {
         /// Determines whether historical PIP data is persisted or removed
         pub PruneHistoricalPips get(fn prune_historical_pips) config(): bool;
 
-        /// The minimum amount to be used as a deposit for community PIP creation.
+        /// The minimum amount to be used as a deposit for a public referendum proposal.
         pub MinimumProposalDeposit get(fn min_proposal_deposit) config(): BalanceOf<T>;
+
+        /// Minimum stake a proposal must gather in order to be considered by the committee.
+        pub QuorumThreshold get(fn quorum_threshold) config(): BalanceOf<T>;
 
         /// During Cool-off period, proposal owner can amend any PIP detail or cancel the entire
         /// proposal.
         pub ProposalCoolOffPeriod get(fn proposal_cool_off_period) config(): T::BlockNumber;
 
-        /// Default enactment period that will be use after a proposal is accepted by GC.
-        pub DefaultEnactmentPeriod get(fn default_enactment_period) config(): T::BlockNumber;
-
-        /// Maximum times a PIP can be skipped before triggering `CannotSkipPip` in `enact_snapshot_results`.
-        pub MaxPipSkipCount get(fn max_pip_skip_count) config(): SkippedCount;
-
-        /// The maximum allowed number for `ActivePipCount`.
-        /// Once reached, new PIPs cannot be proposed by community members.
-        pub ActivePipLimit get(fn active_pip_limit) config(): u32;
+        /// How long (in blocks) a ballot runs
+        pub ProposalDuration get(fn proposal_duration) config(): T::BlockNumber;
 
         /// Proposals so far. id can be used to keep track of PIPs off-chain.
-        PipIdSequence get(fn pip_id_sequence): u32;
-
-        /// Total count of current pending or scheduled PIPs.
-        ActivePipCount get(fn active_pip_count): u32;
+        PipIdSequence: u32;
 
         /// The metadata of the active proposals.
         pub ProposalMetadata get(fn proposal_metadata): map hasher(twox_64_concat) PipId => Option<PipsMetadata<T>>;
+        /// It maps the block number where a list of proposal are considered as matured.
+        pub ProposalsMaturingAt get(fn proposals_maturing_at): map hasher(twox_64_concat) T::BlockNumber => Vec<PipId>;
 
         /// Those who have locked a deposit.
         /// proposal (id, proposer) -> deposit
@@ -381,7 +334,7 @@ decl_storage! {
 
         /// Actual proposal for a given id, if it's current.
         /// proposal id -> proposal
-        pub Proposals get(fn proposals): map hasher(twox_64_concat) PipId => Option<Pip<T::Proposal>>;
+        pub Proposals get(fn proposals): map hasher(twox_64_concat) PipId => Option<Pip<T::Proposal, T::Balance>>;
 
         /// PolymeshVotes on a given proposal, if it is ongoing.
         /// proposal id -> vote count
@@ -389,28 +342,18 @@ decl_storage! {
 
         /// Votes per Proposal and account. Used to avoid double vote issue.
         /// (proposal id, account) -> Vote
-        pub ProposalVotes get(fn proposal_vote): double_map hasher(twox_64_concat) PipId, hasher(twox_64_concat) T::AccountId => Option<Vote<BalanceOf<T>>>;
+        pub ProposalVotes get(fn proposal_vote): double_map hasher(twox_64_concat) PipId, hasher(twox_64_concat) T::AccountId => Vote<BalanceOf<T>>;
 
-        /// Maps PIPs to the block at which they will be executed, if any.
-        pub PipToSchedule get(fn pip_to_schedule): map hasher(twox_64_concat) PipId => Option<T::BlockNumber>;
+        /// Proposals that have met the quorum threshold to be put forward to a governance committee
+        /// proposal id -> proposal
+        pub Referendums get(fn referendums): map hasher(twox_64_concat) PipId => Option<Referendum<T>>;
 
-        /// Maps block numbers to list of PIPs which should be executed at the block number.
+        /// List of id's of current scheduled referendums.
         /// block number -> Pip id
-        pub ExecutionSchedule get(fn execution_schedule): map hasher(twox_64_concat) T::BlockNumber => Vec<PipId>;
+        pub ScheduledReferendumsAt get(fn scheduled_referendums_at): map hasher(twox_64_concat) T::BlockNumber => Vec<PipId>;
 
-        /// The priority queue (lowest priority at index 0) of PIPs at the point of snapshotting.
-        /// Priority is defined by the `weight` in the `SnapshottedPIP`.
-        ///
-        /// A queued PIP can be skipped. Doing so bumps the `pip_skip_count`.
-        /// Once a (configurable) threshhold is exceeded, a PIP cannot be skipped again.
-        pub SnapshotQueue get(fn snapshot_queue): Vec<SnapshottedPip<T>>;
-
-        /// The metadata of the snapshot, if there is one.
-        pub SnapshotMeta get(fn snapshot_metadata): Option<SnapshotMetadata<T>>;
-
-        /// The number of times a certain PIP has been skipped.
-        /// Once a (configurable) threshhold is exceeded, a PIP cannot be skipped again.
-        pub PipSkipCount get(fn pip_skip_count): map hasher(twox_64_concat) PipId => SkippedCount;
+        /// Default enactment period that will be use after a proposal is accepted by GC.
+        pub DefaultEnactmentPeriod get(fn default_enactment_period) config(): T::BlockNumber;
     }
 }
 
@@ -427,55 +370,54 @@ decl_event!(
         ///
         /// # Parameters:
         ///
-        /// Caller DID, Proposer, PIP ID, deposit, URL, description, cool-off period end, proposal data.
+        /// Caller DID, Proposer, PIP ID, deposit, URL, description, cool-off period end, proposal end, proposal
+        /// data.
         ProposalCreated(
             IdentityId,
-            Proposer<AccountId>,
+            AccountId,
             PipId,
             Balance,
             Option<Url>,
             Option<PipDescription>,
             BlockNumber,
+            BlockNumber,
             ProposalData,
         ),
         /// A PIP's details (url & description) were amended.
-        ProposalDetailsAmended(IdentityId, Proposer<AccountId>, PipId, Option<Url>, Option<PipDescription>),
+        ProposalDetailsAmended(IdentityId, AccountId, PipId, Option<Url>, Option<PipDescription>),
+        /// The deposit of a vote on a PIP was adjusted, either by increasing or decreasing.
+        /// `true` represents an increase and `false` a decrease.
+        ProposalBondAdjusted(IdentityId, AccountId, PipId, bool, Balance),
         /// Triggered each time the state of a proposal is amended
         ProposalStateUpdated(IdentityId, PipId, ProposalState),
         /// `AccountId` voted `bool` on the proposal referenced by `PipId`
         Voted(IdentityId, AccountId, PipId, bool, Balance),
         /// Pip has been closed, bool indicates whether data is pruned
         PipClosed(IdentityId, PipId, bool),
-        /// Execution of a PIP has been scheduled at specific block.
-        ExecutionScheduled(IdentityId, PipId, BlockNumber, BlockNumber),
+        /// Referendum created for proposal.
+        ReferendumCreated(IdentityId, PipId, ReferendumType),
+        /// Referendum execution has been scheduled at specific block.
+        ReferendumScheduled(IdentityId, PipId, BlockNumber, BlockNumber),
+        /// Triggered each time the state of a referendum is amended
+        ReferendumStateUpdated(IdentityId, PipId, ReferendumState),
         /// Default enactment period (in blocks) has been changed.
         /// (caller DID, old period, new period)
         DefaultEnactmentPeriodChanged(IdentityId, BlockNumber, BlockNumber),
         /// Minimum deposit amount modified
         /// (caller DID, old amount, new amount)
         MinimumProposalDepositChanged(IdentityId, Balance, Balance),
+        /// Minimum quorum threshold modified
+        /// (caller DID, old threshold, new threshold)
+        QuorumThresholdChanged(IdentityId, Balance, Balance),
         /// Cool off period for proposals modified
         /// (caller DID, old period, new period)
         ProposalCoolOffPeriodChanged(IdentityId, BlockNumber, BlockNumber),
-        /// The maximum times a PIP can be skipped was changed.
-        /// (caller DID, old value, new value)
-        MaxPipSkipCountChanged(IdentityId, SkippedCount, SkippedCount),
-        /// The maximum number of active PIPs was changed.
-        /// (caller DID, old value, new value)
-        ActivePipLimitChanged(IdentityId, u32, u32),
+        /// Proposal duration changed
+        /// (old value, new value)
+        ProposalDurationChanged(IdentityId, BlockNumber, BlockNumber),
         /// Refund proposal
         /// (id, total amount)
         ProposalRefund(IdentityId, PipId, Balance),
-        /// The snapshot was cleared.
-        SnapshotCleared(IdentityId),
-        /// A new snapshot was taken.
-        SnapshotTaken(IdentityId),
-        /// A PIP in the snapshot queue was skipped.
-        /// (gc_did, pip_id, new_skip_count)
-        PipSkipped(IdentityId, PipId, SkippedCount),
-        /// Results (e.g., approved, rejected, and skipped), were enacted for some PIPs.
-        /// (gc_did, skipped_pips_with_new_count, rejected_pips, approved_pips)
-        SnapshotResultsEnacted(IdentityId, Vec<(PipId, SkippedCount)>, Vec<PipId>, Vec<PipId>),
     }
 );
 
@@ -483,19 +425,14 @@ decl_error! {
     pub enum Error for Module<T: Trait> {
         /// Incorrect origin
         BadOrigin,
-        /// The given dispatchable call is not valid for this proposal.
-        /// The proposal must be from the community, but isn't.
-        NotFromCommunity,
-        /// The given dispatchable call is not valid for this proposal.
-        /// The proposal must be by community, but isn't.
-        NotByCommittee,
-        /// The current number of active (pending | scheduled) PIPs exceed the maximum
-        /// and the proposal is not by a committee.
-        TooManyActivePips,
         /// Proposer specifies an incorrect deposit
         IncorrectDeposit,
         /// Proposer can't afford to lock minimum deposit
         InsufficientDeposit,
+        /// when voter vote gain
+        DuplicateVote,
+        /// Duplicate proposal.
+        DuplicateProposal,
         /// The proposal does not exist.
         NoSuchProposal,
         /// Not part of governance committee.
@@ -504,6 +441,10 @@ decl_error! {
         ProposalOnCoolOffPeriod,
         /// Proposal is immutable after cool-off period.
         ProposalIsImmutable,
+        /// Referendum is still on its enactment period.
+        ReferendumOnEnactmentPeriod,
+        /// Referendum is immutable.
+        ReferendumIsImmutable,
         /// When a block number is less than current block number.
         InvalidFutureBlockNumber,
         /// When number of votes overflows.
@@ -512,14 +453,16 @@ decl_error! {
         StakeAmountOfVotesExceeded,
         /// Missing current DID
         MissingCurrentIdentity,
+        /// Cool off period is too large relative to the proposal duration
+        BadCoolOffPeriod,
+        /// The proposal duration is too small relative to the cool off period
+        BadProposalDuration,
+        /// Referendum is not in the correct state
+        IncorrectReferendumState,
         /// Proposal is not in the correct state
         IncorrectProposalState,
-        /// When enacting snapshot results, an unskippable PIP was skipped.
-        CannotSkipPip,
-        /// Tried to enact results for the snapshot queue overflowing its length.
-        SnapshotResultTooLarge,
-        /// Tried to enact result for PIP with id different from that at the position in the queue.
-        SnapshotIdMismatch
+        /// Insufficient treasury funds to pay beneficiaries
+        InsufficientTreasuryFunds,
     }
 }
 
@@ -530,56 +473,6 @@ decl_module! {
         type Error = Error<T>;
 
         fn deposit_event() = default;
-
-        fn on_runtime_upgrade() -> Weight {
-            // Larger goal here is to clear Governance V1.
-            use frame_support::{
-                storage::{unhashed, IterableStorageDoubleMap, migration::StorageIterator},
-                traits::ReservableCurrency,
-                Twox128, StorageHasher
-            };
-
-            // 1. Start with refunding all deposits.
-            // As we've `drain`ed  `Deposits`, we need not do so again below.
-            for (_, _, depo) in <Deposits<T>>::drain() {
-                <T as Trait>::Currency::unreserve(&depo.owner, depo.amount);
-            }
-
-            // 2. Then we clear various storage items that were present on V1.
-            // For future reference, the storage items are defined in:
-            // https://github.com/PolymathNetwork/Polymesh/blob/0047b2570e7ac57771b4153d25867166e8091b9a/pallets/pips/src/lib.rs#L308-L357
-
-            // 2a) Clear all the `map`s and `double_map`s by fully consuming a draining iterator.
-            for item in &[
-                "ProposalMetadata",
-                "ProposalsMaturingAt",
-                "Proposals",
-                "ProposalResult",
-                "Referendums",
-                "ScheduledReferendumsAt",
-                "ProposalVotes",
-            ] {
-                StorageIterator::<()>::new(b"Pips", item.as_bytes()).drain().for_each(drop)
-            }
-
-            // 2b) Reset the PIP ID sequence to `0`.
-            PipIdSequence::kill();
-
-            // 2c) Remove items no longer used in V2.
-            fn storage_value_final_key(module: &[u8], item: &[u8]) -> [u8; 32] {
-                let mut final_key = [0u8; 32];
-                final_key[0..16].copy_from_slice(&Twox128::hash(module));
-                final_key[16..32].copy_from_slice(&Twox128::hash(item));
-                final_key
-            }
-            for item in &["ProposalDuration", "QuorumThreshold"] {
-                unhashed::kill(&storage_value_final_key(b"Pips", item.as_bytes()));
-            }
-
-            // Done; we've cleared all V1 storage needed; V2 can now be filled in.
-            // As for the weight, clearing costs much more than this, but let's pretend.
-            0
-        }
 
         /// Change whether completed PIPs are pruned. Can only be called by governance council
         ///
@@ -604,139 +497,129 @@ decl_module! {
             <MinimumProposalDeposit<T>>::put(deposit);
         }
 
+        /// Change the quorum threshold amount. This is the amount which a proposal must gather so
+        /// as to be considered by a committee. Only Governance committee is allowed to change
+        /// this value.
+        ///
+        /// # Arguments
+        /// * `threshold` the new quorum threshold amount value
+        #[weight = (150_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn set_quorum_threshold(origin, threshold: BalanceOf<T>) {
+            T::CommitteeOrigin::ensure_origin(origin)?;
+            Self::deposit_event(RawEvent::MinimumProposalDepositChanged(GC_DID, Self::quorum_threshold(), threshold));
+            <QuorumThreshold<T>>::put(threshold);
+        }
+
+        /// Change the proposal duration value. This is the number of blocks for which votes are
+        /// accepted on a proposal. Only Governance committee is allowed to change this value.
+        ///
+        /// # Arguments
+        /// * `duration` proposal duration in blocks
+        #[weight = (150_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn set_proposal_duration(origin, duration: T::BlockNumber) {
+            T::CommitteeOrigin::ensure_origin(origin)?;
+            Self::deposit_event(RawEvent::ProposalDurationChanged(GC_DID, Self::proposal_duration(), duration));
+            <ProposalDuration<T>>::put(duration);
+        }
+
+
         /// Change the proposal cool off period value. This is the number of blocks after which the proposer of a pip
         /// can modify or cancel their proposal, and other voting is prohibited
         ///
         /// # Arguments
         /// * `duration` proposal cool off period duration in blocks
-        #[weight = (550_000_000, DispatchClass::Operational, Pays::Yes)]
+        #[weight = (150_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn set_proposal_cool_off_period(origin, duration: T::BlockNumber) {
             T::CommitteeOrigin::ensure_origin(origin)?;
-            Self::deposit_event(RawEvent::ProposalCoolOffPeriodChanged(GC_DID, Self::proposal_cool_off_period(), duration));
+            Self::deposit_event(RawEvent::ProposalDurationChanged(GC_DID, Self::proposal_cool_off_period(), duration));
             <ProposalCoolOffPeriod<T>>::put(duration);
         }
 
         /// Change the default enact period.
-        #[weight = (550_000_000, DispatchClass::Operational, Pays::Yes)]
+        #[weight = (300_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn set_default_enactment_period(origin, duration: T::BlockNumber) {
             T::CommitteeOrigin::ensure_origin(origin)?;
-            let prev = <DefaultEnactmentPeriod<T>>::get();
+            let previous_duration = <DefaultEnactmentPeriod<T>>::get();
             <DefaultEnactmentPeriod<T>>::put(duration);
-            Self::deposit_event(RawEvent::DefaultEnactmentPeriodChanged(GC_DID, prev, duration));
-        }
-
-        /// Change the maximum skip count (`max_pip_skip_count`).
-        /// New values only
-        #[weight = (150_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn set_max_pip_skip_count(origin, new_max: SkippedCount) {
-            T::CommitteeOrigin::ensure_origin(origin)?;
-            let prev_max = MaxPipSkipCount::get();
-            MaxPipSkipCount::put(new_max);
-            Self::deposit_event(RawEvent::MaxPipSkipCountChanged(GC_DID, prev_max, new_max));
-        }
-
-        /// Change the maximum number of active PIPs before community members cannot propose anything.
-        #[weight = (150_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn set_active_pip_limit(origin, new_max: u32) {
-            T::CommitteeOrigin::ensure_origin(origin)?;
-            let prev_max = ActivePipLimit::get();
-            ActivePipLimit::put(new_max);
-            Self::deposit_event(RawEvent::ActivePipLimitChanged(GC_DID, prev_max, new_max));
+            Self::deposit_event(RawEvent::DefaultEnactmentPeriodChanged(GC_DID, duration, previous_duration));
         }
 
         /// A network member creates a PIP by submitting a dispatchable which
         /// changes the network in someway. A minimum deposit is required to open a new proposal.
         ///
         /// # Arguments
-        /// * `proposer` is either a signing key or committee.
-        ///    Used to understand whether this is a committee proposal and verified against `origin`.
         /// * `proposal` a dispatchable call
-        /// * `deposit` minimum deposit value, which is ignored if `proposer` is a committee.
+        /// * `deposit` minimum deposit value
         /// * `url` a link to a website for proposal discussion
         #[weight = (1_850_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn propose(
             origin,
-            proposer: Proposer<T::AccountId>,
             proposal: Box<T::Proposal>,
             deposit: BalanceOf<T>,
             url: Option<Url>,
             description: Option<PipDescription>,
+            beneficiaries: Option<Vec<Beneficiary<T::Balance>>>
         ) -> DispatchResult {
-            // 1. Ensure it's really the `proposer`.
-            Self::ensure_signed_by(origin, &proposer)?;
+            let proposer = ensure_signed(origin)?;
 
-            let did = Self::current_did_or_missing()?;
+            // Pre conditions: caller must have min balance
+            ensure!(
+                deposit >= Self::min_proposal_deposit(),
+                Error::<T>::IncorrectDeposit
+            );
 
-            // 2. Add a deposit for community PIPs.
-            if let Proposer::Community(ref proposer) = proposer {
-                // ...but first make sure active PIP limit isn't crossed.
-                // This doesn't apply to committee PIPs.
-                // `0` is special and denotes no limit.
-                let limit = ActivePipLimit::get();
-                ensure!(limit == 0 || ActivePipCount::get() < limit, Error::<T>::TooManyActivePips);
-
-                // Pre conditions: caller must have min balance.
-                ensure!(deposit >= Self::min_proposal_deposit(), Error::<T>::IncorrectDeposit);
-
-                // Reserve the minimum deposit.
-                <T as Trait>::Currency::reserve(&proposer, deposit)
-                    .map_err(|_| Error::<T>::InsufficientDeposit)?;
-            } else {
-                // Committee PIPs cannot have a deposit.
-                ensure!(deposit.is_zero(), Error::<T>::NotFromCommunity);
-            }
-
-            // 3. Charge protocol fees, even for committee PIPs.
+            // Reserve the minimum deposit
+            <T as Trait>::Currency::reserve(&proposer, deposit).map_err(|_| Error::<T>::InsufficientDeposit)?;
             <T as IdentityTrait>::ProtocolFee::charge_fee(ProtocolOp::PipsPropose)?;
 
-            // 4. Construct and add PIP to storage.
             let id = Self::next_pip_id();
-            ActivePipCount::mutate(|count| *count += 1);
-            let cool_off_until = <system::Module<T>>::block_number() + Self::proposal_cool_off_period();
+            let curr_block_number = <system::Module<T>>::block_number();
+            let cool_off_until = curr_block_number + Self::proposal_cool_off_period();
+            let end = cool_off_until + Self::proposal_duration();
             let proposal_metadata = PipsMetadata {
                 proposer: proposer.clone(),
                 id,
+                end: end,
                 url: url.clone(),
                 description: description.clone(),
                 cool_off_until: cool_off_until,
             };
+            <ProposalsMaturingAt<T>>::append(end, id);
             <ProposalMetadata<T>>::insert(id, proposal_metadata);
 
+            let deposit_info = DepositInfo {
+                owner: proposer.clone(),
+                amount: deposit
+            };
+            <Deposits<T>>::insert(id, &proposer, deposit_info);
             let proposal_data = Self::reportable_proposal_data(&*proposal);
             let pip = Pip {
                 id,
                 proposal: *proposal,
                 state: ProposalState::Pending,
+                beneficiaries,
             };
             <Proposals<T>>::insert(id, pip);
 
-            // 5. Record the deposit and as a signal if we have a community PIP.
-            if let Proposer::Community(ref proposer) = proposer {
-                let deposit_info = DepositInfo {
-                    owner: proposer.clone(),
-                    amount: deposit
-                };
-                <Deposits<T>>::insert(id, &proposer, deposit_info);
-
-                // Add vote and update voting counter.
-                // INTERNAL: It is impossible to overflow counters in the first vote.
-                Self::unsafe_vote(id, proposer.clone(), Vote(true, deposit))
-                    .map_err(|vote_error| {
-                        debug::error!("The counters of voting (id={}) have an overflow during the 1st vote", id);
-                        vote_error
-                    })?;
-            }
-
-            // 6. Emit the event.
+            // Add vote and update voting counter.
+            // INTERNAL: It is impossible to overflow counters in the first vote.
+            Self::unsafe_vote( id, proposer.clone(), Vote::Yes(deposit))
+                .map_err(|vote_error| {
+                    debug::error!("The counters of voting (id={}) have an overflow during the 1st vote", id);
+                    vote_error
+                })?;
+            let current_did = Self::current_did_or_missing()?;
             Self::deposit_event(RawEvent::ProposalCreated(
-                did,
+                current_did,
                 proposer,
                 id,
                 deposit,
                 url,
                 description,
                 cool_off_until,
+                end,
                 proposal_data,
+                //beneficiaries,
             ));
             Ok(())
         }
@@ -749,24 +632,33 @@ decl_module! {
         ///
         #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn amend_proposal(
-            origin,
-            id: PipId,
-            url: Option<Url>,
-            description: Option<PipDescription>,
+                origin,
+                id: PipId,
+                url: Option<Url>,
+                description: Option<PipDescription>
         ) -> DispatchResult {
-            // 1. Fetch proposer and perform sanity checks.
-            let proposer = Self::ensure_owned_by_alterable(origin, id)?;
-            let current_did = Self::current_did_or_missing()?;
+            // 0. Initial info.
+            let proposer = ensure_signed(origin)?;
+            let meta = Self::proposal_metadata(id)
+                .ok_or_else(|| Error::<T>::NoSuchProposal)?;
 
-            // 2. Update proposal metadata.
-            <ProposalMetadata<T>>::mutate(id, |meta| {
+            // 1. Only owner can cancel it.
+            ensure!( meta.proposer == proposer, Error::<T>::BadOrigin);
+            // Check that the proposal is pending
+            Self::is_proposal_state(id, ProposalState::Pending)?;
+
+            // 2. Proposal can be cancelled *ONLY* during its cool-off period.
+            let curr_block_number = <system::Module<T>>::block_number();
+            ensure!( meta.cool_off_until > curr_block_number, Error::<T>::ProposalIsImmutable);
+
+            // 3. Update proposal metadata.
+            <ProposalMetadata<T>>::mutate( id, |meta| {
                 if let Some(meta) = meta {
                     meta.url = url.clone();
                     meta.description = description.clone();
                 }
             });
-
-            // 3. Emit event.
+            let current_did = Self::current_did_or_missing()?;
             Self::deposit_event(RawEvent::ProposalDetailsAmended(current_did, proposer, id, url, description));
 
             Ok(())
@@ -784,339 +676,330 @@ decl_module! {
             // 1. Fetch proposer and perform sanity checks.
             let _ = Self::ensure_owned_by_alterable(origin, id)?;
 
-            // 2. Close that proposal (including refunding).
-            let did = Context::current_identity::<Identity<T>>().unwrap_or_default();
-            let new_state = Self::update_proposal_state(did, id, ProposalState::Cancelled);
-            Self::prune_data(did, id, new_state, Self::prune_historical_pips());
+            // 2. Refund the bond for the proposal.
+            Self::refund_proposal(id);
+
+            // 3. Close that proposal.
+            Self::update_proposal_state(id, ProposalState::Cancelled);
+            Self::prune_data(id, Self::prune_historical_pips());
 
             Ok(())
         }
 
-        /// Vote either in favor (`aye_or_nay` == true) or against a PIP with `id`.
-        /// The "convinction" or strength of the vote is given by `deposit`, which is reserved.
-        ///
-        /// Note that `vote` is *not* additive.
-        /// That is, `vote(id, true, 50)` followed by `vote(id, true, 40)`
-        /// will first reserve `50` and then refund `50 - 10`, ending up with `40` in deposit.
-        /// To add atop of existing votes, you'll need `existing_deposit + addition`.
-        ///
-        /// # Arguments
-        /// * `id`, proposal id
-        /// * `aye_or_nay`, a bool representing for or against vote
-        /// * `deposit`, the "conviction" with which the vote is made.
+        /// Id bonds an additional deposit to proposal with id `id`.
+        /// That amount is added to the current deposit.
         ///
         /// # Errors
-        /// * `NoSuchProposal` if `id` doesn't reference a valid PIP.
-        /// * `NotFromCommunity` if proposal was made by a committee.
-        /// * `ProposalOnCoolOffPeriod` if non-owner is voting and PIP is cooling off.
-        /// * `IncorrectProposalState` if PIP isn't pending.
-        /// * `InsufficientDeposit` if `origin` cannot reserve `deposit - old_deposit`.
+        /// * `BadOrigin`: Only the owner of the proposal can bond an additional deposit.
+        /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
+        #[weight = 900_000_000]
+        pub fn bond_additional_deposit(origin,
+            id: PipId,
+            additional_deposit: BalanceOf<T>
+        ) -> DispatchResult {
+            // 1. Sanity checks.
+            let proposer = Self::ensure_owned_by_alterable(origin, id)?;
+
+            // 2. Reserve extra deposit & update deposit info for this proposal
+            let curr_deposit = Self::deposits(id, &proposer).amount;
+            let max_additional_deposit = curr_deposit.saturating_add( additional_deposit) - curr_deposit;
+            <T as Trait>::Currency::reserve(&proposer, max_additional_deposit)
+                .map_err(|_| Error::<T>::InsufficientDeposit)?;
+
+            <Deposits<T>>::mutate(
+                id,
+                &proposer,
+                |depo_info| depo_info.amount += max_additional_deposit);
+
+            // 3. Update vote details to record additional vote
+            <ProposalResult<T>>::mutate(
+                id,
+                |stats| stats.ayes_stake += max_additional_deposit
+            );
+            <ProposalVotes<T>>::insert(id, &proposer, Vote::Yes(curr_deposit + max_additional_deposit));
+
+            Self::emit_proposal_bond_adjusted(proposer, id, true, max_additional_deposit)
+        }
+
+        /// It unbonds any amount from the deposit of the proposal with id `id`.
+        ///
+        /// # Errors
+        /// * `BadOrigin`: Only the owner of the proposal can release part of the deposit.
+        /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
+        /// * `InsufficientDeposit`: If the final deposit will be less that the minimum deposit for
+        /// a proposal.
+        #[weight = 900_000_000]
+        pub fn unbond_deposit(origin,
+            id: PipId,
+            amount: BalanceOf<T>
+        ) -> DispatchResult {
+            // 1. Sanity checks.
+            let proposer = Self::ensure_owned_by_alterable(origin, id)?;
+
+            // 2. Double-check that `amount` is valid.
+            let mut depo_info = Self::deposits(id, &proposer);
+            let new_deposit = depo_info.amount.checked_sub(&amount)
+                    .ok_or_else(|| Error::<T>::InsufficientDeposit)?;
+            ensure!(
+                new_deposit >= Self::min_proposal_deposit(),
+                Error::<T>::IncorrectDeposit);
+            let diff_amount = depo_info.amount - new_deposit;
+            depo_info.amount = new_deposit;
+
+            // 2.1. Unreserve and update deposit info.
+            <T as Trait>::Currency::unreserve(&depo_info.owner, diff_amount);
+            <Deposits<T>>::insert(id, &proposer, depo_info);
+
+            // 3. Update vote details to record reduced vote
+            <ProposalResult<T>>::mutate(
+                id,
+                |stats| stats.ayes_stake = new_deposit
+            );
+            <ProposalVotes<T>>::insert(id, &proposer, Vote::Yes(new_deposit));
+
+            Self::emit_proposal_bond_adjusted(proposer, id, false, amount)
+        }
+
+        /// A network member can vote on any PIP by selecting the id that
+        /// corresponds ot the dispatchable action and vote with some balance.
+        ///
+        /// # Arguments
+        /// * `proposal` a dispatchable call
+        /// * `id` proposal id
+        /// * `aye_or_nay` a bool representing for or against vote
+        /// * `deposit` minimum deposit value
         #[weight = 1_000_000_000]
         pub fn vote(origin, id: PipId, aye_or_nay: bool, deposit: BalanceOf<T>) {
-            let voter = ensure_signed(origin)?;
+            let proposer = ensure_signed(origin)?;
             let meta = Self::proposal_metadata(id)
                 .ok_or_else(|| Error::<T>::NoSuchProposal)?;
 
-            // 1. Proposal must be from the community.
-            let proposer = match meta.proposer {
-                Proposer::Committee(_) => return Err(Error::<T>::NotFromCommunity.into()),
-                Proposer::Community(p) => p,
-            };
-
-            if proposer == voter {
-                // 2a. Deposit must be above minimum.
-                // Note that proposer can still vote against their own PIP.
-                ensure!(deposit >= Self::min_proposal_deposit(), Error::<T>::IncorrectDeposit);
-            } else {
-                // 2b. Only proposer can vote during PIP's cool-off period.
-                let curr_block_number = <system::Module<T>>::block_number();
-                ensure!(meta.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
-            }
-
-            // 3. Proposal must be pending.
-            Self::is_proposal_state(id, ProposalState::Pending)?;
-
-            let current_did = Self::current_did_or_missing()?;
-
-            with_transaction(|| {
-                // 4. Reserve the deposit, or refund if needed.
-                let curr_deposit = Self::deposits(id, &voter).amount;
-                if deposit < curr_deposit {
-                    <T as Trait>::Currency::unreserve(&voter, curr_deposit - deposit);
-                } else {
-                    <T as Trait>::Currency::reserve(&voter, deposit - curr_deposit).map_err(|_| Error::<T>::InsufficientDeposit)?;
-                }
-                // 5. Save the vote.
-                Self::unsafe_vote(id, voter.clone(), Vote(aye_or_nay, deposit))
-            })?;
-
-            <Deposits<T>>::insert(id, &voter, DepositInfo {
-                owner: voter.clone(),
-                amount: deposit,
-            });
-
-            // 6. Emit event.
-            Self::deposit_event(RawEvent::Voted(current_did, voter, id, aye_or_nay, deposit));
-        }
-
-        /// Approves the pending non-cooling committee PIP given by the `id`.
-        ///
-        /// # Errors
-        /// * `BadOrigin` unless a GC voting majority executes this function.
-        /// * `NoSuchProposal` if the PIP with `id` doesn't exist.
-        /// * `IncorrectProposalState` if the proposal isn't pending.
-        /// * `ProposalOnCoolOffPeriod` if the proposal is cooling off.
-        /// * `NotByCommittee` if the proposal isn't by a committee.
-        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn approve_committee_proposal(origin, id: PipId) {
-            // 1. Only GC can do this.
-            T::VotingMajorityOrigin::ensure_origin(origin)?;
-
-            // 2. Proposal must be pending.
-            Self::is_proposal_state(id, ProposalState::Pending)?;
-
-            // 3. Proposal must not be cooling-off and must be by committee.
-            let meta = Self::proposal_metadata(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
+            // No one should be able to vote during the proposal cool-off period.
             let curr_block_number = <system::Module<T>>::block_number();
-            ensure!(meta.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
-            ensure!(matches!(meta.proposer, Proposer::Committee(_)), Error::<T>::NotByCommittee);
+            ensure!( meta.cool_off_until <= curr_block_number, Error::<T>::ProposalOnCoolOffPeriod);
 
-            // 4. All is good, schedule PIP for execution.
-            Self::schedule_pip_for_execution(GC_DID, id);
+            // Check that the proposal is pending
+            Self::is_proposal_state(id, ProposalState::Pending)?;
+
+            // Valid PipId
+            ensure!(<ProposalResult<T>>::contains_key(id), Error::<T>::NoSuchProposal);
+
+            // Double-check vote duplication.
+            ensure!( Self::proposal_vote(id, &proposer) == Vote::None, Error::<T>::DuplicateVote);
+
+            // Reserve the deposit
+            <T as Trait>::Currency::reserve(&proposer, deposit).map_err(|_| Error::<T>::InsufficientDeposit)?;
+
+            // Save your vote.
+            let vote = if aye_or_nay {
+                Vote::Yes(deposit)
+            } else {
+                Vote::No(deposit)
+            };
+            Self::unsafe_vote( id, proposer.clone(), vote)
+                .map_err( |vote_error| {
+                    debug::warn!("The counters of voting (id={}) have an overflow, transaction is roll-back", id);
+                    let _ = <T as Trait>::Currency::unreserve(&proposer, deposit);
+                    vote_error
+                })?;
+
+            let depo_info = DepositInfo {
+                owner: proposer.clone(),
+                amount: deposit,
+            };
+            <Deposits<T>>::insert(id, &proposer, depo_info);
+            let current_did = Self::current_did_or_missing()?;
+            Self::deposit_event(RawEvent::Voted(current_did, proposer, id, aye_or_nay, deposit));
         }
 
-        /// Rejects the PIP given by the `id`, refunding any bonded funds,
-        /// assuming it hasn't been cancelled or executed.
-        /// Note that cooling-off and proposals scheduled-for-execution can also be rejected.
-        ///
-        /// # Errors
-        /// * `BadOrigin` unless a GC voting majority executes this function.
-        /// * `NoSuchProposal` if the PIP with `id` doesn't exist.
-        /// * `IncorrectProposalState` if the proposal was cancelled or executed.
+        /// An emergency stop measure to kill a proposal. Governance committee can kill
+        /// a proposal at any time.
         #[weight = (550_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn reject_proposal(origin, id: PipId) {
+        pub fn kill_proposal(origin, id: PipId) {
             T::VotingMajorityOrigin::ensure_origin(origin)?;
-            let proposal = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-            ensure!(Self::is_active(proposal.state), Error::<T>::IncorrectProposalState);
-            Self::maybe_unschedule_pip(id, proposal.state);
-            Self::maybe_unsnapshot_pip(id, proposal.state);
-            Self::unsafe_reject_proposal(GC_DID, id);
+            ensure!(<Proposals<T>>::contains_key(id), Error::<T>::NoSuchProposal);
+            // Check that the proposal is pending
+            Self::is_proposal_state(id, ProposalState::Pending)?;
+            Self::refund_proposal(id);
+            Self::update_proposal_state(id, ProposalState::Killed);
+            Self::prune_data(id, Self::prune_historical_pips());
         }
 
-        /// Prune the PIP given by the `id`, refunding any funds not already refunded.
-        /// The PIP may not be active
-        ///
-        /// This function is intended for storage garbage collection purposes.
-        ///
-        /// # Errors
-        /// * `BadOrigin` unless a GC voting majority executes this function.
-        /// * `NoSuchProposal` if the PIP with `id` doesn't exist.
-        /// * `IncorrectProposalState` if the proposal is active.
+        /// An emergency stop measure to kill a proposal. Governance committee can kill
+        /// a proposal at any time.
         #[weight = (550_000_000, DispatchClass::Operational, Pays::Yes)]
         pub fn prune_proposal(origin, id: PipId) {
             T::VotingMajorityOrigin::ensure_origin(origin)?;
+            // Check that the proposal is in a state valid for pruning
             let proposal = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-            ensure!(!Self::is_active(proposal.state), Error::<T>::IncorrectProposalState);
-            Self::prune_data(GC_DID, id, proposal.state, true);
+            if proposal.state == ProposalState::Referendum {
+                // Check that the referendum is in a state valid for pruning
+                let referendum = Self::referendums(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
+                ensure!(
+                    referendum.state == ReferendumState::Rejected ||
+                    referendum.state == ReferendumState::Failed ||
+                    referendum.state == ReferendumState::Executed,
+                    Error::<T>::IncorrectReferendumState
+                );
+            } else {
+                ensure!(
+                    proposal.state == ProposalState::Cancelled ||
+                    proposal.state == ProposalState::Killed ||
+                    proposal.state == ProposalState::Rejected,
+                    Error::<T>::IncorrectProposalState
+                );
+            }
+            Self::prune_data(id, true);
         }
 
-        /// Updates the execution schedule of the PIP given by `id`.
+        /// Any governance committee member can fast track a proposal and turn it into a referendum
+        /// that will be voted on by the committee.
+        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn fast_track_proposal(origin, id: PipId) -> DispatchResult {
+            let sender = ensure_signed(origin)?;
+            let did = Context::current_identity_or::<Identity<T>>(&sender)?;
+
+            ensure!(
+                T::GovernanceCommittee::is_member(&did),
+                Error::<T>::NotACommitteeMember
+            );
+
+            ensure!(<Proposals<T>>::contains_key(id), Error::<T>::NoSuchProposal);
+            // Check that the proposal is pending
+            Self::is_proposal_state(id, ProposalState::Pending)?;
+            Self::create_referendum(
+                id,
+                ReferendumState::Pending,
+                ReferendumType::FastTracked,
+            );
+            Self::refund_proposal(id);
+
+            Ok(())
+        }
+
+        /// Governance committee can make a proposal that automatically becomes a referendum on
+        /// which the committee can vote on.
+        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn emergency_referendum(
+            origin,
+            proposal: Box<T::Proposal>,
+            url: Option<Url>,
+            description: Option<PipDescription>,
+            beneficiaries: Option<Vec<Beneficiary<T::Balance>>>
+        ) -> DispatchResult {
+            let proposer = ensure_signed(origin)?;
+            let did = Context::current_identity_or::<Identity<T>>(&proposer)?;
+
+            ensure!(
+                T::GovernanceCommittee::is_member(&did),
+                Error::<T>::NotACommitteeMember
+            );
+            let proposal_data = Self::reportable_proposal_data(&*proposal);
+            let id = Self::next_pip_id();
+            let pip = Pip {
+                id,
+                proposal: *proposal,
+                state: ProposalState::Pending,
+                beneficiaries,
+            };
+            <Proposals<T>>::insert(id, pip);
+
+            let proposal_metadata = PipsMetadata {
+                proposer: proposer.clone(),
+                id,
+                end: Zero::zero(),
+                url: url.clone(),
+                description: description.clone(),
+                cool_off_until: Zero::zero(),
+            };
+            <ProposalMetadata<T>>::insert(id, proposal_metadata);
+            Self::deposit_event(RawEvent::ProposalCreated(
+                did,
+                proposer,
+                id,
+                Zero::zero(),
+                url,
+                description,
+                Zero::zero(),
+                Zero::zero(),
+                proposal_data,
+                //beneficiaries,
+            ));
+            Self::create_referendum(
+                id,
+                ReferendumState::Pending,
+                ReferendumType::Emergency,
+            );
+            Ok(())
+        }
+
+        /// Moves a referendum instance into dispatch queue.
+        #[weight = (800_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn enact_referendum(origin, id: PipId) -> DispatchResult {
+            T::VotingMajorityOrigin::ensure_origin(origin)?;
+            // Check that referendum is Pending
+            Self::is_referendum_state(id, ReferendumState::Pending)?;
+            Self::prepare_to_dispatch(id)
+        }
+
+        /// Moves a referendum instance into rejected state.
+        #[weight = (400_000_000, DispatchClass::Operational, Pays::Yes)]
+        pub fn reject_referendum(origin, id: PipId) -> DispatchResult {
+            T::VotingMajorityOrigin::ensure_origin(origin)?;
+            // Check that referendum is Pending
+            Self::is_referendum_state(id, ReferendumState::Pending)?;
+
+            // Close proposal
+            Self::update_referendum_state(id, ReferendumState::Rejected);
+            Self::prune_data(id, Self::prune_historical_pips());
+            Ok(())
+        }
+
+        /// It updates the enactment period of a specific referendum.
         ///
         /// # Arguments
-        /// * `until` defines the future block where the enactment period will finished.
-        ///    `None` value means that enactment period is going to finish in the next block.
+        /// * `until`, It defines the future block where the enactment period will finished.  A
+        /// `None` value means that enactment period is going to finish in the next block.
         ///
         /// # Errors
-        /// * `BadOrigin` unless triggered by release coordinator.
-        /// * `IncorrectProposalState` unless the proposal was in a scheduled state.
+        /// * `BadOrigin`, Only the release coordinator can update the enactment period.
+        /// * ``,
         #[weight = (750_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn reschedule_execution(origin, id: PipId, until: Option<T::BlockNumber>) -> DispatchResult {
+        pub fn override_referendum_enactment_period(origin, id: PipId, until: Option<T::BlockNumber>) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let current_did = Context::current_identity_or::<Identity<T>>(&sender)?;
 
             // 1. Only release coordinator
             ensure!(
                 Some(current_did) == T::GovernanceCommittee::release_coordinator(),
-                DispatchError::BadOrigin
-            );
+                Error::<T>::BadOrigin);
 
-            Self::is_proposal_state(id, ProposalState::Scheduled)?;
+            Self::is_referendum_state(id, ReferendumState::Scheduled)?;
 
             // 2. New value should be valid block number.
             let next_block = <system::Module<T>>::block_number() + 1.into();
             let new_until = until.unwrap_or(next_block);
-            ensure!(new_until >= next_block, Error::<T>::InvalidFutureBlockNumber);
+            ensure!( new_until >= next_block, Error::<T>::InvalidFutureBlockNumber);
 
-            // 3. Update enactment period & reschule it.
-            let old_until = <PipToSchedule<T>>::mutate(id, |old| mem::replace(old, Some(new_until))).unwrap();
-            <ExecutionSchedule<T>>::append(new_until, id);
-            Self::remove_pip_from_schedule(old_until, id);
+            // 3. Update enactment period.
+            // 3.1 Update referendum.
+            let referendum = Self::referendums(id)
+                .ok_or_else(|| Error::<T>::NoSuchProposal)?;
 
-            // 4. Emit event.
-            Self::deposit_event(RawEvent::ExecutionScheduled(current_did, id, old_until, new_until));
-            Ok(())
-        }
+            let old_until = referendum.enactment_period;
 
-        /// Clears the snapshot and emits the event `SnapshotCleared`.
-        ///
-        /// # Errors
-        /// * `NotACommitteeMember` - triggered when a non-GC-member executes the function.
-        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn clear_snapshot(origin) -> DispatchResult {
-            // 1. Check that a GC member is executing this.
-            let actor = ensure_signed(origin)?;
-            let did = Context::current_identity_or::<Identity<T>>(&actor)?;
-            ensure!(T::GovernanceCommittee::is_member(&did), Error::<T>::NotACommitteeMember);
-
-            // 2. Clear the snapshot.
-            <SnapshotMeta<T>>::kill();
-            <SnapshotQueue<T>>::kill();
-
-            // 3. Emit event.
-            Self::deposit_event(RawEvent::SnapshotCleared(did));
-            Ok(())
-        }
-
-        /// Takes a new snapshot of the current list of active && pending PIPs.
-        /// The PIPs are then sorted into a priority queue based on each PIP's weight.
-        ///
-        /// # Errors
-        /// * `NotACommitteeMember` - triggered when a non-GC-member executes the function.
-        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn snapshot(origin) -> DispatchResult {
-            // 1. Check that a GC member is executing this.
-            let made_by = ensure_signed(origin)?;
-            let did = Context::current_identity_or::<Identity<T>>(&made_by)?;
-            ensure!(T::GovernanceCommittee::is_member(&did), Error::<T>::NotACommitteeMember);
-
-            // 2. Fetch intersection of pending && non-cooling PIPs and aggregate their votes.
-            let created_at = <system::Module<T>>::block_number();
-            let mut queue = <Proposals<T>>::iter_values()
-                // Only keep pending PIPs.
-                .filter(|pip| matches!(pip.state, ProposalState::Pending))
-                .map(|pip| pip.id)
-                // Only keep community PIPs not cooling-off.
-                .filter(|id| {
-                    <ProposalMetadata<T>>::get(id)
-                        .filter(|meta| meta.cool_off_until <= created_at)
-                        .filter(|meta| matches!(meta.proposer, Proposer::Community(_)))
-                        .is_some()
-                })
-                // Aggregate the votes; `true` denotes a positive sign.
-                .map(|id| {
-                    let VotingResult { ayes_stake, nays_stake, .. } = <ProposalResult<T>>::get(id);
-                    let weight = if ayes_stake >= nays_stake {
-                        (true, ayes_stake - nays_stake)
-                    } else {
-                        (false, nays_stake - ayes_stake)
-                    };
-                    SnapshottedPip { id, weight }
-                })
-                .collect::<Vec<_>>();
-
-            // 5. Sort pips into priority queue, with highest priority *last*.
-            // Having higher prio last allows efficient tail popping, so we have a LIFO structure.
-            queue.sort_unstable_by(|l, r| {
-                let (l_dir, l_stake): (bool, BalanceOf<T>) = l.weight;
-                let (r_dir, r_stake): (bool, BalanceOf<T>) = r.weight;
-                l_dir.cmp(&r_dir) // Negative has lower prio.
-                    .then_with(|| match l_dir {
-                        true => l_stake.cmp(&r_stake), // Higher stake, higher prio...
-                         // Unless negative stake, in which case lower abs stake, higher prio.
-                        false => r_stake.cmp(&l_stake)
-                    })
-                    // Lower id was made first, so assigned higher prio.
-                    // This also gives us sorting stability through a total order.
-                    // Moreover, as `queue` should be in by-id order originally.
-                    .then(r.id.cmp(&l.id))
+            <Referendums<T>>::mutate( id, |referendum| {
+                if let Some(ref mut referendum) = referendum {
+                    referendum.enactment_period = new_until;
+                }
             });
 
-            // 4. Commit the new snapshot.
-            <SnapshotMeta<T>>::set(Some(SnapshotMetadata { created_at, made_by }));
-            <SnapshotQueue<T>>::set(queue);
+            // 3.1. Re-schedule it
+            <ScheduledReferendumsAt<T>>::mutate( old_until, |ids| ids.retain( |i| *i != id));
+            <ScheduledReferendumsAt<T>>::mutate( new_until, |ids| ids.push(id));
 
-            // 5. Emit event.
-            Self::deposit_event(RawEvent::SnapshotTaken(did));
+            Self::deposit_event(RawEvent::ReferendumScheduled(current_did, id, old_until, new_until));
             Ok(())
-        }
-
-        /// Enacts `results` for the PIPs in the snapshot queue.
-        /// The snapshot will be available for further enactments until it is cleared.
-        ///
-        /// The `results` are encoded a list of `(id, result)` where `result` is applied to `id`.
-        /// Note that the snapshot priority queue is encoded with the *lowest priority first*.
-        /// so `results = [(id, Approve)]` will approve `SnapshotQueue[SnapshotQueue.len() - 1]`.
-        ///
-        /// # Errors
-        /// * `BadOrigin` - unless a GC voting majority executes this function.
-        /// * `CannotSkipPip` - a given PIP has already been skipped too many times.
-        /// * `SnapshotResultTooLarge` - on len(results) > len(snapshot_queue).
-        /// * `SnapshotIdMismatch` - if:
-        ///   ```
-        ///    ∃ (i ∈ 0..SnapshotQueue.len()).
-        ///      results[i].0 ≠ SnapshotQueue[SnapshotQueue.len() - i].id
-        ///   ```
-        ///    This is protects against clearing queue while GC is voting.
-        #[weight = (1_000_000_000, DispatchClass::Operational, Pays::Yes)]
-        pub fn enact_snapshot_results(origin, results: Vec<(PipId, SnapshotResult)>) -> DispatchResult {
-            T::VotingMajorityOrigin::ensure_origin(origin)?;
-
-            let max_pip_skip_count = Self::max_pip_skip_count();
-
-            <SnapshotQueue<T>>::try_mutate(|queue| {
-                let mut to_bump_skipped = Vec::new();
-                // Default after-first-push capacity is 4, we bump this slightly.
-                // Rationale: GC are humans sitting together and reaching conensus.
-                // This is time consuming, so considering 20 PIPs in total might take few hours.
-                let speculative_capacity = queue.len().max(10);
-                let mut to_reject = Vec::with_capacity(speculative_capacity);
-                let mut to_approve = Vec::with_capacity(speculative_capacity);
-
-                // Go over each result...
-                for (id, action) in results.iter().copied() {
-                    match queue.pop() { // ...and "zip" with the queue in reverse.
-                        // An action is missing a corresponding PIP in the queue, bail!
-                        None => return Err(Error::<T>::SnapshotResultTooLarge.into()),
-                        // The id at queue position vs. results mismatches.
-                        Some(p) if p.id != id => return Err(Error::<T>::SnapshotIdMismatch.into()),
-                        // All is right...
-                        Some(_) => {},
-                    }
-                    match action {
-                        // Make sure the PIP can be skipped and enqueue bumping of skip.
-                        SnapshotResult::Skip => {
-                            let count = PipSkipCount::get(id);
-                            ensure!(count < max_pip_skip_count, Error::<T>::CannotSkipPip);
-                            to_bump_skipped.push((id, count + 1));
-                        },
-                        // Mark PIP as rejected.
-                        SnapshotResult::Reject => to_reject.push(id),
-                        // Approve PIP.
-                        SnapshotResult::Approve => to_approve.push(id),
-                    }
-                }
-
-                // Update skip counts.
-                for (pip_id, new_count) in to_bump_skipped.iter().copied() {
-                    PipSkipCount::insert(pip_id, new_count);
-                    Self::deposit_event(RawEvent::PipSkipped(GC_DID, pip_id, new_count));
-                }
-
-                // Reject proposals as instructed & refund.
-                for pip_id in to_reject.iter().copied() {
-                    Self::unsafe_reject_proposal(GC_DID, pip_id);
-                }
-
-                // Approve proposals as instructed.
-                for pip_id in to_approve.iter().copied() {
-                    Self::schedule_pip_for_execution(GC_DID, pip_id);
-                }
-
-                let event = RawEvent::SnapshotResultsEnacted(GC_DID, to_bump_skipped, to_reject, to_approve);
-                Self::deposit_event(event);
-
-                Ok(())
-            })
         }
 
         /// When constructing a block check if it's time for a ballot to end. If ballot ends,
@@ -1127,51 +1010,42 @@ decl_module! {
                 0
             })
         }
+
     }
 }
 
 impl<T: Trait> Module<T> {
-    /// Ensure that `origin` represents a signed extrinsic (i.e. transaction)
-    /// and confirms that the account is the same as the given `proposer`.
-    ///
-    /// For example, if `proposer` denotes a committee,
-    /// then `origin` is checked against the committee's origin.
-    ///
-    /// # Errors
-    /// * `BadOrigin` unless the checks above pass.
-    fn ensure_signed_by(origin: T::Origin, proposer: &Proposer<T::AccountId>) -> DispatchResult {
-        match proposer {
-            Proposer::Community(acc) => {
-                ensure!(acc == &ensure_signed(origin)?, DispatchError::BadOrigin)
-            }
-            Proposer::Committee(Committee::Technical) => {
-                T::TechnicalCommitteeVMO::ensure_origin(origin)?;
-            }
-            Proposer::Committee(Committee::Upgrade) => {
-                T::UpgradeCommitteeVMO::ensure_origin(origin)?;
-            }
-        }
-        Ok(())
-    }
-
     /// Returns the current identity or emits `MissingCurrentIdentity`.
     fn current_did_or_missing() -> Result<IdentityId, Error<T>> {
         Context::current_identity::<Identity<T>>().ok_or_else(|| Error::<T>::MissingCurrentIdentity)
     }
 
-    /// Ensure that proposer is owner of the proposal which must be in the cool off period.
+    fn emit_proposal_bond_adjusted(
+        proposer: T::AccountId,
+        id: PipId,
+        increased: bool,
+        amount: BalanceOf<T>,
+    ) -> DispatchResult {
+        let current_did = Self::current_did_or_missing()?;
+        let event = RawEvent::ProposalBondAdjusted(current_did, proposer, id, increased, amount);
+        Self::deposit_event(event);
+        Ok(())
+    }
+
+    /// Ensure that proposer is owner of the proposal which mustn't be in the cool off period.
     ///
     /// # Errors
-    /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
     /// * `BadOrigin`: Only the owner of the proposal can mutate it.
+    /// * `ProposalIsImmutable`: A Proposal is mutable only during its cool off period.
     fn ensure_owned_by_alterable(
         origin: T::Origin,
         id: PipId,
-    ) -> Result<Proposer<T::AccountId>, DispatchError> {
-        // 1. Only owner can act on proposal.
+    ) -> Result<T::AccountId, DispatchError> {
+        let proposer = ensure_signed(origin)?;
         let meta = Self::proposal_metadata(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
-        Self::ensure_signed_by(origin, &meta.proposer)?;
 
+        // 1. Only owner can act on proposal.
+        ensure!(meta.proposer == proposer, Error::<T>::BadOrigin);
         // 2. Check that the proposal is pending.
         Self::is_proposal_state(id, ProposalState::Pending)?;
 
@@ -1182,151 +1056,229 @@ impl<T: Trait> Module<T> {
             Error::<T>::ProposalIsImmutable
         );
 
-        Ok(meta.proposer)
+        Ok(proposer)
     }
 
     /// Runs the following procedure:
-    /// 1. Executes all PIPs scheduled for this block.
+    /// 1. Find all proposals that need to end as of this block and close voting
+    /// 2. Tally votes
+    /// 3. Submit any proposals that meet the quorum threshold, to the governance committee
+    /// 4. Automatically execute any referendum
     pub fn end_block(block_number: T::BlockNumber) -> Result<Weight, DispatchError> {
-        // Some arbitrary number right now, It is subject to change after proper benchmarking
-        let mut weight: Weight = 50_000_000;
-        // 1. Execute all PIPs scheduled for this block.
-        <ExecutionSchedule<T>>::take(block_number)
+        let mut weight: Weight = 50_000_000; // Some arbitrary number right now, It is subject to change after proper benchmarking
+                                             // Find all matured proposals...
+        <ProposalsMaturingAt<T>>::take(block_number)
             .into_iter()
             .for_each(|id| {
-                <PipToSchedule<T>>::remove(id);
-                weight += Self::execute_proposal(id);
+                // It is possible the proposal has been killed, cancelled or fast tracked
+                if let Some(proposal) = Self::proposals(id) {
+                    if proposal.state == ProposalState::Pending {
+                        // Tally votes and create referendums
+                        let voting = Self::proposal_result(id);
+
+                        // 1. Ayes staked must be more than nays staked (simple majority)
+                        // 2. Ayes staked are more than the minimum quorum threshold
+                        if voting.ayes_stake > voting.nays_stake
+                            && voting.ayes_stake >= Self::quorum_threshold()
+                        {
+                            Self::refund_proposal(id);
+                            Self::create_referendum(
+                                id,
+                                ReferendumState::Pending,
+                                ReferendumType::Community,
+                            );
+                        } else {
+                            Self::update_proposal_state(id, ProposalState::Rejected);
+                            Self::refund_proposal(id);
+                            Self::prune_data(id, Self::prune_historical_pips());
+                        }
+                    }
+                }
             });
-        <ExecutionSchedule<T>>::remove(block_number);
+        <ProposalsMaturingAt<T>>::remove(block_number);
+        // Execute automatically referendums after its enactment period.
+        let referendum_ids = <ScheduledReferendumsAt<T>>::take(block_number);
+        referendum_ids.into_iter().for_each(|id| {
+            weight += Self::execute_referendum(id);
+        });
+        <ScheduledReferendumsAt<T>>::remove(block_number);
         Ok(weight)
     }
 
-    /// Rejects the given `id`, refunding the deposit, and possibly pruning the proposal's data.
-    fn unsafe_reject_proposal(did: IdentityId, id: PipId) {
-        let new_state = Self::update_proposal_state(did, id, ProposalState::Rejected);
-        Self::prune_data(did, id, new_state, Self::prune_historical_pips());
+    /// Create a referendum object from a proposal. If governance committee is composed of less
+    /// than 2 members, enact it immediately. Otherwise, committee votes on this referendum and
+    /// decides whether it should be enacted.
+    fn create_referendum(id: PipId, state: ReferendumState, referendum_type: ReferendumType) {
+        let enactment_period: T::BlockNumber = 0.into();
+        let referendum = Referendum {
+            id,
+            state,
+            referendum_type,
+            enactment_period,
+        };
+        <Referendums<T>>::insert(id, referendum);
+        Self::update_proposal_state(id, ProposalState::Referendum);
+        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
+        Self::deposit_event(RawEvent::ReferendumCreated(
+            current_did,
+            id,
+            referendum_type,
+        ));
     }
 
-    /// Refunds any tokens used to vote or bond a proposal.
-    ///
-    /// This operation is idempotent wrt. chain state,
-    /// i.e., once run, refunding again will refund nothing.
-    fn refund_proposal(did: IdentityId, id: PipId) {
+    /// Refunds any tokens used to vote or bond a proposal
+    fn refund_proposal(id: PipId) {
         let total_refund =
             <Deposits<T>>::iter_prefix_values(id).fold(0.into(), |acc, depo_info| {
                 let amount = <T as Trait>::Currency::unreserve(&depo_info.owner, depo_info.amount);
                 amount.saturating_add(acc)
             });
         <Deposits<T>>::remove_prefix(id);
-        Self::deposit_event(RawEvent::ProposalRefund(did, id, total_refund));
+        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
+        Self::deposit_event(RawEvent::ProposalRefund(current_did, id, total_refund));
     }
 
-    /// Unschedule PIP with given `id` if it's scheduled for execution.
-    fn maybe_unschedule_pip(id: PipId, state: ProposalState) {
-        if let ProposalState::Scheduled = state {
-            Self::remove_pip_from_schedule(<PipToSchedule<T>>::take(id).unwrap(), id);
-        }
-    }
-
-    /// Remove the PIP with `id` from the `ExecutionSchedule` at `block_no`.
-    fn remove_pip_from_schedule(block_no: T::BlockNumber, id: PipId) {
-        <ExecutionSchedule<T>>::mutate(block_no, |ids| ids.retain(|i| *i != id));
-    }
-
-    /// Remove the PIP with `id` from the snapshot if it is there.
-    fn maybe_unsnapshot_pip(id: PipId, state: ProposalState) {
-        if let ProposalState::Pending = state {
-            let cool_until = <ProposalMetadata<T>>::get(id).unwrap().cool_off_until;
-            if cool_until <= <system::Module<T>>::block_number()
-                && <SnapshotMeta<T>>::get()
-                    .filter(|m| cool_until <= m.created_at)
-                    .is_some()
-            {
-                // Proposal is pending, no longer in cool-down, and wasn't when snapshot was made.
-                // Hence, it is in the snapshot and filtering it out will have an effect.
-                // Note: These checks are not strictly necessary, but are done to avoid work.
-                <SnapshotQueue<T>>::mutate(|queue| queue.retain(|i| i.id != id));
-            }
-        }
-    }
-
-    /// Prunes (nearly) all data associated with a proposal, removing it from storage.
+    /// Close a proposal.
     ///
-    /// For efficiency, some data (e.g., re. execution schedules) is not removed in this function,
-    /// but is removed in functions executing this one.
-    fn prune_data(did: IdentityId, id: PipId, state: ProposalState, prune: bool) {
-        Self::refund_proposal(did, id);
-        Self::decrement_count_if_active(state);
+    /// Voting ceases and proposal is removed from storage.
+    /// It also refunds all deposits.
+    ///
+    /// # Internal
+    /// * `ProposalsMaturingat` does not need to be deleted here.
+    ///
+    /// # TODO
+    /// * Should we remove the proposal when it is Cancelled?, killed?, rejected?
+    fn prune_data(id: PipId, prune: bool) {
+        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
         if prune {
             <ProposalResult<T>>::remove(id);
             <ProposalVotes<T>>::remove_prefix(id);
             <ProposalMetadata<T>>::remove(id);
             <Proposals<T>>::remove(id);
-            PipSkipCount::remove(id);
+            <Referendums<T>>::remove(id);
         }
-        Self::deposit_event(RawEvent::PipClosed(did, id, prune));
+        Self::deposit_event(RawEvent::PipClosed(current_did, id, prune));
     }
 
-    fn schedule_pip_for_execution(did: IdentityId, id: PipId) {
+    fn prepare_to_dispatch(id: PipId) -> DispatchResult {
+        ensure!(
+            <Referendums<T>>::contains_key(id),
+            Error::<T>::NoSuchProposal
+        );
+
         // Set the default enactment period and move it to `Scheduled`
         let curr_block_number = <system::Module<T>>::block_number();
-        let executed_at = curr_block_number + Self::default_enactment_period();
+        let enactment_period = curr_block_number + Self::default_enactment_period();
 
-        Self::update_proposal_state(did, id, ProposalState::Scheduled);
-        <PipToSchedule<T>>::insert(id, executed_at);
-        <ExecutionSchedule<T>>::append(executed_at, id);
-        let event = RawEvent::ExecutionScheduled(did, id, Zero::zero(), executed_at);
-        Self::deposit_event(event);
+        <Referendums<T>>::mutate(id, |referendum| {
+            if let Some(ref mut referendum) = referendum {
+                referendum.enactment_period = enactment_period;
+                referendum.state = ReferendumState::Scheduled;
+            }
+        });
+        <ScheduledReferendumsAt<T>>::mutate(enactment_period, |ids| ids.push(id));
+        let current_did = Self::current_did_or_missing()?;
+        Self::deposit_event(RawEvent::ReferendumScheduled(
+            current_did,
+            id,
+            Zero::zero(),
+            enactment_period,
+        ));
+        Ok(())
     }
 
-    /// Execute the PIP given by `id`.
-    /// Panics if the PIP doesn't exist or isn't scheduled.
-    fn execute_proposal(id: PipId) -> Weight {
-        let proposal = Self::proposals(id).expect("PIP was scheduled but doesn't exist");
-        assert_eq!(proposal.state, ProposalState::Scheduled);
-        let res = proposal.proposal.dispatch(system::RawOrigin::Root.into());
-        let weight = res.unwrap_or_else(|e| e.post_info).actual_weight;
-        let new_state = res.map_or(ProposalState::Failed, |_| ProposalState::Executed);
-        let did = Context::current_identity::<Identity<T>>().unwrap_or_default();
-        Self::update_proposal_state(did, id, new_state);
-        Self::prune_data(did, id, new_state, Self::prune_historical_pips());
-        weight.unwrap_or(0)
+    fn execute_referendum(id: PipId) -> Weight {
+        let mut actual_weight: Weight = 0;
+        if let Some(proposal) = Self::proposals(id) {
+            if proposal.state == ProposalState::Referendum {
+                match Self::check_beneficiaries(id) {
+                    Ok(_) => {
+                        match proposal.proposal.dispatch(system::RawOrigin::Root.into()) {
+                            Ok(post_info) => {
+                                actual_weight = post_info.actual_weight.unwrap_or(0);
+                                Self::pay_to_beneficiaries(id);
+                                Self::update_referendum_state(id, ReferendumState::Executed);
+                            }
+                            Err(e) => {
+                                Self::update_referendum_state(id, ReferendumState::Failed);
+                                debug::error!(
+                                    "Referendum {}, its execution fails: {:?}",
+                                    id,
+                                    e.error
+                                );
+                            }
+                        };
+                    }
+                    Err(e) => {
+                        Self::update_referendum_state(id, ReferendumState::Failed);
+                        debug::error!("Referendum {}, its beneficiaries fails: {:?}", id, e);
+                    }
+                }
+                Self::prune_data(id, Self::prune_historical_pips());
+            }
+        }
+        actual_weight
     }
 
-    fn update_proposal_state(
-        did: IdentityId,
-        id: PipId,
-        new_state: ProposalState,
-    ) -> ProposalState {
+    fn check_beneficiaries(id: PipId) -> DispatchResult {
+        if let Some(proposal) = Self::proposals(id) {
+            if let Some(beneficiaries) = proposal.beneficiaries {
+                let total_amount = beneficiaries
+                    .iter()
+                    .fold(0.into(), |acc, b| b.amount.saturating_add(acc));
+                ensure!(
+                    T::Treasury::balance() >= total_amount,
+                    Error::<T>::InsufficientTreasuryFunds
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn pay_to_beneficiaries(id: PipId) {
+        if let Some(proposal) = Self::proposals(id) {
+            if let Some(beneficiaries) = proposal.beneficiaries {
+                let _ = beneficiaries.into_iter().fold(0.into(), |acc, b| {
+                    T::Treasury::disbursement(b.id, b.amount);
+                    b.amount.saturating_add(acc)
+                });
+            }
+        }
+    }
+
+    fn update_proposal_state(id: PipId, new_state: ProposalState) {
         <Proposals<T>>::mutate(id, |proposal| {
             if let Some(ref mut proposal) = proposal {
-                if (proposal.state, new_state) != (ProposalState::Pending, ProposalState::Scheduled)
-                {
-                    Self::decrement_count_if_active(proposal.state);
-                }
                 proposal.state = new_state;
             }
         });
-        Self::deposit_event(RawEvent::ProposalStateUpdated(did, id, new_state));
-        new_state
+        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
+        Self::deposit_event(RawEvent::ProposalStateUpdated(current_did, id, new_state));
+    }
+
+    fn update_referendum_state(id: PipId, new_state: ReferendumState) {
+        <Referendums<T>>::mutate(id, |referendum| {
+            if let Some(ref mut referendum) = referendum {
+                referendum.state = new_state;
+            }
+        });
+        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
+        Self::deposit_event(RawEvent::ReferendumStateUpdated(current_did, id, new_state));
+    }
+
+    fn is_referendum_state(id: PipId, state: ReferendumState) -> DispatchResult {
+        let referendum = Self::referendums(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
+        ensure!(
+            referendum.state == state,
+            Error::<T>::IncorrectReferendumState
+        );
+        Ok(())
     }
 
     fn is_proposal_state(id: PipId, state: ProposalState) -> DispatchResult {
         let proposal = Self::proposals(id).ok_or_else(|| Error::<T>::NoSuchProposal)?;
         ensure!(proposal.state == state, Error::<T>::IncorrectProposalState);
         Ok(())
-    }
-
-    /// Returns `true` if `state` is `Pending | Scheduled`.
-    fn is_active(state: ProposalState) -> bool {
-        matches!(state, ProposalState::Pending | ProposalState::Scheduled)
-    }
-
-    /// Decrement active proposal count if `state` signifies it is active.
-    fn decrement_count_if_active(state: ProposalState) {
-        if Self::is_active(state) {
-            ActivePipCount::mutate(|count| *count -= 1);
-        }
     }
 }
 
@@ -1348,10 +1300,10 @@ impl<T: Trait> Module<T> {
         }
     }
 
-    /// Retrieve proposals made by `proposer`.
-    pub fn proposed_by(proposer: Proposer<T::AccountId>) -> Vec<PipId> {
+    /// Retrieve proposals made by `address`.
+    pub fn proposed_by(address: T::AccountId) -> Vec<PipId> {
         <ProposalMetadata<T>>::iter()
-            .filter(|(_, meta)| meta.proposer == proposer)
+            .filter(|(_, meta)| meta.proposer == address)
             .map(|(_, meta)| meta.id)
             .collect()
     }
@@ -1359,7 +1311,10 @@ impl<T: Trait> Module<T> {
     /// Retrieve proposals `address` voted on
     pub fn voted_on(address: T::AccountId) -> Vec<PipId> {
         <ProposalMetadata<T>>::iter()
-            .filter_map(|(_, meta)| Self::proposal_vote(meta.id, &address).map(|_| meta.id))
+            .filter_map(|(_, meta)| match Self::proposal_vote(meta.id, &address) {
+                Vote::None => None,
+                _ => Some(meta.id),
+            })
             .collect::<Vec<_>>()
     }
 
@@ -1368,11 +1323,9 @@ impl<T: Trait> Module<T> {
         who: T::AccountId,
     ) -> HistoricalVotingByAddress<Vote<BalanceOf<T>>> {
         <ProposalMetadata<T>>::iter()
-            .filter_map(|(_, meta)| {
-                Some(VoteByPip {
-                    pip: meta.id,
-                    vote: Self::proposal_vote(meta.id, &who)?,
-                })
+            .map(|(_, meta)| VoteByPip {
+                pip: meta.id,
+                vote: Self::proposal_vote(meta.id, &who),
             })
             .collect::<Vec<_>>()
     }
@@ -1389,43 +1342,46 @@ impl<T: Trait> Module<T> {
             .collect::<HistoricalVotingById<_, _>>()
     }
 
-    /// Returns the id to use for the next PIP to be made.
-    /// Invariant: `next_pip_id() == next_pip_id() + 1`.
+    /// It generates the next id for proposals and referendums.
     fn next_pip_id() -> u32 {
-        <PipIdSequence>::mutate(|id| mem::replace(id, *id + 1))
+        let id = <PipIdSequence>::get();
+        <PipIdSequence>::put(id + 1);
+
+        id
     }
 
-    /// Changes the vote of `voter` to `vote`, if any.
-    fn unsafe_vote(id: PipId, voter: T::AccountId, vote: Vote<BalanceOf<T>>) -> DispatchResult {
+    /// It inserts the vote and updates the accountability of target proposal.
+    fn unsafe_vote(id: PipId, proposer: T::AccountId, vote: Vote<BalanceOf<T>>) -> DispatchResult {
         let mut stats = Self::proposal_result(id);
-
-        // Update the vote and get the old one, if any, in which case also remove it from stats.
-        if let Some(Vote(direction, deposit)) = <ProposalVotes<T>>::get(id, voter.clone()) {
-            let (count, stake) = match direction {
-                true => (&mut stats.ayes_count, &mut stats.ayes_stake),
-                false => (&mut stats.nays_count, &mut stats.nays_stake),
-            };
-            *count -= 1;
-            *stake -= deposit;
-        }
-
-        // Add new vote to stats.
-        let Vote(direction, deposit) = vote;
-        let (count, stake) = match direction {
-            true => (&mut stats.ayes_count, &mut stats.ayes_stake),
-            false => (&mut stats.nays_count, &mut stats.nays_stake),
+        match vote {
+            Vote::Yes(deposit) => {
+                stats.ayes_count = stats
+                    .ayes_count
+                    .checked_add(1)
+                    .ok_or_else(|| Error::<T>::NumberOfVotesExceeded)?;
+                stats.ayes_stake = stats
+                    .ayes_stake
+                    .checked_add(&deposit)
+                    .ok_or_else(|| Error::<T>::StakeAmountOfVotesExceeded)?;
+            }
+            Vote::No(deposit) => {
+                stats.nays_count = stats
+                    .nays_count
+                    .checked_add(1)
+                    .ok_or_else(|| Error::<T>::NumberOfVotesExceeded)?;
+                stats.nays_stake = stats
+                    .nays_stake
+                    .checked_add(&deposit)
+                    .ok_or_else(|| Error::<T>::StakeAmountOfVotesExceeded)?;
+            }
+            Vote::None => {
+                // It should be unreachable because public API only allows binary options.
+                debug::warn!("Unexpected none vote");
+            }
         };
-        *count = count
-            .checked_add(1)
-            .ok_or_else(|| Error::<T>::NumberOfVotesExceeded)?;
-        *stake = stake
-            .checked_add(&deposit)
-            .ok_or_else(|| Error::<T>::StakeAmountOfVotesExceeded)?;
 
-        // Commit all changes.
         <ProposalResult<T>>::insert(id, stats);
-        <ProposalVotes<T>>::insert(id, voter, vote);
-
+        <ProposalVotes<T>>::insert(id, proposer, vote);
         Ok(())
     }
 
@@ -1439,5 +1395,11 @@ impl<T: Trait> Module<T> {
             ProposalData::Proposal(encoded_proposal)
         };
         proposal_data
+    }
+
+    /// A proposal is valid if there is an associated proposal and it is in pending state.
+    pub fn is_proposal_id_valid(id: PipId) -> bool {
+        <Proposals<T>>::contains_key(id)
+            && Self::is_referendum_state(id, ReferendumState::Pending).is_ok()
     }
 }

--- a/pallets/runtime/develop/src/lib.rs
+++ b/pallets/runtime/develop/src/lib.rs
@@ -36,10 +36,6 @@ pub mod config {
     pub type StakingConfig = pallet_staking::GenesisConfig<crate::Runtime>;
     pub type PolymeshCommitteeConfig =
         committee::GenesisConfig<crate::Runtime, committee::Instance1>;
-    pub type TechnicalCommitteeConfig =
-        committee::GenesisConfig<crate::Runtime, committee::Instance3>;
-    pub type UpgradeCommitteeConfig =
-        committee::GenesisConfig<crate::Runtime, committee::Instance4>;
     pub type PipsConfig = pallet_pips::GenesisConfig<crate::Runtime>;
     pub type ContractsConfig = pallet_contracts::GenesisConfig;
     pub type IndicesConfig = pallet_indices::GenesisConfig<crate::Runtime>;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -421,7 +421,6 @@ impl committee::Trait<GovernanceCommittee> for Runtime {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for Runtime {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -442,8 +441,6 @@ macro_rules! committee_config {
         }
         impl group::Trait<group::$instance> for Runtime {
             type Event = Event;
-            // Committee cannot alter its own active membership limit.
-            type LimitOrigin = frame_system::EnsureRoot<AccountId>;
             // Can manage its own addition, deletion, and swapping of membership...
             type AddOrigin = VMO<committee::$instance>;
             type RemoveOrigin = VMO<committee::$instance>;
@@ -712,8 +709,6 @@ impl dividend::Trait for Runtime {
 /// CddProviders instance of group
 impl group::Trait<group::Instance2> for Runtime {
     type Event = Event;
-    // Cannot alter its own active membership limit.
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -27,7 +27,11 @@ use pallet_utility as utility;
 use polymesh_common_utilities::{
     constants::currency::*,
     protocol_fee::ProtocolOp,
-    traits::{balances::AccountData, identity::Trait as IdentityTrait},
+    traits::{
+        balances::AccountData,
+        identity::Trait as IdentityTrait,
+        pip::{EnactProposalMaker, PipId},
+    },
     CommonTrait,
 };
 use polymesh_primitives::{
@@ -406,18 +410,16 @@ impl pallet_staking::Trait for Runtime {
 parameter_types! {
     pub const MotionDuration: BlockNumber = 0;
 }
-
-/// Voting majority origin for `Instance`.
-type VMO<Instance> = committee::EnsureProportionAtLeast<_1, _2, AccountId, Instance>;
-
 type GovernanceCommittee = committee::Instance1;
 impl committee::Trait<GovernanceCommittee> for Runtime {
     type Origin = Origin;
     type Proposal = Call;
-    type CommitteeOrigin = VMO<GovernanceCommittee>;
+    type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
     type Event = Event;
     type MotionDuration = MotionDuration;
+    type EnactProposalMaker = Runtime;
 }
+
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for Runtime {
     type Event = Event;
@@ -429,40 +431,12 @@ impl group::Trait<group::Instance1> for Runtime {
     type MembershipChanged = PolymeshCommittee;
 }
 
-macro_rules! committee_config {
-    ($committee:ident, $instance:ident) => {
-        impl committee::Trait<committee::$instance> for Runtime {
-            type Origin = Origin;
-            type Proposal = Call;
-            // Can act upon itself.
-            type CommitteeOrigin = VMO<committee::$instance>;
-            type Event = Event;
-            type MotionDuration = MotionDuration;
-        }
-        impl group::Trait<group::$instance> for Runtime {
-            type Event = Event;
-            // Can manage its own addition, deletion, and swapping of membership...
-            type AddOrigin = VMO<committee::$instance>;
-            type RemoveOrigin = VMO<committee::$instance>;
-            type SwapOrigin = VMO<committee::$instance>;
-            // ...but it cannot reset its own membership; GC needs to do that.
-            type ResetOrigin = VMO<GovernanceCommittee>;
-            type MembershipInitialized = $committee;
-            type MembershipChanged = $committee;
-        }
-    };
-}
-
-committee_config!(TechnicalCommittee, Instance3);
-committee_config!(UpgradeCommittee, Instance4);
-
 impl pallet_pips::Trait for Runtime {
     type Currency = Balances;
     type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
-    type VotingMajorityOrigin = VMO<GovernanceCommittee>;
+    type VotingMajorityOrigin =
+        committee::EnsureProportionAtLeast<_1, _2, AccountId, GovernanceCommittee>;
     type GovernanceCommittee = PolymeshCommittee;
-    type TechnicalCommitteeVMO = VMO<committee::Instance3>;
-    type UpgradeCommitteeVMO = VMO<committee::Instance4>;
     type Treasury = Treasury;
     type Event = Event;
 }
@@ -724,6 +698,19 @@ impl pallet_utility::Trait for Runtime {
     type Call = Call;
 }
 
+impl EnactProposalMaker<Origin, Call> for Runtime {
+    fn is_pip_id_valid(id: PipId) -> bool {
+        Pips::is_proposal_id_valid(id)
+    }
+
+    fn enact_referendum_call(id: PipId) -> Call {
+        Call::Pips(pallet_pips::Call::enact_referendum(id))
+    }
+
+    fn reject_referendum_call(id: PipId) -> Call {
+        Call::Pips(pallet_pips::Call::reject_referendum(id))
+    }
+}
 impl confidential::Trait for Runtime {
     type Event = Event;
 }
@@ -795,12 +782,6 @@ construct_runtime!(
         PolymeshCommittee: committee::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
         CommitteeMembership: group::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
         Pips: pallet_pips::{Module, Call, Storage, Event<T>, Config<T>},
-
-        TechnicalCommittee: committee::<Instance3>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
-        TechnicalCommitteeMembership: group::<Instance3>::{Module, Call, Storage, Event<T>, Config<T>},
-
-        UpgradeCommittee: committee::<Instance4>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
-        UpgradeCommitteeMembership: group::<Instance4>::{Module, Call, Storage, Event<T>, Config<T>},
 
         //Polymesh
         Asset: asset::{Module, Call, Storage, Config<T>, Event<T>},
@@ -1080,7 +1061,7 @@ impl_runtime_apis! {
 
         /// Proposals voted by `address`
         fn proposed_by(address: AccountId) -> Vec<u32> {
-            Pips::proposed_by(pallet_pips::Proposer::Community(address))
+            Pips::proposed_by(address)
         }
 
         /// Proposals `address` voted on

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -421,7 +421,6 @@ impl committee::Trait<GovernanceCommittee> for Runtime {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for Runtime {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -442,7 +441,6 @@ macro_rules! committee_config {
         }
         impl group::Trait<group::$instance> for Runtime {
             type Event = Event;
-            type LimitOrigin = frame_system::EnsureRoot<AccountId>;
             // Can manage its own addition, deletion, and swapping of membership...
             type AddOrigin = VMO<committee::$instance>;
             type RemoveOrigin = VMO<committee::$instance>;
@@ -711,7 +709,6 @@ impl dividend::Trait for Runtime {
 /// CddProviders instance of group
 impl group::Trait<group::Instance2> for Runtime {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -26,7 +26,11 @@ use pallet_utility as utility;
 use polymesh_common_utilities::{
     constants::currency::*,
     protocol_fee::ProtocolOp,
-    traits::{balances::AccountData, identity::Trait as IdentityTrait},
+    traits::{
+        balances::AccountData,
+        identity::Trait as IdentityTrait,
+        pip::{EnactProposalMaker, PipId},
+    },
     CommonTrait,
 };
 use polymesh_primitives::{
@@ -405,17 +409,14 @@ impl pallet_staking::Trait for Runtime {
 parameter_types! {
     pub const MotionDuration: BlockNumber = 0;
 }
-
-/// Voting majority origin for `Instance`.
-type VMO<Instance> = committee::EnsureProportionAtLeast<_2, _3, AccountId, Instance>;
-
 type GovernanceCommittee = committee::Instance1;
 impl committee::Trait<GovernanceCommittee> for Runtime {
     type Origin = Origin;
     type Proposal = Call;
-    type CommitteeOrigin = VMO<GovernanceCommittee>;
+    type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
     type Event = Event;
     type MotionDuration = MotionDuration;
+    type EnactProposalMaker = Runtime;
 }
 
 /// PolymeshCommittee as an instance of group
@@ -429,40 +430,12 @@ impl group::Trait<group::Instance1> for Runtime {
     type MembershipChanged = PolymeshCommittee;
 }
 
-macro_rules! committee_config {
-    ($committee:ident, $instance:ident) => {
-        impl committee::Trait<committee::$instance> for Runtime {
-            type Origin = Origin;
-            type Proposal = Call;
-            // Can act upon itself.
-            type CommitteeOrigin = VMO<committee::$instance>;
-            type Event = Event;
-            type MotionDuration = MotionDuration;
-        }
-        impl group::Trait<group::$instance> for Runtime {
-            type Event = Event;
-            // Can manage its own addition, deletion, and swapping of membership...
-            type AddOrigin = VMO<committee::$instance>;
-            type RemoveOrigin = VMO<committee::$instance>;
-            type SwapOrigin = VMO<committee::$instance>;
-            // ...but it cannot reset its own membership; GC needs to do that.
-            type ResetOrigin = VMO<GovernanceCommittee>;
-            type MembershipInitialized = $committee;
-            type MembershipChanged = $committee;
-        }
-    };
-}
-
-committee_config!(TechnicalCommittee, Instance3);
-committee_config!(UpgradeCommittee, Instance4);
-
 impl pallet_pips::Trait for Runtime {
     type Currency = Balances;
     type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
-    type VotingMajorityOrigin = VMO<GovernanceCommittee>;
+    type VotingMajorityOrigin =
+        committee::EnsureProportionAtLeast<_2, _3, AccountId, GovernanceCommittee>;
     type GovernanceCommittee = PolymeshCommittee;
-    type TechnicalCommitteeVMO = VMO<committee::Instance3>;
-    type UpgradeCommitteeVMO = VMO<committee::Instance4>;
     type Treasury = Treasury;
     type Event = Event;
 }
@@ -724,6 +697,20 @@ impl pallet_utility::Trait for Runtime {
     type Call = Call;
 }
 
+impl EnactProposalMaker<Origin, Call> for Runtime {
+    fn is_pip_id_valid(id: PipId) -> bool {
+        Pips::is_proposal_id_valid(id)
+    }
+
+    fn enact_referendum_call(id: PipId) -> Call {
+        Call::Pips(pallet_pips::Call::enact_referendum(id))
+    }
+
+    fn reject_referendum_call(id: PipId) -> Call {
+        Call::Pips(pallet_pips::Call::reject_referendum(id))
+    }
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
@@ -766,12 +753,6 @@ construct_runtime!(
         PolymeshCommittee: committee::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
         CommitteeMembership: group::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
         Pips: pallet_pips::{Module, Call, Storage, Event<T>, Config<T>},
-
-        TechnicalCommittee: committee::<Instance3>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
-        TechnicalCommitteeMembership: group::<Instance3>::{Module, Call, Storage, Event<T>, Config<T>},
-
-        UpgradeCommittee: committee::<Instance4>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
-        UpgradeCommitteeMembership: group::<Instance4>::{Module, Call, Storage, Event<T>, Config<T>},
 
         //Polymesh
         Asset: asset::{Module, Call, Storage, Config<T>, Event<T>},
@@ -1048,7 +1029,7 @@ impl_runtime_apis! {
 
         /// Proposals voted by `address`
         fn proposed_by(address: AccountId) -> Vec<u32> {
-            Pips::proposed_by(pallet_pips::Proposer::Community(address))
+            Pips::proposed_by(address)
         }
 
         /// Proposals `address` voted on

--- a/pallets/runtime/tests/src/committee_test.rs
+++ b/pallets/runtime/tests/src/committee_test.rs
@@ -1,20 +1,21 @@
 use super::{
-    ext_builder::{ExtBuilder, COOL_OFF_PERIOD},
     storage::{
-        fast_forward_blocks, get_identity_id, register_keyring_account, Call, EventTest,
+        fast_forward_to_block, get_identity_id, register_keyring_account, Call, EventTest,
         TestStorage,
     },
+    ExtBuilder,
 };
-use frame_support::{
-    assert_err, assert_noop, assert_ok,
-    dispatch::{DispatchError, DispatchResult},
-};
+use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
 use frame_system::{EventRecord, Phase};
 use pallet_committee::{self as committee, PolymeshVotes, RawEvent as CommitteeRawEvent};
-use pallet_group as group;
+use pallet_group::{self as group};
 use pallet_identity as identity;
-use pallet_pips::{self as pips, ProposalState, Proposer, SnapshotResult};
-use polymesh_common_utilities::traits::pip::PipId;
+use pallet_pips::{
+    self as pips, Pip, PipDescription, ProposalState, Referendum, ReferendumState, ReferendumType,
+    Url,
+};
+
+use polymesh_common_utilities::traits::pip::{EnactProposalMaker, PipId};
 use polymesh_primitives::IdentityId;
 use sp_core::H256;
 use sp_runtime::traits::Hash;
@@ -27,6 +28,10 @@ type System = frame_system::Module<TestStorage>;
 type Identity = identity::Module<TestStorage>;
 type Pips = pips::Module<TestStorage>;
 type Origin = <TestStorage as frame_system::Trait>::Origin;
+
+pub fn root() -> Origin {
+    Origin::from(frame_system::RawOrigin::Root)
+}
 
 #[test]
 fn motions_basic_environment_works() {
@@ -52,65 +57,14 @@ fn make_proposal(value: u64) -> Call {
     Call::Identity(identity::Call::accept_primary_key(value, Some(value)))
 }
 
-const APPROVE_0: &[(PipId, SnapshotResult)] = &[(0, SnapshotResult::Approve)];
-
-pub fn set_members(ids: Vec<IdentityId>) {
-    CommitteeGroup::reset_members(root(), ids).unwrap();
+fn hash_enact_referendum(pip: PipId) -> H256 {
+    <TestStorage as frame_system::Trait>::Hashing::hash_of(&TestStorage::enact_referendum_call(pip))
 }
 
-fn assert_mem_len(len: u32) {
-    assert_ok!(u32::try_from((Committee::members()).len()), len)
-}
-
-fn assert_mem(who: IdentityId, is: bool) {
-    assert_eq!(Committee::is_member(&who), is);
-}
-
-fn abdicate_membership(who: IdentityId, signer: &Origin, n: u32) {
-    assert_mem_len(n);
-    assert_mem(who, true);
-    assert_ok!(CommitteeGroup::abdicate_membership(signer.clone()));
-    assert_mem(who, false);
-    assert_mem_len(n - 1);
-}
-
-fn prepare_proposal(ring: AccountKeyring) {
-    let proposal = make_proposal(42);
-    let acc = ring.public();
-    assert_ok!(Pips::propose(
-        Origin::signed(acc),
-        Proposer::Community(acc),
-        Box::new(proposal.clone()),
-        50,
-        None,
-        None,
-    ));
-    fast_forward_blocks(COOL_OFF_PERIOD);
-}
-
-fn check_scheduled(id: PipId) {
-    assert_eq!(Pips::proposals(id).unwrap().state, ProposalState::Scheduled);
-}
-
-pub fn root() -> Origin {
-    Origin::from(frame_system::RawOrigin::Root)
-}
-
-fn enact_snapshot_results_call() -> Call {
-    Call::Pips(pallet_pips::Call::enact_snapshot_results(APPROVE_0.into()))
-}
-
-fn hash_enact_snapshot_results() -> H256 {
-    let call = enact_snapshot_results_call();
-    <TestStorage as frame_system::Trait>::Hashing::hash_of(&call)
-}
-
-fn vote(who: &Origin, approve: bool) -> DispatchResult {
-    Committee::vote_or_propose(
-        who.clone(),
-        approve,
-        Box::new(enact_snapshot_results_call()),
-    )
+fn hash_reject_referendum(pip: PipId) -> H256 {
+    <TestStorage as frame_system::Trait>::Hashing::hash_of(&TestStorage::reject_referendum_call(
+        pip,
+    ))
 }
 
 #[test]
@@ -123,25 +77,46 @@ fn single_member_committee_works() {
 fn single_member_committee_works_we() {
     System::set_block_number(1);
 
-    let alice_ring = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice_ring.public());
-    let alice_did = register_keyring_account(alice_ring).unwrap();
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
 
-    set_members(vec![alice_did]);
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    CommitteeGroup::reset_members(root, vec![alice_did]).unwrap();
 
     // Proposal is executed if committee is comprised of a single member
-    prepare_proposal(alice_ring);
-    assert_ok!(Pips::snapshot(alice_signer.clone()));
+    let proposal = make_proposal(42);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), 0));
     assert_eq!(Committee::proposals(), vec![]);
 
-    assert_ok!(vote(&alice_signer, true));
-    check_scheduled(0);
-    let hash = hash_enact_snapshot_results();
+    assert_ok!(Committee::vote_enact_referendum(alice_signer, 0));
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 101,
+        })
+    );
+    fast_forward_to_block(102);
+
+    let hash = hash_enact_referendum(0);
     let expected_event = EventRecord {
         phase: Phase::Initialization,
         event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(alice_did, hash, true)),
         topics: vec![],
     };
+
+    // assert_eq!(System::events(), vec![expected_event.clone()]);
     assert_eq!(System::events().contains(&expected_event), true);
 }
 
@@ -155,18 +130,26 @@ fn preventing_motions_from_non_members_works() {
 fn preventing_motions_from_non_members_works_we() {
     System::set_block_number(1);
 
-    let alice_ring = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice_ring.public());
-    let _ = register_keyring_account(alice_ring).unwrap();
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let _ = register_keyring_account(AccountKeyring::Alice).unwrap();
 
-    prepare_proposal(alice_ring);
+    let proposal = make_proposal(42);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
     assert_err!(
-        Pips::snapshot(alice_signer.clone()),
+        Pips::fast_track_proposal(alice_signer.clone(), 0),
         pips::Error::<TestStorage>::NotACommitteeMember
     );
     assert_eq!(Committee::proposals(), vec![]);
+
     assert_noop!(
-        vote(&alice_signer, true),
+        Committee::vote_enact_referendum(alice_signer, 0),
         committee::Error::<TestStorage, committee::Instance1>::BadOrigin
     );
 }
@@ -181,18 +164,28 @@ fn preventing_voting_from_non_members_works() {
 fn preventing_voting_from_non_members_works_we() {
     System::set_block_number(1);
 
-    let alice_ring = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice_ring.public());
-    let alice_did = register_keyring_account(alice_ring).unwrap();
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
     let bob_signer = Origin::signed(AccountKeyring::Bob.public());
     let _ = register_keyring_account(AccountKeyring::Bob).unwrap();
 
-    set_members(vec![alice_did]);
-    prepare_proposal(alice_ring);
-    assert_ok!(Pips::snapshot(alice_signer.clone()));
+    CommitteeGroup::reset_members(root, vec![alice_did]).unwrap();
+
+    let proposal = make_proposal(42);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), 0));
     assert_eq!(Committee::proposals(), vec![]);
+
     assert_noop!(
-        vote(&bob_signer, true),
+        Committee::vote_enact_referendum(bob_signer, 0),
         committee::Error::<TestStorage, committee::Instance1>::BadOrigin
     );
 }
@@ -207,70 +200,105 @@ fn motions_revoting_works() {
 fn motions_revoting_works_we() {
     System::set_block_number(1);
 
-    let alice_ring = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice_ring.public());
-    let alice_did = register_keyring_account(alice_ring).unwrap();
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
     let _bob_signer = Origin::signed(AccountKeyring::Bob.public());
     let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
     let _charlie_signer = Origin::signed(AccountKeyring::Charlie.public());
     let charlie_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
 
-    set_members(vec![alice_did, bob_did, charlie_did]);
-    prepare_proposal(alice_ring);
-    assert_eq!(Committee::proposals(), vec![]);
+    CommitteeGroup::reset_members(root, vec![alice_did, bob_did, charlie_did]).unwrap();
 
-    assert_ok!(vote(&alice_signer, true));
-    let enact_hash = hash_enact_snapshot_results();
+    let proposal = make_proposal(42);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), 0));
+    assert_ok!(Committee::vote_enact_referendum(alice_signer.clone(), 0));
+
+    let enact_hash = hash_enact_referendum(0);
+    let block_number = System::block_number();
     assert_eq!(
         Committee::voting(&enact_hash),
         Some(PolymeshVotes {
             index: 0,
             ayes: vec![alice_did],
             nays: vec![],
-            end: System::block_number(),
+            end: block_number
         })
     );
     assert_noop!(
-        vote(&alice_signer, true),
+        Committee::vote_enact_referendum(alice_signer.clone(), 0),
         committee::Error::<TestStorage, committee::Instance1>::DuplicateVote
     );
-    assert_ok!(vote(&alice_signer, false));
+    assert_ok!(Committee::vote_reject_referendum(alice_signer.clone(), 0));
+
+    let block_number = System::block_number();
+    let reject_hash = hash_reject_referendum(0);
     assert_eq!(
-        Committee::voting(&enact_hash),
+        Committee::voting(&reject_hash),
         Some(PolymeshVotes {
-            index: 0,
-            ayes: vec![],
-            nays: vec![alice_did],
-            end: System::block_number(),
+            index: 1,
+            ayes: vec![alice_did],
+            nays: vec![],
+            end: block_number
         })
     );
     assert_noop!(
-        vote(&alice_signer, false),
+        Committee::vote_enact_referendum(alice_signer, 0),
         committee::Error::<TestStorage, committee::Instance1>::DuplicateVote
     );
 }
 
 #[test]
-fn first_vote_cannot_be_reject() {
-    ExtBuilder::default()
-        .build()
-        .execute_with(first_vote_cannot_be_reject_we);
+fn voting_works() {
+    ExtBuilder::default().build().execute_with(voting_works_we);
 }
 
-fn first_vote_cannot_be_reject_we() {
+fn voting_works_we() {
     System::set_block_number(1);
 
-    let alice_ring = AccountKeyring::Alice;
-    let alice_did = register_keyring_account(alice_ring).unwrap();
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
+    let bob_signer = Origin::signed(AccountKeyring::Bob.public());
     let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
+    let _charlie_signer = Origin::signed(AccountKeyring::Charlie.public());
     let charlie_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
 
-    set_members(vec![alice_did, bob_did, charlie_did]);
-    prepare_proposal(alice_ring);
-    assert_eq!(Committee::proposals(), vec![]);
-    assert_noop!(
-        vote(&Origin::signed(alice_ring.public()), false),
-        committee::Error::<TestStorage, committee::Instance1>::FirstVoteReject
+    CommitteeGroup::reset_members(root, vec![alice_did, bob_did, charlie_did]).unwrap();
+
+    let proposal = make_proposal(69);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), 0));
+
+    let enact_hash = hash_enact_referendum(0);
+    assert_eq!(Committee::voting(&enact_hash), None);
+    assert_ok!(Committee::vote_reject_referendum(bob_signer.clone(), 0));
+
+    let reject_hash = hash_reject_referendum(0);
+    let block_number = System::block_number();
+    assert_eq!(
+        Committee::voting(&reject_hash),
+        Some(PolymeshVotes {
+            index: 0,
+            ayes: vec![bob_did],
+            nays: vec![],
+            end: block_number
+        })
     );
 }
 
@@ -284,7 +312,11 @@ fn changing_vote_threshold_works() {
 
 fn changing_vote_threshold_works_we() {
     assert_eq!(Committee::vote_threshold(), (1, 1));
-    assert_ok!(Committee::set_vote_threshold(root(), 4, 17));
+    assert_ok!(Committee::set_vote_threshold(
+        Origin::from(frame_system::RawOrigin::Root),
+        4,
+        17
+    ));
     assert_eq!(Committee::vote_threshold(), (4, 17));
 }
 
@@ -298,8 +330,7 @@ fn rage_quit() {
 
 fn rage_quit_we() {
     // 1. Add members to committee
-    let alice_ring = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice_ring.public());
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
     let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
     let bob_signer = Origin::signed(AccountKeyring::Bob.public());
     let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
@@ -308,105 +339,131 @@ fn rage_quit_we() {
     let dave_did = register_keyring_account(AccountKeyring::Dave).unwrap();
     let ferdie_signer = Origin::signed(AccountKeyring::Ferdie.public());
     let ferdie_did = register_keyring_account(AccountKeyring::Ferdie).unwrap();
-    set_members(vec![alice_did, bob_did, charlie_did, dave_did]);
-    assert_mem_len(4);
+    let committee = vec![alice_did, bob_did, charlie_did, dave_did];
 
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    CommitteeGroup::reset_members(root.clone(), committee).unwrap();
+    // Assigning random DID but in Production root will have DID
+
+    assert_ok!(u32::try_from((Committee::members()).len()), 4);
     // Ferdie is NOT a member
-    assert_mem(ferdie_did, false);
+    assert_eq!(Committee::is_member(&ferdie_did), false);
     assert_err!(
         CommitteeGroup::abdicate_membership(ferdie_signer),
         group::Error::<TestStorage, group::Instance1>::NoSuchMember
     );
 
     // Make a proposal... only Alice & Bob approve it.
-    prepare_proposal(alice_ring);
-    assert_ok!(Pips::snapshot(alice_signer.clone()));
-    assert_eq!(Committee::proposals(), vec![]);
+    let proposal = make_proposal(42);
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        None,
+        None,
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), 0));
 
-    assert_ok!(vote(&bob_signer, true));
-    assert_ok!(vote(&charlie_signer, false));
-    let enact_hash = hash_enact_snapshot_results();
+    assert_ok!(Committee::vote_enact_referendum(bob_signer.clone(), 0));
+    assert_ok!(Committee::vote_reject_referendum(charlie_signer.clone(), 0,));
+    let block_number = System::block_number();
+
+    let enact_hash = hash_enact_referendum(0);
+    let reject_hash = hash_reject_referendum(0);
     assert_eq!(
         Committee::voting(&enact_hash),
         Some(PolymeshVotes {
             index: 0,
             ayes: vec![bob_did],
-            nays: vec![charlie_did],
-            end: System::block_number(),
+            nays: vec![],
+            end: block_number
+        })
+    );
+    assert_eq!(
+        Committee::voting(&reject_hash),
+        Some(PolymeshVotes {
+            index: 1,
+            ayes: vec![charlie_did],
+            nays: vec![],
+            end: block_number
         })
     );
 
     // Bob quits, its vote should be removed.
-    abdicate_membership(bob_did, &bob_signer, 4);
-    assert_eq!(
-        Committee::voting(&enact_hash),
-        Some(PolymeshVotes {
-            index: 0,
-            ayes: vec![],
-            nays: vec![charlie_did],
-            end: System::block_number(),
-        })
-    );
+    assert_ok!(u32::try_from((Committee::members()).len()), 4);
+    assert_eq!(Committee::is_member(&bob_did), true);
+    assert_ok!(CommitteeGroup::abdicate_membership(bob_signer.clone()));
+    assert_eq!(Committee::is_member(&bob_did), false);
+    assert_ok!(u32::try_from((Committee::members()).len()), 3);
 
-    // Charlie quits, its vote should be removed.
-    abdicate_membership(charlie_did, &charlie_signer, 3);
+    let block_number = System::block_number();
     assert_eq!(
         Committee::voting(&enact_hash),
         Some(PolymeshVotes {
             index: 0,
             ayes: vec![],
             nays: vec![],
-            end: System::block_number(),
+            end: block_number
+        })
+    );
+    assert_eq!(
+        Committee::voting(&reject_hash),
+        Some(PolymeshVotes {
+            index: 1,
+            ayes: vec![charlie_did],
+            nays: vec![],
+            end: block_number
         })
     );
 
-    set_members(vec![alice_did, bob_did, charlie_did]);
-    assert_ok!(vote(&bob_signer, false));
-    assert_err!(
-        vote(&bob_signer, false),
-        committee::Error::<TestStorage, committee::Instance1>::DuplicateVote
-    );
+    // Charlie quits, its vote should be removed and
+    // propose should be accepted.
+    assert_eq!(Committee::is_member(&charlie_did), true);
+    assert_ok!(CommitteeGroup::abdicate_membership(charlie_signer.clone()));
+    assert_ok!(u32::try_from((Committee::members()).len()), 2);
+    assert_eq!(Committee::is_member(&charlie_did), false);
+    // TODO: Only one member, voting should be approved.
+    let block_number = System::block_number();
     assert_eq!(
-        Committee::voting(&enact_hash),
+        Committee::voting(&reject_hash),
         Some(PolymeshVotes {
-            index: 0,
+            index: 1,
             ayes: vec![],
-            nays: vec![bob_did],
-            end: System::block_number()
+            nays: vec![],
+            end: block_number
         })
     );
-    assert_ok!(vote(&alice_signer, true));
+
+    // Assigning random DID but in Production root will have DID
+    let committee = vec![alice_did, bob_did, charlie_did];
+    CommitteeGroup::reset_members(root, committee).unwrap();
+    assert_ok!(Committee::vote_enact_referendum(bob_signer.clone(), 0));
+    assert_err!(
+        Committee::vote_enact_referendum(bob_signer.clone(), 0),
+        committee::Error::<TestStorage, committee::Instance1>::DuplicateVote
+    );
+
+    let block_number = System::block_number();
     assert_eq!(
         Committee::voting(&enact_hash),
         Some(PolymeshVotes {
             index: 0,
-            ayes: vec![alice_did],
-            nays: vec![bob_did],
-            end: System::block_number()
+            ayes: vec![bob_did],
+            nays: vec![],
+            end: block_number
         })
     );
 
     // Alice should not quit because she is the last member.
-    abdicate_membership(charlie_did, &charlie_signer, 3);
-    abdicate_membership(bob_did, &bob_signer, 2);
-    assert_mem(alice_did, true);
+    assert_ok!(CommitteeGroup::abdicate_membership(charlie_signer));
+    assert_ok!(CommitteeGroup::abdicate_membership(bob_signer));
+    assert_eq!(Committee::is_member(&alice_did), true);
     assert_err!(
         CommitteeGroup::abdicate_membership(alice_signer),
         group::Error::<TestStorage, group::Instance1>::LastMemberCannotQuit
     );
-    assert_mem(alice_did, true);
-    assert_eq!(Committee::voting(&enact_hash), None);
-
-    // By quitting, only alice remains, so threshold passes, and therefore proposal is executed.
-    check_scheduled(0);
-    let hash = hash_enact_snapshot_results();
-    let did = IdentityId::default();
-    let expected_event = EventRecord {
-        phase: Phase::Initialization,
-        event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(did, hash, true)),
-        topics: vec![],
-    };
-    assert_eq!(System::events().contains(&expected_event), true);
+    assert_eq!(Committee::is_member(&alice_did), true);
 }
 
 #[test]
@@ -420,6 +477,7 @@ fn release_coordinator() {
 }
 
 fn release_coordinator_we() {
+    let root = Origin::from(frame_system::RawOrigin::Root);
     let alice = Origin::signed(AccountKeyring::Alice.public());
     let alice_id = get_identity_id(AccountKeyring::Alice).expect("Alice is part of the committee");
     let bob = Origin::signed(AccountKeyring::Bob.public());
@@ -437,65 +495,23 @@ fn release_coordinator_we() {
     );
 
     assert_err!(
-        Committee::set_release_coordinator(root(), charlie_id),
+        Committee::set_release_coordinator(root.clone(), charlie_id),
         committee::Error::<TestStorage, committee::Instance1>::MemberNotFound
     );
 
-    assert_ok!(Committee::set_release_coordinator(root(), bob_id));
+    assert_ok!(Committee::set_release_coordinator(root.clone(), bob_id));
     assert_eq!(Committee::release_coordinator(), Some(bob_id));
 
     // Bob abdicates
     assert_ok!(CommitteeGroup::abdicate_membership(bob));
     assert_eq!(Committee::release_coordinator(), None);
 
-    assert_ok!(Committee::set_release_coordinator(root(), alice_id));
+    assert_ok!(Committee::set_release_coordinator(root.clone(), alice_id));
     assert_eq!(Committee::release_coordinator(), Some(alice_id));
 }
 
 #[test]
-fn release_coordinator_majority() {
-    let committee = [AccountKeyring::Alice.public(), AccountKeyring::Bob.public()].to_vec();
-    ExtBuilder::default()
-        .governance_committee(committee)
-        .governance_committee_vote_threshold((2, 3))
-        .build()
-        .execute_with(release_coordinator_majority_we);
-}
-
-fn release_coordinator_majority_we() {
-    let alice = Origin::signed(AccountKeyring::Alice.public());
-    let bob = Origin::signed(AccountKeyring::Bob.public());
-    let bob_id = get_identity_id(AccountKeyring::Bob).expect("Bob is part of the committee");
-
-    assert_eq!(
-        Committee::release_coordinator(),
-        Some(IdentityId::from(999))
-    );
-
-    // Vote to change RC => bob.
-    let call = Call::Committee(pallet_committee::Call::set_release_coordinator(bob_id));
-    assert_ok!(Committee::vote_or_propose(
-        alice.clone(),
-        true,
-        Box::new(call.clone()),
-    ));
-
-    // No majority yet.
-    assert_eq!(
-        Committee::release_coordinator(),
-        Some(IdentityId::from(999))
-    );
-
-    // Bob votes for themselves, this time *via hash*.
-    let hash = <TestStorage as frame_system::Trait>::Hashing::hash_of(&call);
-    assert_ok!(Committee::vote(bob, hash, 0, true));
-
-    // Now we have a new RC.
-    assert_eq!(Committee::release_coordinator(), Some(bob_id));
-}
-
-#[test]
-fn enact() {
+fn enact_referendum() {
     let committee = vec![
         AccountKeyring::Alice.public(),
         AccountKeyring::Bob.public(),
@@ -504,75 +520,127 @@ fn enact() {
     ExtBuilder::default()
         .governance_committee(committee)
         .build()
-        .execute_with(enact_we);
+        .execute_with(enact_referendum_we);
 }
 
-fn enact_we() {
+fn enact_referendum_we() {
     System::set_block_number(1);
 
-    let alice = AccountKeyring::Alice;
-    let alice_signer = Origin::signed(alice.public());
-    let _ = register_keyring_account(alice);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let alice = AccountKeyring::Alice.public();
+    let _alice_id = register_keyring_account(AccountKeyring::Alice);
     let bob = AccountKeyring::Bob.public();
-    let _ = register_keyring_account(AccountKeyring::Bob);
+    let _bob_id = register_keyring_account(AccountKeyring::Bob);
+    let charlie = AccountKeyring::Charlie.public();
+    let _charlie_id = register_keyring_account(AccountKeyring::Charlie);
     let dave = AccountKeyring::Dave.public();
-    let _ = register_keyring_account(AccountKeyring::Dave);
+    let _dave_id = register_keyring_account(AccountKeyring::Dave);
 
     // 1. Create the PIP.
-    prepare_proposal(alice);
-    assert_ok!(Pips::snapshot(alice_signer.clone()));
-    assert_eq!(Committee::proposals(), vec![]);
+    assert_ok!(Pips::propose(
+        Origin::signed(alice),
+        Box::new(proposal.clone()),
+        50,
+        Some(proposal_url.clone()),
+        Some(proposal_desc.clone()),
+        None
+    ));
+    assert_eq!(
+        Pips::proposals(0),
+        Some(Pip {
+            id: 0,
+            proposal: proposal.clone(),
+            state: ProposalState::Pending,
+            beneficiaries: None,
+        })
+    );
+    assert_ok!(Pips::fast_track_proposal(Origin::signed(alice), 0));
 
     // 2. Alice and Bob vote to enact that pip, they are 2/3 of committee.
-    assert_ok!(vote(&alice_signer, true));
+    assert_ok!(Committee::vote_enact_referendum(Origin::signed(alice), 0));
     assert_err!(
-        vote(&Origin::signed(dave), true),
+        Committee::vote_enact_referendum(Origin::signed(dave), 0),
         committee::Error::<TestStorage, committee::Instance1>::BadOrigin,
     );
-    assert_ok!(vote(&Origin::signed(bob), true));
-    check_scheduled(0);
-}
+    assert_ok!(Committee::vote_enact_referendum(Origin::signed(bob), 0));
+    assert_eq!(
+        Pips::proposals(0),
+        Some(Pip {
+            id: 0,
+            proposal,
+            state: ProposalState::Referendum,
+            beneficiaries: None,
+        })
+    );
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 101,
+        })
+    );
+    // Execute referendum
+    fast_forward_to_block(102);
+    /*assert_eq!(
+    Pips::referendums(0),
+    Some(Referendum {
+    id: 0,
+    state: ReferendumState::Executed,
+    referendum_type: ReferendumType::FastTracked,
+    enactment_period: 101,
+    })
+    );*/
 
-#[test]
-fn mesh_1065_regression_test() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
+    // 3. Invalid referendum.
+    assert_err!(
+        Committee::vote_enact_referendum(Origin::signed(alice), 1),
+        committee::Error::<TestStorage, committee::Instance1>::NoSuchProposal,
+    );
 
-        let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
-        let bob_signer = Origin::signed(AccountKeyring::Bob.public());
-        let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
-        let charlie_did = register_keyring_account(AccountKeyring::Charlie).unwrap();
-        set_members(vec![alice_did, bob_did, charlie_did]);
-        assert_mem_len(3);
+    // 4. Reject referendums.
+    // Bob and Chalie reject the referendum.
+    let proposal_rej = make_proposal(1);
+    assert_ok!(Pips::propose(
+        Origin::signed(alice),
+        Box::new(proposal_rej.clone()),
+        50,
+        Some(proposal_url),
+        Some(proposal_desc),
+        None
+    ));
+    assert_ok!(Pips::fast_track_proposal(Origin::signed(alice), 1));
 
-        let assert_ayes = |ayes| {
-            assert_eq!(
-                Committee::voting(&hash_enact_snapshot_results()),
-                Some(PolymeshVotes {
-                    index: 0,
-                    ayes,
-                    nays: vec![],
-                    end: System::block_number(),
-                })
-            );
-        };
+    assert_ok!(Committee::vote_reject_referendum(Origin::signed(bob), 1));
+    assert_ok!(Committee::vote_reject_referendum(
+        Origin::signed(charlie),
+        1
+    ));
+    assert_eq!(
+        Pips::proposals(1),
+        Some(Pip {
+            id: 1,
+            proposal: proposal_rej,
+            state: ProposalState::Referendum,
+            beneficiaries: None
+        })
+    );
+    assert_eq!(
+        Pips::referendums(1),
+        Some(Referendum {
+            id: 1,
+            state: ReferendumState::Rejected,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 0,
+        })
+    );
 
-        // Bob votes for something.
-        // It doesn't matter that no PIP exist; we're only testing voting itself.
-        assert_ok!(vote(&bob_signer, true));
-        assert_ayes(vec![bob_did]);
-
-        // Bob abdicates.
-        abdicate_membership(bob_did, &bob_signer, 3);
-        assert_ayes(vec![]);
-
-        // Bob rejoins.
-        set_members(vec![alice_did, bob_did, charlie_did]);
-        assert_mem_len(3);
-        assert_ayes(vec![]);
-
-        // Bob revotes, and there's no `DuplicateVote` error.
-        assert_ok!(vote(&bob_signer, true));
-        assert_ayes(vec![bob_did]);
-    });
+    assert_err!(
+        Committee::vote_enact_referendum(Origin::signed(dave), 1),
+        committee::Error::<TestStorage, committee::Instance1>::BadOrigin,
+    );
 }

--- a/pallets/runtime/tests/src/committee_test.rs
+++ b/pallets/runtime/tests/src/committee_test.rs
@@ -13,7 +13,7 @@ use frame_system::{EventRecord, Phase};
 use pallet_committee::{self as committee, PolymeshVotes, RawEvent as CommitteeRawEvent};
 use pallet_group as group;
 use pallet_identity as identity;
-use pallet_pips::{self as pips, ProposalState, SnapshotResult};
+use pallet_pips::{self as pips, ProposalState, Proposer, SnapshotResult};
 use polymesh_common_utilities::traits::pip::PipId;
 use polymesh_primitives::IdentityId;
 use sp_core::H256;
@@ -79,6 +79,7 @@ fn prepare_proposal(ring: AccountKeyring) {
     let acc = ring.public();
     assert_ok!(Pips::propose(
         Origin::signed(acc),
+        Proposer::Community(acc),
         Box::new(proposal.clone()),
         50,
         None,
@@ -281,34 +282,9 @@ fn changing_vote_threshold_works() {
         .execute_with(changing_vote_threshold_works_we);
 }
 
-/// Constructs an origin for the governance council voting majority.
-pub fn gc_vmo() -> Origin {
-    pallet_committee::Origin::<TestStorage, committee::Instance1>::Members(0, 0).into()
-}
-
 fn changing_vote_threshold_works_we() {
-    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
-    let alice_did = register_keyring_account(AccountKeyring::Alice).unwrap();
-    let bob_signer = Origin::signed(AccountKeyring::Bob.public());
-    let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
-    set_members(vec![alice_did, bob_did]);
-
     assert_eq!(Committee::vote_threshold(), (1, 1));
-
-    let call_svt = Box::new(Call::Committee(pallet_committee::Call::set_vote_threshold(
-        4, 17,
-    )));
-    assert_ok!(Committee::vote_or_propose(
-        alice_signer,
-        true,
-        call_svt.clone()
-    ));
-    assert_ok!(Committee::vote_or_propose(
-        bob_signer,
-        true,
-        call_svt.clone()
-    ));
-
+    assert_ok!(Committee::set_vote_threshold(root(), 4, 17));
     assert_eq!(Committee::vote_threshold(), (4, 17));
 }
 
@@ -411,16 +387,15 @@ fn rage_quit_we() {
     );
 
     // Alice should not quit because she is the last member.
-    System::reset_events();
     abdicate_membership(charlie_did, &charlie_signer, 3);
     abdicate_membership(bob_did, &bob_signer, 2);
-    assert_eq!(Committee::voting(&enact_hash), None);
     assert_mem(alice_did, true);
     assert_err!(
         CommitteeGroup::abdicate_membership(alice_signer),
         group::Error::<TestStorage, group::Instance1>::LastMemberCannotQuit
     );
     assert_mem(alice_did, true);
+    assert_eq!(Committee::voting(&enact_hash), None);
 
     // By quitting, only alice remains, so threshold passes, and therefore proposal is executed.
     check_scheduled(0);
@@ -462,18 +437,18 @@ fn release_coordinator_we() {
     );
 
     assert_err!(
-        Committee::set_release_coordinator(gc_vmo(), charlie_id),
+        Committee::set_release_coordinator(root(), charlie_id),
         committee::Error::<TestStorage, committee::Instance1>::MemberNotFound
     );
 
-    assert_ok!(Committee::set_release_coordinator(gc_vmo(), bob_id));
+    assert_ok!(Committee::set_release_coordinator(root(), bob_id));
     assert_eq!(Committee::release_coordinator(), Some(bob_id));
 
     // Bob abdicates
     assert_ok!(CommitteeGroup::abdicate_membership(bob));
     assert_eq!(Committee::release_coordinator(), None);
 
-    assert_ok!(Committee::set_release_coordinator(gc_vmo(), alice_id));
+    assert_ok!(Committee::set_release_coordinator(root(), alice_id));
     assert_eq!(Committee::release_coordinator(), Some(alice_id));
 }
 

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -326,7 +326,6 @@ impl ExtBuilder {
             .collect::<Vec<_>>();
 
         group::GenesisConfig::<TestStorage, group::Instance2> {
-            active_members_limit: u32::MAX,
             active_members: cdd_ids,
             ..Default::default()
         }
@@ -348,7 +347,6 @@ impl ExtBuilder {
             .collect::<Vec<_>>();
 
         group::GenesisConfig::<TestStorage, group::Instance1> {
-            active_members_limit: u32::MAX,
             active_members: gc_ids.clone(),
             ..Default::default()
         }

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -17,8 +17,6 @@ use test_client::AccountKeyring;
 /// A prime number fee to test the split between multiple recipients.
 pub const PROTOCOL_OP_BASE_FEE: u128 = 41;
 
-pub const COOL_OFF_PERIOD: u64 = 100;
-
 struct BuilderVoteThreshold {
     pub numerator: u32,
     pub denominator: u32,
@@ -375,10 +373,10 @@ impl ExtBuilder {
         pips::GenesisConfig::<TestStorage> {
             prune_historical_pips: false,
             min_proposal_deposit: 50,
-            proposal_cool_off_period: COOL_OFF_PERIOD,
+            quorum_threshold: 70,
+            proposal_duration: 10,
+            proposal_cool_off_period: 100,
             default_enactment_period: 100,
-            max_pip_skip_count: 1,
-            active_pip_limit: 5,
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -528,7 +528,6 @@ fn proposal_details_are_correct() {
             created_at: 42,
             url: Some(proposal_url),
             description: Some(proposal_desc),
-            transaction_version: 0,
         };
         assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
 
@@ -624,7 +623,6 @@ fn amend_proposal_works() {
             created_at: 1,
             url,
             description,
-            transaction_version: 0,
         };
         assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
     });

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -1,27 +1,22 @@
 use super::{
-    committee_test::{root, set_members},
     storage::{
-        fast_forward_blocks, get_identity_id, register_keyring_account, Call, EventTest,
+        get_identity_id, register_keyring_account, register_keyring_account_with_balance, Call,
         TestStorage,
     },
     ExtBuilder,
 };
-use frame_support::{
-    assert_noop, assert_ok,
-    dispatch::{DispatchError, DispatchResult},
-    StorageDoubleMap, StoragePrefixedMap,
-};
-use frame_system::{self, EventRecord};
+use frame_support::{assert_err, assert_ok, dispatch::DispatchError};
+use frame_system;
 use pallet_balances as balances;
 use pallet_committee as committee;
 use pallet_group as group;
 use pallet_pips::{
-    self as pips, DepositInfo, Pip, PipDescription, ProposalState, Proposer, RawEvent as Event,
-    SnapshotMetadata, SnapshotResult, SnapshottedPip, Url, Vote, VotingResult,
+    self as pips, DepositInfo, Error, PipDescription, PipsMetadata, Referendum, ReferendumState,
+    ReferendumType, Url, VotingResult,
 };
 use pallet_treasury as treasury;
-use polymesh_common_utilities::pip::PipId;
-use polymesh_primitives::IdentityId;
+use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
+use polymesh_primitives::{Beneficiary, Signatory};
 use sp_core::sr25519::Public;
 use test_client::AccountKeyring;
 
@@ -31,133 +26,11 @@ type Pips = pips::Module<TestStorage>;
 type Group = group::Module<TestStorage, group::Instance1>;
 type Committee = committee::Module<TestStorage, committee::Instance1>;
 type Treasury = treasury::Module<TestStorage>;
-type Error = pallet_pips::Error<TestStorage>;
-type Deposits = pallet_pips::Deposits<TestStorage>;
-type Votes = pallet_pips::ProposalVotes<TestStorage>;
 
 type Origin = <TestStorage as frame_system::Trait>::Origin;
 
-#[derive(Copy, Clone)]
-struct User {
-    ring: AccountKeyring,
-    did: IdentityId,
-}
-
-impl User {
-    fn new(ring: AccountKeyring) -> Self {
-        let did = register_keyring_account(ring).unwrap();
-        Self { ring, did }
-    }
-
-    fn existing(ring: AccountKeyring) -> Self {
-        let did = get_identity_id(ring).unwrap();
-        User { ring, did }
-    }
-
-    fn balance(self, balance: u128) -> Self {
-        use frame_support::traits::Currency as _;
-        Balances::make_free_balance_be(&self.acc(), balance);
-        self
-    }
-
-    fn acc(&self) -> Public {
-        self.ring.public()
-    }
-
-    fn signer(&self) -> Origin {
-        Origin::signed(self.acc())
-    }
-}
-
-macro_rules! assert_last_event {
-    ($event:pat) => {
-        assert_last_event!($event, true);
-    };
-    ($event:pat, $cond:expr) => {
-        assert!(matches!(
-            &*System::events(),
-            [.., EventRecord {
-                event: EventTest::pips($event),
-                ..
-            }]
-            if $cond
-        ));
-    };
-}
-
-macro_rules! assert_bad_origin {
-    ($e:expr) => {
-        assert_noop!($e, DispatchError::BadOrigin);
-    };
-}
-
-macro_rules! assert_bad_state {
-    ($e:expr) => {{
-        assert_noop!($e, Error::IncorrectProposalState);
-    }};
-}
-
-macro_rules! assert_no_pip {
-    ($e:expr) => {{
-        assert_noop!($e, Error::NoSuchProposal);
-    }};
-}
-
-macro_rules! assert_immutable {
-    ($e:expr) => {{
-        assert_noop!($e, Error::ProposalIsImmutable);
-    }};
-}
-
 fn make_proposal(value: u64) -> Call {
     Call::Pips(pips::Call::set_min_proposal_deposit(value.into()))
-}
-
-fn proposal(
-    signer: &Origin,
-    proposer: &Proposer<Public>,
-    proposal: Call,
-    deposit: u128,
-    url: Option<Url>,
-    desc: Option<PipDescription>,
-) -> DispatchResult {
-    let before = Pips::pip_id_sequence();
-    let active = Pips::active_pip_count();
-    let signer = signer.clone();
-    let proposer = proposer.clone();
-    let result = Pips::propose(signer, proposer, Box::new(proposal), deposit, url, desc);
-    let add = result.map_or(0, |_| 1);
-    if let Ok(_) = result {
-        assert_last_event!(Event::ProposalCreated(_, _, id, ..), *id == before);
-    }
-    assert_eq!(Pips::pip_id_sequence(), before + add);
-    assert_eq!(Pips::active_pip_count(), active + add);
-    result
-}
-
-fn standard_proposal(
-    signer: &Origin,
-    proposer: &Proposer<Public>,
-    deposit: u128,
-) -> DispatchResult {
-    proposal(signer, proposer, make_proposal(42), deposit, None, None)
-}
-
-fn committee_proposal(deposit: u128) -> DispatchResult {
-    let prop_committee = Proposer::Committee(pallet_pips::Committee::Technical);
-    standard_proposal(&root(), &prop_committee, deposit)
-}
-
-fn alice_proposal(deposit: u128) -> DispatchResult {
-    let acc = AccountKeyring::Alice.public();
-    standard_proposal(&Origin::signed(acc), &Proposer::Community(acc), deposit)
-}
-
-fn consensus_call(call: pallet_pips::Call<TestStorage>, signers: &[&Origin]) {
-    let call = Box::new(Call::Pips(call));
-    for signer in signers.iter().copied().cloned() {
-        assert_ok!(Committee::vote_or_propose(signer, true, call.clone()));
-    }
 }
 
 fn fast_forward_to(n: u64) {
@@ -168,1634 +41,950 @@ fn fast_forward_to(n: u64) {
     });
 }
 
-fn assert_state(id: PipId, care_about_pruned: bool, state: ProposalState) {
-    let prop = Pips::proposals(id);
-    if care_about_pruned && Pips::prune_historical_pips() {
-        assert_eq!(prop, None);
-    } else {
-        assert_eq!(prop.unwrap().state, state);
-    }
+pub fn assert_balance(acc: Public, free: u128, locked: u128) {
+    assert_eq!(Balances::free_balance(&acc), free);
+    assert_eq!(Balances::usable_balance(&acc), free - locked);
 }
 
 #[test]
-fn updating_pips_variables_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        assert_eq!(Pips::prune_historical_pips(), false);
-        assert_ok!(Pips::set_prune_historical_pips(root(), true));
-        assert_last_event!(Event::HistoricalPipsPruned(_, false, true));
-        assert_eq!(Pips::prune_historical_pips(), true);
-
-        assert_eq!(Pips::min_proposal_deposit(), 50);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 10));
-        assert_last_event!(Event::MinimumProposalDepositChanged(_, 50, 10));
-        assert_eq!(Pips::min_proposal_deposit(), 10);
-
-        assert_eq!(Pips::proposal_cool_off_period(), 100);
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 10));
-        assert_last_event!(Event::ProposalCoolOffPeriodChanged(_, 100, 10));
-        assert_eq!(Pips::proposal_cool_off_period(), 10);
-
-        assert_eq!(Pips::default_enactment_period(), 100);
-        assert_ok!(Pips::set_default_enactment_period(root(), 10));
-        assert_last_event!(Event::DefaultEnactmentPeriodChanged(_, 100, 10));
-        assert_eq!(Pips::default_enactment_period(), 10);
-
-        assert_eq!(Pips::max_pip_skip_count(), 1);
-        assert_ok!(Pips::set_max_pip_skip_count(root(), 42));
-        assert_last_event!(Event::MaxPipSkipCountChanged(_, 1, 42));
-        assert_eq!(Pips::max_pip_skip_count(), 42);
-
-        assert_eq!(Pips::active_pip_limit(), 5);
-        assert_ok!(Pips::set_active_pip_limit(root(), 42));
-        assert_last_event!(Event::ActivePipLimitChanged(_, 5, 42));
-        assert_eq!(Pips::active_pip_limit(), 42);
-    });
+fn starting_a_proposal_works() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(starting_a_proposal_works_we)
 }
 
-#[test]
-fn updating_pips_variables_only_root() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let signer = Origin::signed(AccountKeyring::Alice.public());
-        System::reset_events();
+fn starting_a_proposal_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
 
-        assert_noop!(
-            Pips::set_prune_historical_pips(signer.clone(), false),
-            DispatchError::BadOrigin,
-        );
-        assert_noop!(
-            Pips::set_min_proposal_deposit(signer.clone(), 0),
-            DispatchError::BadOrigin,
-        );
-        assert_noop!(
-            Pips::set_proposal_cool_off_period(signer.clone(), 0),
-            DispatchError::BadOrigin,
-        );
-        assert_noop!(
-            Pips::set_default_enactment_period(signer.clone(), 0),
-            DispatchError::BadOrigin,
-        );
-        assert_noop!(
-            Pips::set_max_pip_skip_count(signer.clone(), 0),
-            DispatchError::BadOrigin,
-        );
-        assert_noop!(
-            Pips::set_active_pip_limit(signer.clone(), 0),
-            DispatchError::BadOrigin,
-        );
+    TestStorage::set_payer_context(Some(AccountKeyring::Alice.public()));
+    let alice_acc = AccountKeyring::Alice.public();
+    let alice_signer = Origin::signed(alice_acc.clone());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Alice, 300).unwrap();
 
-        assert_eq!(System::events(), vec![])
-    });
-}
-
-#[test]
-fn historical_prune_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        // We just test one case for brevity.
-        System::set_block_number(1);
-        assert_ok!(Pips::set_prune_historical_pips(root(), true));
-        assert_pruned(cancelled_proposal());
-        assert_pruned(rejected_proposal());
-        let bob = User::new(AccountKeyring::Bob);
-        set_members(vec![bob.did]);
-        assert_pruned(executed_community_proposal(&bob.signer()));
-        assert_pruned(failed_community_proposal(bob, 1337));
-    });
-}
-
-#[test]
-fn min_deposit_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let deposit = 40;
-        assert_ok!(Pips::set_min_proposal_deposit(root(), deposit + 1));
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-
-        // Error when min deposit requirements are not met.
-        assert_eq!(Pips::pip_id_sequence(), 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_noop!(alice_proposal(deposit), Error::IncorrectDeposit);
-
-        // Now let's use enough.
-        assert_ok!(alice_proposal(deposit + 1));
-        assert_state(0, false, ProposalState::Pending);
-        assert_eq!(
-            Pips::proposal_metadata(0).unwrap().proposer,
-            Proposer::Community(alice.acc())
-        );
-
-        // Committees are exempt from min deposit.
-        assert_ok!(committee_proposal(0));
-        assert_state(1, false, ProposalState::Pending);
-        let prop_committee = Proposer::Committee(pallet_pips::Committee::Technical);
-        assert_eq!(Pips::proposal_metadata(1).unwrap().proposer, prop_committee);
-        assert_vote_details(1, VotingResult::default(), vec![], vec![]);
-    })
-}
-
-#[test]
-fn active_limit_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-
-        assert_eq!(Pips::pip_id_sequence(), 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-
-        assert_ok!(alice_proposal(0));
-        assert_eq!(Pips::active_pip_count(), 1);
-
-        // Limit reached, so error.
-        assert_ok!(Pips::set_active_pip_limit(root(), 1));
-        assert_noop!(alice_proposal(0), Error::TooManyActivePips);
-        assert_eq!(Pips::active_pip_count(), 1);
-
-        // Bump limit; ok again.
-        assert_ok!(Pips::set_active_pip_limit(root(), 2));
-        assert_ok!(alice_proposal(0));
-        assert_eq!(Pips::active_pip_count(), 2);
-
-        // Reached again, so error.
-        assert_noop!(alice_proposal(0), Error::TooManyActivePips);
-        assert_eq!(Pips::active_pip_count(), 2);
-
-        // Committees are exempt from limit.
-        assert_ok!(committee_proposal(0));
-        assert_eq!(Pips::active_pip_count(), 3);
-
-        // Remove limit completely, and let's add more.
-        assert_ok!(Pips::set_active_pip_limit(root(), 0));
-        assert_ok!(alice_proposal(0));
-        assert_eq!(Pips::active_pip_count(), 4);
-    })
-}
-
-#[test]
-fn cool_off_period_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let block = System::block_number();
-        let propose_check = |cooling_until| {
-            assert_ok!(Pips::set_proposal_cool_off_period(root(), cooling_until));
-            assert_ok!(alice_proposal(0));
-            assert_eq!(
-                block + cooling_until,
-                Pips::proposal_metadata(Pips::pip_id_sequence() - 1)
-                    .unwrap()
-                    .cool_off_until,
-            );
-        };
-        propose_check(0);
-        propose_check(1);
-        propose_check(10);
-        propose_check(42);
-    })
-}
-
-#[test]
-fn default_enactment_period_works_community() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-        set_members(vec![alice.did]);
-
-        let check_community = |period| {
-            assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-            assert_ok!(alice_proposal(0));
-            let last_id = Pips::pip_id_sequence() - 1;
-            fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
-            assert_ok!(Pips::snapshot(alice.signer()));
-            assert_ok!(Pips::set_default_enactment_period(root(), period));
-            let block_at_approval = System::block_number();
-            assert_ok!(Pips::enact_snapshot_results(
-                root(),
-                vec![(last_id, SnapshotResult::Approve)]
-            ));
-            let expected = Pips::pip_to_schedule(last_id).unwrap();
-            assert!(Pips::execution_schedule(expected).contains(&last_id));
-            assert_eq!(expected, block_at_approval + period);
-        };
-        check_community(0);
-        check_community(3);
-        check_community(42);
-        check_community(1337);
-    });
-}
-
-#[test]
-fn default_enactment_period_works_committee() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-        set_members(vec![alice.did]);
-
-        let check_committee = |period| {
-            assert_ok!(committee_proposal(0));
-            let last_id = Pips::pip_id_sequence() - 1;
-            fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
-            assert_ok!(Pips::set_default_enactment_period(root(), period));
-            let block_at_approval = System::block_number();
-            assert_ok!(Pips::approve_committee_proposal(root(), last_id));
-            let expected = Pips::pip_to_schedule(last_id).unwrap();
-            assert!(Pips::execution_schedule(expected).contains(&last_id));
-            assert_eq!(expected, block_at_approval + period);
-        };
-        check_committee(0);
-        check_committee(3);
-        check_committee(42);
-        check_committee(1337);
-    })
-}
-
-#[test]
-fn skip_limit_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-        set_members(vec![alice.did]);
-
-        let snap = || Pips::snapshot(alice.signer()).unwrap();
-        let count = |n| Pips::set_max_pip_skip_count(root(), n).unwrap();
-        let commit = || Pips::enact_snapshot_results(root(), vec![(0, SnapshotResult::Skip)]);
-
-        assert_ok!(alice_proposal(0));
-
-        snap();
-        count(0);
-        assert_noop!(commit(), Error::CannotSkipPip);
-
-        snap();
-        count(1);
-        assert_ok!(commit());
-        snap();
-        assert_noop!(commit(), Error::CannotSkipPip);
-
-        snap();
-        count(2);
-        assert_ok!(commit());
-        snap();
-        assert_noop!(commit(), Error::CannotSkipPip);
-    });
-}
-
-fn assert_vote_details(
-    id: PipId,
-    results: VotingResult<u128>,
-    deposits: Vec<DepositInfo<Public, u128>>,
-    votes: Vec<Vote<u128>>,
-) {
-    assert_eq!(results, Pips::proposal_result(id));
-    assert_eq!(
-        deposits,
-        Deposits::iter_prefix_values(id).collect::<Vec<_>>(),
-    );
-    assert_eq!(votes, Votes::iter_prefix_values(id).collect::<Vec<_>>());
-}
-
-fn assert_votes(id: PipId, owner: Public, amount: u128) {
-    assert_vote_details(
-        id,
-        VotingResult {
-            ayes_count: 1,
-            ayes_stake: amount,
-            nays_count: 0,
-            nays_stake: 0,
-        },
-        vec![DepositInfo { owner, amount }],
-        vec![Vote(true, amount)],
-    );
-}
-
-#[test]
-fn proposal_details_are_correct() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-
-        let call = make_proposal(42);
-        let proposal_url: Url = b"www.abc.com".into();
-        let proposal_desc: PipDescription = b"Test description".into();
-
-        let proposer = Proposer::Community(alice.acc());
-
-        // Alice starts a proposal with min deposit.
-        assert_ok!(proposal(
-            &alice.signer(),
-            &proposer,
-            call.clone(),
-            60,
+    // Error when min deposit requirements are not met
+    assert_err!(
+        Pips::propose(
+            alice_signer.clone(),
+            Box::new(proposal.clone()),
+            40,
             Some(proposal_url.clone()),
             Some(proposal_desc.clone()),
-        ));
-        assert_last_event!(Event::ProposalCreated(..));
-
-        let prop = Pips::proposals(0).unwrap();
-        assert_eq!(prop.id, 0);
-        assert_eq!(prop.proposal, call);
-        assert_eq!(prop.state, ProposalState::Pending);
-
-        let meta = Pips::proposal_metadata(0).unwrap();
-        assert_eq!(meta.id, 0);
-        assert_eq!(meta.proposer, proposer);
-        assert_eq!(meta.url, Some(proposal_url));
-        assert_eq!(meta.description, Some(proposal_desc));
-        assert_eq!(
-            meta.cool_off_until,
-            System::block_number() + Pips::proposal_cool_off_period()
-        );
-
-        assert_eq!(Balances::free_balance(&alice.acc()), 300 - 60);
-        assert_votes(0, alice.acc(), 60);
-    });
-}
-
-#[test]
-fn propose_committee_pip_only_zero_deposit() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(committee_proposal(0));
-        assert_noop!(committee_proposal(1337), Error::NotFromCommunity);
-    });
-}
-
-#[test]
-fn amend_proposal_no_such_proposal() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_no_pip!(Pips::amend_proposal(root(), 0, None, None));
-        assert_no_pip!(Pips::cancel_proposal(root(), 0));
-        let signer = Origin::signed(AccountKeyring::Bob.public());
-        assert_no_pip!(Pips::vote(signer, 0, false, 0));
-    });
-}
-
-#[test]
-fn amend_proposal_not_owner_bad_origin() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(alice_proposal(0));
-        let bob = Origin::signed(AccountKeyring::Bob.public());
-        assert_bad_origin!(Pips::amend_proposal(bob.clone(), 0, None, None));
-        assert_bad_origin!(Pips::cancel_proposal(bob.clone(), 0));
-    });
-}
-
-#[test]
-fn amend_proposal_not_pending() {
-    let op_and_check = |op_and_check: &dyn Fn(Origin, PipId)| {
-        ExtBuilder::default().build().execute_with(|| {
-            System::set_block_number(1);
-            assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-            assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-            let alice = User::new(AccountKeyring::Alice);
-            set_members(vec![alice.did]);
-
-            op_and_check(alice.signer(), cancelled_proposal());
-            op_and_check(alice.signer(), rejected_proposal());
-            op_and_check(alice.signer(), executed_community_proposal(&alice.signer()));
-            op_and_check(alice.signer(), failed_community_proposal(alice, 1337));
-            op_and_check(alice.signer(), scheduled_proposal(&alice.signer(), 0));
-        })
-    };
-    op_and_check(&|o, id| assert_bad_state!(Pips::amend_proposal(o, id, None, None)));
-    op_and_check(&|o, id| assert_bad_state!(Pips::cancel_proposal(o, id)));
-    op_and_check(&|o, id| assert_bad_state!(Pips::vote(o, id, false, 0)));
-}
-
-#[test]
-fn amend_proposal_beyond_cool_off() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 42));
-        assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
-        fast_forward_blocks(Pips::proposal_cool_off_period());
-        let signer = Origin::signed(AccountKeyring::Alice.public());
-        assert_immutable!(Pips::amend_proposal(signer.clone(), 0, None, None));
-        assert_immutable!(Pips::cancel_proposal(signer.clone(), 0));
-    });
-}
-
-#[test]
-fn amend_proposal_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
-        let signer = Origin::signed(AccountKeyring::Alice.public());
-        let url = Some("https:://example.com".into());
-        let desc = Some("foo bar baz".into());
-        assert_ok!(Pips::amend_proposal(signer, 0, url.clone(), desc.clone()));
-        let meta = Pips::proposal_metadata(0).unwrap();
-        assert_eq!(meta.url, url);
-        assert_eq!(meta.description, desc);
-    });
-}
-
-#[test]
-fn vote_bond_additional_deposit_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-
-        let init_free = 1000;
-        let init_amount = 300;
-        let then_amount = 137;
-        let amount = init_amount + then_amount;
-
-        let acc = AccountKeyring::Alice.public();
-        let signer = Origin::signed(acc);
-        assert_eq!(Balances::free_balance(&acc), init_free);
-
-        assert_ok!(alice_proposal(init_amount));
-        assert_eq!(Balances::free_balance(&acc), init_free - init_amount);
-        assert_ok!(Pips::vote(signer, 0, true, amount));
-        assert_eq!(Balances::free_balance(&acc), init_free - amount);
-        assert_last_event!(Event::Voted(.., true, _));
-        assert_votes(0, acc, amount);
-    });
-}
-
-#[test]
-fn vote_owner_below_min_deposit() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        let min = 50;
-        let sub = min - 1;
-        assert_ok!(Pips::set_min_proposal_deposit(root(), min));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-
-        let alice = User::new(AccountKeyring::Alice);
-        let bob = User::new(AccountKeyring::Bob);
-
-        assert_ok!(alice_proposal(100));
-        assert_noop!(
-            Pips::vote(alice.signer(), 0, true, sub),
-            Error::IncorrectDeposit
-        );
-        assert_votes(0, alice.acc(), 100);
-        // Doesn't apply to Bob though, as they didn't propose it.
-        assert_ok!(Pips::vote(bob.signer(), 0, true, sub));
-        assert_vote_details(
-            0,
-            VotingResult {
-                ayes_count: 2,
-                ayes_stake: 100 + sub,
-                ..VotingResult::default()
-            },
-            vec![
-                DepositInfo {
-                    owner: alice.acc(),
-                    amount: 100,
-                },
-                DepositInfo {
-                    owner: bob.acc(),
-                    amount: sub,
-                },
-            ],
-            vec![Vote(true, 100), Vote(true, sub)],
-        );
-    });
-}
-
-#[test]
-fn vote_unbond_deposit_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-
-        let init_free = 1000;
-        let init_amount = 200;
-        let then_amount = 100;
-
-        let acc = AccountKeyring::Alice.public();
-        let signer = Origin::signed(acc);
-        assert_eq!(Balances::free_balance(&acc), init_free);
-
-        assert_ok!(alice_proposal(init_amount));
-        assert_eq!(Balances::free_balance(&acc), init_free - init_amount);
-        assert_ok!(Pips::vote(signer, 0, true, then_amount));
-        assert_eq!(Balances::free_balance(&acc), init_free - then_amount);
-        assert_last_event!(Event::Voted(.., true, _));
-        assert_votes(0, acc, then_amount);
-    });
-}
-
-#[test]
-fn vote_on_community_only() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(committee_proposal(0));
-        let signer = Origin::signed(AccountKeyring::Alice.public());
-        assert_noop!(Pips::vote(signer, 0, false, 0), Error::NotFromCommunity);
-    });
-}
-
-#[test]
-fn vote_on_cool_off() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 42));
-        assert_ok!(alice_proposal(0));
-        assert!(Pips::proposal_metadata(0).unwrap().cool_off_until > System::block_number());
-        // Alice made the PIP, so they can vote during cool-off period.
-        let signer = User::new(AccountKeyring::Alice).signer();
-        assert_ok!(Pips::vote(signer, 0, false, 0));
-        // Bob cannot vote until cool-off has passed.
-        let signer = Origin::signed(AccountKeyring::Bob.public());
-        assert_noop!(
-            Pips::vote(signer.clone(), 0, false, 0),
-            Error::ProposalOnCoolOffPeriod
-        );
-        // Fast-forward beyond cool-off; Bob can vote now.
-        fast_forward_blocks(42);
-        assert_ok!(Pips::vote(signer, 0, false, 0));
-    });
-}
-
-#[test]
-fn vote_duplicate_ok() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        let signer = Origin::signed(AccountKeyring::Alice.public());
-
-        assert_ok!(alice_proposal(42));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                ayes_count: 1,
-                ayes_stake: 42,
-                ..VotingResult::default()
-            }
-        );
-        assert_ok!(Pips::vote(signer.clone(), 0, true, 21));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                ayes_count: 1,
-                ayes_stake: 21,
-                ..VotingResult::default()
-            }
-        );
-        assert_ok!(Pips::vote(signer.clone(), 0, false, 21));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                nays_count: 1,
-                nays_stake: 21,
-                ..VotingResult::default()
-            }
-        );
-        assert_ok!(Pips::vote(signer.clone(), 0, false, 42));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                nays_count: 1,
-                nays_stake: 42,
-                ..VotingResult::default()
-            }
-        );
-        assert_ok!(Pips::vote(signer.clone(), 0, true, 42));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                ayes_count: 1,
-                ayes_stake: 42,
-                ..VotingResult::default()
-            }
-        );
-    });
-}
-
-#[test]
-fn vote_stake_overflow() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        let alice = User::new(AccountKeyring::Alice).balance(u128::MAX);
-        let bob = User::new(AccountKeyring::Bob).balance(100);
-
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(alice_proposal(u128::MAX));
-        assert_eq!(
-            Pips::proposal_result(0),
-            VotingResult {
-                ayes_count: 1,
-                ayes_stake: u128::MAX,
-                ..VotingResult::default()
-            }
-        );
-        assert_noop!(
-            Pips::vote(bob.signer(), 0, true, 1),
-            Error::StakeAmountOfVotesExceeded,
-        );
-        assert_ok!(Pips::vote(bob.signer(), 0, false, 1));
-        assert_noop!(
-            Pips::vote(alice.signer(), 0, false, u128::MAX),
-            Error::StakeAmountOfVotesExceeded,
-        );
-    });
-}
-
-#[test]
-fn vote_insufficient_reserve() {
-    ExtBuilder::default()
-        .monied(false)
-        .build()
-        .execute_with(|| {
-            System::set_block_number(1);
-            assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-            assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-            let signer = Origin::signed(AccountKeyring::Bob.public());
-            assert_ok!(alice_proposal(0));
-            assert_noop!(
-                Pips::vote(signer.clone(), 0, false, 50),
-                Error::InsufficientDeposit
-            );
-            assert_noop!(Pips::vote(signer, 0, true, 1), Error::InsufficientDeposit);
-        });
-}
-
-#[test]
-fn vote_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        let alice_acc = AccountKeyring::Alice.public();
-        let bob_acc = AccountKeyring::Bob.public();
-        let bob = Origin::signed(bob_acc);
-        let charlie_acc = AccountKeyring::Charlie.public();
-        let charlie = Origin::signed(charlie_acc);
-        assert_ok!(alice_proposal(100));
-        assert_eq!(Balances::free_balance(&bob_acc), 2000);
-        assert_eq!(Balances::free_balance(&charlie_acc), 3000);
-        assert_ok!(Pips::vote(bob, 0, false, 1337));
-        assert_last_event!(Event::Voted(.., false, 1337));
-        assert_ok!(Pips::vote(charlie, 0, true, 2441));
-        assert_last_event!(Event::Voted(.., true, 2441));
-        assert_eq!(Balances::free_balance(&bob_acc), 2000 - 1337);
-        assert_eq!(Balances::free_balance(&charlie_acc), 3000 - 2441);
-        assert_vote_details(
-            0,
-            VotingResult {
-                ayes_count: 2,
-                ayes_stake: 2541,
-                nays_count: 1,
-                nays_stake: 1337,
-            },
-            vec![
-                DepositInfo {
-                    owner: alice_acc,
-                    amount: 100,
-                },
-                DepositInfo {
-                    owner: bob_acc,
-                    amount: 1337,
-                },
-                DepositInfo {
-                    owner: charlie_acc,
-                    amount: 2441,
-                },
-            ],
-            vec![Vote(true, 100), Vote(false, 1337), Vote(true, 2441)],
-        );
-    });
-}
-
-#[test]
-fn approve_committee_proposal_not_pending() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-        let alice = User::new(AccountKeyring::Alice);
-        set_members(vec![alice.did]);
-
-        let acp_bad_state = |id| assert_bad_state!(Pips::approve_committee_proposal(root(), id));
-        acp_bad_state(cancelled_proposal());
-        acp_bad_state(rejected_proposal());
-        acp_bad_state(executed_community_proposal(&alice.signer()));
-        acp_bad_state(failed_community_proposal(alice, 1337));
-        acp_bad_state(scheduled_proposal(&alice.signer(), 0));
-    });
-}
-
-#[test]
-fn approve_committee_proposal_no_such_proposal() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_no_pip!(Pips::approve_committee_proposal(root(), 0));
-    });
-}
-
-#[test]
-fn approve_committee_proposal_on_cool_off() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 42));
-        assert_ok!(committee_proposal(0));
-        assert!(Pips::proposal_metadata(0).unwrap().cool_off_until > System::block_number());
-        assert_noop!(
-            Pips::approve_committee_proposal(root(), 0),
-            Error::ProposalOnCoolOffPeriod,
-        );
-    });
-}
-
-#[test]
-fn approve_committee_proposal_not_by_committee() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(alice_proposal(0));
-        fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
-        assert_noop!(
-            Pips::approve_committee_proposal(root(), 0),
-            Error::NotByCommittee,
-        );
-    });
-}
-
-#[test]
-fn only_gc_majority_stuff() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-
-        let alice = User::new(AccountKeyring::Alice);
-        let bob = User::new(AccountKeyring::Bob);
-        let charlie = User::new(AccountKeyring::Charlie);
-        set_members(vec![bob.did, charlie.did]);
-
-        // Make a proposal
-        let id = Pips::pip_id_sequence();
-        assert_eq!(id, 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(alice_proposal(0));
-        // Alice not part of GC and cannot reject.
-        assert_bad_origin!(Pips::reject_proposal(alice.signer(), id));
-        // Bob & Charlie but need to seek consensus.
-        assert_bad_origin!(Pips::reject_proposal(bob.signer(), id));
-        assert_bad_origin!(Pips::reject_proposal(charlie.signer(), id));
-        // Ditto for pruning.
-        assert_bad_origin!(Pips::prune_proposal(alice.signer(), id));
-        // Bob & Charlie but need to seek consensus.
-        assert_bad_origin!(Pips::prune_proposal(bob.signer(), id));
-        assert_bad_origin!(Pips::prune_proposal(charlie.signer(), id));
-        // Ditto for `approve_committee_proposal`.
-        assert_bad_origin!(Pips::approve_committee_proposal(alice.signer(), id));
-        // Bob & Charlie but need to seek consensus.
-        assert_bad_origin!(Pips::approve_committee_proposal(bob.signer(), id));
-        assert_bad_origin!(Pips::approve_committee_proposal(charlie.signer(), id));
-        // Ditto for `enact_snapshot_result`.
-        assert_bad_origin!(Pips::enact_snapshot_results(alice.signer(), vec![]));
-        // Bob & Charlie but need to seek consensus.
-        assert_bad_origin!(Pips::enact_snapshot_results(bob.signer(), vec![]));
-        assert_bad_origin!(Pips::enact_snapshot_results(charlie.signer(), vec![]));
-
-        // Root can reject.
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-        assert_ok!(Pips::reject_proposal(root(), id));
-        assert_eq!(Pips::pip_id_sequence(), 1);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_state(id, false, ProposalState::Rejected);
-        // Root can also prune.
-        assert_ok!(Pips::prune_proposal(root(), id));
-        assert_eq!(Pips::proposals(id), None);
-        // Root can also `approve_committee_proposal`.
-        let id = Pips::pip_id_sequence();
-        assert_ok!(committee_proposal(0));
-        assert_ok!(Pips::approve_committee_proposal(root(), id));
-        assert_ok!(Pips::reject_proposal(root(), id));
-        assert_ok!(Pips::prune_proposal(root(), id));
-        // Root can also `enact_snapshot_results`.
-        let id = Pips::pip_id_sequence();
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(bob.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(id, SnapshotResult::Reject)]
-        ));
-
-        let consensus_call = |call| consensus_call(call, &[&bob.signer(), &charlie.signer()]);
-
-        // Bob & Charlie seek consensus and successfully reject.
-        let id = Pips::pip_id_sequence();
-        assert_ok!(alice_proposal(0));
-        assert_eq!(Pips::pip_id_sequence(), id + 1);
-        assert_eq!(Pips::active_pip_count(), 1);
-        consensus_call(pallet_pips::Call::reject_proposal(id));
-        assert_eq!(Pips::pip_id_sequence(), id + 1);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_state(id, false, ProposalState::Rejected);
-        // And now they seek consensus to and do prune.
-        consensus_call(pallet_pips::Call::prune_proposal(id));
-        assert_eq!(Pips::proposals(id), None);
-
-        // Bob & Charlie seek consensus.
-        // They successfully do `approve_committee_proposal` & `enact_snapshot_results`.
-        let id_committee = Pips::pip_id_sequence();
-        assert_ok!(committee_proposal(0));
-        let id_snapshot = Pips::pip_id_sequence();
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(bob.signer()));
-        consensus_call(pallet_pips::Call::approve_committee_proposal(id_committee));
-        consensus_call(pallet_pips::Call::enact_snapshot_results(vec![(
-            id_snapshot,
-            SnapshotResult::Approve,
-        )]));
-        assert_state(id_committee, false, ProposalState::Scheduled);
-        assert_state(id_snapshot, false, ProposalState::Scheduled);
-    });
-}
-
-#[test]
-fn cannot_reject_no_such_proposal() {
-    ExtBuilder::default().build().execute_with(|| {
-        // Rejecting PIP that doesn't exist errors.
-        assert_eq!(Pips::pip_id_sequence(), 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_no_pip!(Pips::reject_proposal(root(), 0));
-        assert_eq!(Pips::pip_id_sequence(), 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_no_pip!(Pips::prune_proposal(root(), 0));
-        assert_eq!(Pips::pip_id_sequence(), 0);
-        assert_eq!(Pips::active_pip_count(), 0);
-    });
-}
-
-fn cancelled_proposal() -> PipId {
-    let next_id = Pips::pip_id_sequence();
-    assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
-    let active = Pips::active_pip_count();
-    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
-    assert_ok!(Pips::cancel_proposal(alice_signer, next_id));
-    assert_state(next_id, true, ProposalState::Cancelled);
-    assert_eq!(Pips::pip_id_sequence(), next_id + 1);
-    assert_eq!(Pips::active_pip_count(), active - 1);
-    next_id
-}
-
-fn scheduled_proposal(signer: &Origin, deposit: u128) -> PipId {
-    let next_id = Pips::pip_id_sequence();
-    assert_ok!(alice_proposal(deposit));
-    let active = Pips::active_pip_count();
-    fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
-    assert_ok!(Pips::snapshot(signer.clone()));
-    assert_ok!(Pips::enact_snapshot_results(
-        root(),
-        vec![(next_id, SnapshotResult::Approve)]
-    ));
-    assert_state(next_id, false, ProposalState::Scheduled);
-    assert_eq!(Pips::active_pip_count(), active);
-    next_id
-}
-
-fn executed_community_proposal(signer: &Origin) -> PipId {
-    let deposit = Pips::min_proposal_deposit();
-    let next_id = scheduled_proposal(signer, deposit);
-    let active = Pips::active_pip_count();
-    fast_forward_blocks(Pips::default_enactment_period() + 1);
-    assert_ok!(Pips::set_min_proposal_deposit(root(), deposit));
-    assert_state(next_id, true, ProposalState::Executed);
-    assert_eq!(Pips::active_pip_count(), active - 1);
-    next_id
-}
-
-fn failed_community_proposal(user: User, bad_id: PipId) -> PipId {
-    let next_id = Pips::pip_id_sequence();
-    assert_ok!(proposal(
-        &user.signer(),
-        &Proposer::Community(user.acc()),
-        Call::Pips(pallet_pips::Call::reject_proposal(bad_id)),
-        Pips::min_proposal_deposit(),
-        None,
-        None
-    ));
-    let active = Pips::active_pip_count();
-    fast_forward_blocks(Pips::proposal_cool_off_period() + 1);
-    assert_ok!(Pips::snapshot(user.signer()));
-    assert_ok!(Pips::enact_snapshot_results(
-        root(),
-        vec![(next_id, SnapshotResult::Approve)]
-    ));
-    assert_state(next_id, false, ProposalState::Scheduled);
-    assert_eq!(Pips::active_pip_count(), active);
-    fast_forward_blocks(Pips::default_enactment_period() + 1);
-    assert_state(next_id, true, ProposalState::Failed);
-    assert_eq!(Pips::active_pip_count(), active - 1);
-    next_id
-}
-
-fn rejected_proposal() -> PipId {
-    let next_id = Pips::pip_id_sequence();
-    assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
-    let active = Pips::active_pip_count();
-    assert_ok!(Pips::reject_proposal(root(), next_id));
-    assert_state(next_id, true, ProposalState::Rejected);
-    assert_eq!(Pips::active_pip_count(), active - 1);
-    assert_eq!(Pips::pip_id_sequence(), next_id + 1);
-    next_id
-}
-
-#[test]
-fn cannot_reject_incorrect_state() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-        let bob = User::new(AccountKeyring::Bob);
-        set_members(vec![bob.did]);
-
-        let reject_bad_state = |id| assert_bad_state!(Pips::reject_proposal(root(), id));
-        // Cannot reject cancelled, executed, failed, and rejected:
-        let cancelled_id = cancelled_proposal();
-        reject_bad_state(cancelled_id);
-        reject_bad_state(executed_community_proposal(&bob.signer()));
-        reject_bad_state(failed_community_proposal(bob, cancelled_id));
-        reject_bad_state(rejected_proposal());
-    });
-}
-
-fn assert_pruned(id: PipId) {
-    assert_eq!(Pips::proposal_metadata(id), None);
-    assert_eq!(Deposits::iter_prefix_values(id).count(), 0);
-    assert_eq!(Pips::proposals(id), None);
-    assert_vote_details(id, VotingResult::default(), vec![], vec![]);
-    assert_eq!(Pips::pip_to_schedule(id), None);
-    for v in <pallet_pips::ExecutionSchedule<TestStorage>>::iter_values() {
-        assert!(v.iter().all(|x| *x != id));
-    }
-    assert!(Pips::snapshot_queue().iter().all(|p| p.id != id));
-    assert_eq!(Pips::pip_skip_count(id), 0);
-}
-
-#[test]
-fn can_prune_states_that_cannot_be_rejected() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-        let init_bal = 1000;
-        let alice = User::new(AccountKeyring::Alice).balance(init_bal);
-        let bob = User::new(AccountKeyring::Bob);
-        set_members(vec![bob.did]);
-
-        // Can prune cancelled:
-        assert_ok!(alice_proposal(100));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 100);
-        assert_eq!(Pips::pip_id_sequence(), 1);
-        assert_eq!(Pips::active_pip_count(), 1);
-        assert_ok!(Pips::cancel_proposal(alice.signer(), 0));
-        assert_state(0, false, ProposalState::Cancelled);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_eq!(Pips::pip_id_sequence(), 1);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 0));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_pruned(0);
-
-        // Can prune executed:
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_ok!(alice_proposal(200));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 200);
-        assert_eq!(Pips::pip_id_sequence(), 2);
-        assert_eq!(Pips::active_pip_count(), 1);
-        assert_ok!(Pips::snapshot(bob.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(1, SnapshotResult::Approve)]
-        ));
-        assert_state(1, false, ProposalState::Scheduled);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 200);
-        assert_eq!(Pips::active_pip_count(), 1);
-        fast_forward_blocks(Pips::default_enactment_period() + 1);
-        assert_state(1, false, ProposalState::Executed);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 1));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_pruned(1);
-
-        // Can prune failed:
-        assert_ok!(proposal(
-            &alice.signer(),
-            &Proposer::Community(alice.acc()),
-            Call::Pips(pallet_pips::Call::reject_proposal(1337)),
-            300,
             None,
-            None
-        ));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 300);
-        assert_eq!(Pips::pip_id_sequence(), 3);
-        assert_eq!(Pips::active_pip_count(), 1);
-        assert_ok!(Pips::snapshot(bob.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(2, SnapshotResult::Approve)]
-        ));
-        assert_state(2, false, ProposalState::Scheduled);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 300);
-        assert_eq!(Pips::active_pip_count(), 1);
-        fast_forward_blocks(Pips::default_enactment_period() + 1);
-        assert_state(2, false, ProposalState::Failed);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 2));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_pruned(2);
+        ),
+        Error::<TestStorage>::IncorrectDeposit
+    );
 
-        // Can prune rejected:
-        assert_ok!(alice_proposal(400));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 400);
-        assert_eq!(Pips::pip_id_sequence(), 4);
-        assert_eq!(Pips::active_pip_count(), 1);
-        assert_ok!(Pips::reject_proposal(root(), 3));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_state(3, false, ProposalState::Rejected);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_ok!(Pips::prune_proposal(root(), 3));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_pruned(4);
-    });
-}
+    // Account 6 starts a proposal with min deposit
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal),
+        60,
+        Some(proposal_url),
+        Some(proposal_desc),
+        None,
+    ));
 
-#[test]
-fn cannot_prune_active() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
+    assert_eq!(Balances::free_balance(&alice_acc), 158);
 
-        let init_bal = 300;
-        let alice = User::new(AccountKeyring::Alice).balance(init_bal);
-        set_members(vec![alice.did]);
-
-        // Alice starts a proposal with some deposit.
-        assert_ok!(alice_proposal(50));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 50);
-        // Now remove that PIP and check that funds are back.
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-        assert_state(0, false, ProposalState::Pending);
-        assert_bad_state!(Pips::prune_proposal(root(), 0));
-        assert_eq!(Pips::pip_id_sequence(), 1);
-        assert_eq!(Pips::active_pip_count(), 1);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 50);
-
-        // Alice starts a proposal with some deposit.
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(alice_proposal(60));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 50 - 60);
-        // Schedule the PIP.
-        assert_ok!(Pips::snapshot(alice.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(1, SnapshotResult::Approve)]
-        ));
-        assert_state(1, false, ProposalState::Scheduled);
-        // Now remove that PIP and check that funds are back.
-        assert_bad_state!(Pips::prune_proposal(root(), 1));
-        assert_eq!(Pips::pip_id_sequence(), 2);
-        assert_eq!(Pips::active_pip_count(), 2);
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 50 - 60);
-    });
-}
-
-#[test]
-fn reject_proposal_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-
-        let init_bal = 300;
-        let alice = User::new(AccountKeyring::Alice).balance(init_bal);
-        set_members(vec![alice.did]);
-
-        // Alice starts a proposal with some deposit.
-        assert_ok!(alice_proposal(50));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 50);
-        let result = VotingResult {
-            ayes_count: 1,
-            ayes_stake: 50,
-            nays_count: 0,
-            nays_stake: 0,
-        };
-        assert_eq!(Pips::proposal_result(0), result);
-
-        // Now remove that PIP and check that funds are back.
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-        assert_state(0, false, ProposalState::Pending);
-        assert_ok!(Pips::reject_proposal(root(), 0));
-        assert_eq!(Pips::pip_id_sequence(), 1);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_eq!(
-            Pips::proposals(0).unwrap(),
-            Pip {
-                id: 0,
-                proposal: make_proposal(42),
-                state: ProposalState::Rejected,
-            }
-        );
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_eq!(Deposits::iter_prefix_values(0).count(), 0);
-        // We keep this info for posterity.
-        assert_eq!(Votes::iter_prefix_values(0).count(), 1);
-        assert_eq!(Pips::proposal_result(0), result);
-
-        // Alice starts a proposal with some deposit.
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(alice_proposal(60));
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal - 60);
-        let result = VotingResult {
+    assert_eq!(Pips::proposed_by(alice_acc.clone()), vec![0]);
+    assert_eq!(
+        Pips::proposal_result(0),
+        VotingResult {
             ayes_count: 1,
             ayes_stake: 60,
             nays_count: 0,
             nays_stake: 0,
-        };
-        assert_eq!(Pips::proposal_result(1), result);
-
-        // Schedule the PIP.
-        assert_ok!(Pips::snapshot(alice.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(1, SnapshotResult::Approve)]
-        ));
-        assert_state(1, false, ProposalState::Scheduled);
-
-        // Now remove that PIP and check that funds are back.
-        assert_ok!(Pips::reject_proposal(root(), 1));
-        assert_eq!(Pips::pip_id_sequence(), 2);
-        assert_eq!(Pips::active_pip_count(), 0);
-        assert_eq!(
-            Pips::proposals(1).unwrap(),
-            Pip {
-                id: 1,
-                proposal: make_proposal(42),
-                state: ProposalState::Rejected,
-            }
-        );
-        assert_eq!(Balances::free_balance(&alice.acc()), init_bal);
-        assert_eq!(Deposits::iter_prefix_values(1).count(), 0);
-        // We keep this info for posterity.
-        assert_eq!(Votes::iter_prefix_values(1).count(), 1);
-        assert_eq!(Pips::proposal_result(1), result);
-    });
-}
-
-#[test]
-fn reject_proposal_will_unsnapshot() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-        set_members(vec![alice.did]);
-
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(alice.signer()));
-        assert_eq!(Pips::snapshot_queue()[0].id, 0);
-        assert_ok!(Pips::reject_proposal(root(), 0));
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-    });
-}
-
-#[test]
-fn reject_proposal_will_unschedule() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-
-        let alice = User::new(AccountKeyring::Alice).balance(300);
-        set_members(vec![alice.did]);
-
-        let check = |id: PipId| {
-            let scheduled_at = Pips::pip_to_schedule(id).unwrap();
-            assert_eq!(Pips::execution_schedule(scheduled_at), vec![id]);
-            assert_ok!(Pips::reject_proposal(root(), id));
-            assert_eq!(Pips::pip_to_schedule(id), None);
-            assert_eq!(Pips::execution_schedule(scheduled_at), Vec::<PipId>::new());
-        };
-
-        // Test snapshot method.
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(alice.signer()));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(0, SnapshotResult::Approve)]
-        ));
-        check(0);
-
-        // Test committee method.
-        assert_ok!(committee_proposal(0));
-        assert_ok!(Pips::approve_committee_proposal(root(), 1));
-        check(1);
-    });
-}
-
-#[test]
-fn reschedule_execution_only_release_coordinator() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        let alice = User::new(AccountKeyring::Alice);
-        let bob = User::new(AccountKeyring::Bob);
-        let charlie = User::new(AccountKeyring::Charlie);
-        set_members(vec![alice.did, bob.did, charlie.did]);
-        assert_ok!(Committee::set_release_coordinator(root(), charlie.did));
-
-        assert_bad_origin!(Pips::reschedule_execution(root(), 0, None));
-        assert_bad_origin!(Pips::reschedule_execution(alice.signer(), 0, None));
-        assert_bad_origin!(Pips::reschedule_execution(bob.signer(), 0, None));
-
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let id = scheduled_proposal(&alice.signer(), 0);
-        let scheduled_at = Pips::pip_to_schedule(id);
-        consensus_call(
-            pallet_pips::Call::reschedule_execution(0, None),
-            &[&alice.signer(), &bob.signer(), &charlie.signer()],
-        );
-        assert_eq!(scheduled_at, Pips::pip_to_schedule(id));
-        assert_ok!(Pips::reschedule_execution(charlie.signer(), id, None));
-        assert_ne!(scheduled_at, Pips::pip_to_schedule(id));
-    });
-}
-
-fn init_rc() -> Origin {
-    let user = User::new(AccountKeyring::Alice);
-    set_members(vec![user.did]);
-    assert_ok!(Committee::set_release_coordinator(root(), user.did));
-    user.signer()
-}
-
-#[test]
-fn reschedule_execution_no_such_proposal() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let signer = init_rc();
-        assert_no_pip!(Pips::reschedule_execution(signer, 0, None));
-    });
-}
-
-#[test]
-fn reschedule_execution_not_scheduled() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let rc = init_rc();
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let id = Pips::pip_id_sequence();
-        assert_ok!(alice_proposal(0));
-        assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-        assert_ok!(Pips::reject_proposal(root(), id));
-        assert_ok!(Pips::prune_proposal(root(), id));
-        let id = cancelled_proposal();
-        assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-        let id = rejected_proposal();
-        assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-        let id = executed_community_proposal(&rc);
-        assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-        let id = failed_community_proposal(User::existing(AccountKeyring::Alice), 1337);
-        assert_bad_state!(Pips::reschedule_execution(rc.clone(), id, None));
-    });
-}
-
-#[test]
-fn reschedule_execution_in_the_past() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let rc = init_rc();
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let id = scheduled_proposal(&rc, 0);
-        let next = System::block_number() + 1;
-        assert_noop!(
-            Pips::reschedule_execution(rc.clone(), id, Some(next - 1)),
-            Error::InvalidFutureBlockNumber
-        );
-        assert_noop!(
-            Pips::reschedule_execution(rc, id, Some(next - 2)),
-            Error::InvalidFutureBlockNumber
-        );
-    });
-}
-
-#[test]
-fn reschedule_execution_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let rc = init_rc();
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let id = scheduled_proposal(&rc, 0);
-        let scheduled_at = Pips::pip_to_schedule(id).unwrap();
-        assert!(Pips::execution_schedule(scheduled_at).contains(&id));
-
-        let next = System::block_number() + 1;
-        assert_ok!(Pips::reschedule_execution(rc.clone(), id, None));
-        assert_eq!(Pips::pip_to_schedule(id).unwrap(), next);
-        assert!(!Pips::execution_schedule(scheduled_at).contains(&id));
-        assert!(Pips::execution_schedule(next).contains(&id));
-
-        assert_ok!(Pips::reschedule_execution(rc.clone(), id, Some(next + 50)));
-        assert_eq!(Pips::pip_to_schedule(id).unwrap(), next + 50);
-        assert!(!Pips::execution_schedule(scheduled_at).contains(&id));
-        assert!(!Pips::execution_schedule(next).contains(&id));
-        assert!(Pips::execution_schedule(next + 50).contains(&id));
-    });
-}
-
-#[test]
-fn clear_snapshot_not_gc_member() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        init_rc();
-        assert_bad_origin!(Pips::clear_snapshot(root()));
-        let bob = User::new(AccountKeyring::Bob);
-        assert_noop!(
-            Pips::clear_snapshot(bob.signer()),
-            Error::NotACommitteeMember,
-        );
-    });
-}
-
-#[test]
-fn clear_snapshot_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
-        let rc = init_rc();
-        // No snapshot, but we can still clear.
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-        assert_eq!(Pips::snapshot_metadata(), None);
-        assert_ok!(Pips::clear_snapshot(rc.clone()));
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-        assert_eq!(Pips::snapshot_metadata(), None);
-
-        // Make a snapshot with something and clear it.
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(alice_proposal(100));
-        assert_ok!(alice_proposal(200));
-        assert_ok!(alice_proposal(400));
-        assert_ok!(Pips::snapshot(rc.clone()));
-        assert_ne!(Pips::snapshot_queue(), vec![]);
-        assert_ne!(Pips::snapshot_metadata(), None);
-        assert_ok!(Pips::clear_snapshot(rc));
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-        assert_eq!(Pips::snapshot_metadata(), None);
-    });
-}
-
-#[test]
-fn snapshot_not_gc_member() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        init_rc();
-        assert_bad_origin!(Pips::snapshot(root()));
-        let bob = User::new(AccountKeyring::Bob);
-        assert_noop!(Pips::snapshot(bob.signer()), Error::NotACommitteeMember);
-    });
-}
-
-#[test]
-fn snapshot_only_pending_hot_community() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-        let rc = init_rc();
-
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        let c = cancelled_proposal();
-        let r = rejected_proposal();
-        let e = executed_community_proposal(&rc);
-        let f = failed_community_proposal(User::existing(AccountKeyring::Alice), 1337);
-        let s = scheduled_proposal(&rc, 0);
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 100));
-        assert_ok!(alice_proposal(0));
-        let p = Pips::pip_id_sequence() - 1;
-        for id in &[c, r, e, f, s, p] {
-            assert!(matches!(
-                Pips::proposal_metadata(*id).unwrap().proposer,
-                Proposer::Community(_)
-            ));
         }
-        assert_ok!(committee_proposal(0));
-
-        assert_ok!(Pips::snapshot(rc));
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-        assert_ne!(Pips::snapshot_metadata(), None);
-    });
+    );
 }
 
 #[test]
-fn snapshot_works() {
-    ExtBuilder::default().monied(true).build().execute_with(|| {
-        System::set_block_number(1);
+fn closing_a_proposal_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(closing_a_proposal_works_we);
+}
 
-        let user = User::new(AccountKeyring::Bob);
-        set_members(vec![user.did]);
+fn closing_a_proposal_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let index = 0;
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
 
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
-        assert_ok!(Pips::set_active_pip_limit(root(), 0));
+    // Voting majority
+    let root = Origin::from(frame_system::RawOrigin::Root);
 
-        assert_ok!(alice_proposal(0)); // 0
-        assert_ok!(Pips::vote(user.signer(), 0, true, 100));
+    TestStorage::set_payer_context(Some(AccountKeyring::Alice.public()));
+    let alice_acc = AccountKeyring::Alice.public();
+    let alice_signer = Origin::signed(alice_acc.clone());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Alice, 300).unwrap();
 
-        assert_ok!(alice_proposal(0)); // 1
-        assert_ok!(Pips::vote(user.signer(), 1, false, 100));
+    // Alice starts a proposal with min deposit
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        Some(proposal_url.clone()),
+        Some(proposal_desc),
+        None
+    ));
 
-        assert_ok!(alice_proposal(0)); // 2
-        assert_ok!(alice_proposal(0)); // 3
+    assert_eq!(Balances::free_balance(&alice_acc), 168);
+    assert_eq!(
+        Pips::proposal_result(0),
+        VotingResult {
+            ayes_count: 1,
+            ayes_stake: 50,
+            nays_count: 0,
+            nays_stake: 0,
+        }
+    );
 
-        assert_ok!(alice_proposal(50)); // 4
-        assert_ok!(Pips::vote(user.signer(), 4, true, 100));
-
-        assert_ok!(alice_proposal(50)); // 5
-        assert_ok!(Pips::vote(user.signer(), 5, false, 100));
-
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_eq!(
-            Pips::snapshot_queue(),
-            vec![
-                SnapshottedPip {
-                    id: 1,
-                    weight: (false, 100)
-                },
-                SnapshottedPip {
-                    id: 5,
-                    weight: (false, 50)
-                },
-                SnapshottedPip {
-                    id: 3,
-                    weight: (true, 0)
-                },
-                SnapshottedPip {
-                    id: 2,
-                    weight: (true, 0)
-                },
-                SnapshottedPip {
-                    id: 0,
-                    weight: (true, 100)
-                },
-                SnapshottedPip {
-                    id: 4,
-                    weight: (true, 150)
-                },
-            ]
-        );
-        assert_eq!(
-            Pips::snapshot_metadata(),
-            Some(SnapshotMetadata {
-                created_at: 1,
-                made_by: user.acc(),
-            })
-        );
-    });
+    assert_ok!(Pips::kill_proposal(root, index));
+    assert_eq!(Balances::free_balance(&alice_acc), 218);
 }
 
 #[test]
-fn enact_snapshot_results_input_too_large() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
+fn creating_a_referendum_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(creating_a_referendum_works_we);
+}
 
-        let user = User::new(AccountKeyring::Bob);
-        set_members(vec![user.did]);
+fn creating_a_referendum_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
 
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
+    let alice_acc = AccountKeyring::Alice.public();
+    TestStorage::set_payer_context(Some(alice_acc.clone()));
+    let alice_signer = Origin::signed(alice_acc.clone());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Alice, 300).unwrap();
+    let bob_acc = AccountKeyring::Bob.public();
+    TestStorage::set_payer_context(Some(bob_acc));
+    let bob_signer = Origin::signed(bob_acc.clone());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Bob, 200);
+    // Voting majority
+    let root = Origin::from(frame_system::RawOrigin::Root);
 
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_noop!(
-            Pips::enact_snapshot_results(root(), vec![(0, SnapshotResult::Skip)]),
-            Error::SnapshotResultTooLarge,
-        );
-        assert_noop!(
-            Pips::enact_snapshot_results(
-                root(),
-                vec![(0, SnapshotResult::Reject), (1, SnapshotResult::Approve)]
-            ),
-            Error::SnapshotResultTooLarge,
-        );
-        assert_ok!(alice_proposal(0));
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_noop!(
-            Pips::enact_snapshot_results(
-                root(),
-                vec![
-                    (0, SnapshotResult::Reject),
-                    (1, SnapshotResult::Approve),
-                    (2, SnapshotResult::Skip)
-                ]
-            ),
-            Error::SnapshotResultTooLarge,
-        );
-    });
+    TestStorage::set_payer_context(Some(alice_acc));
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        Some(proposal_url),
+        Some(proposal_desc),
+        None
+    ));
+
+    // Cannot prune proposal at this stage
+    assert_err!(
+        Pips::prune_proposal(root.clone(), 0),
+        Error::<TestStorage>::IncorrectProposalState
+    );
+
+    assert_err!(
+        Pips::vote(bob_signer.clone(), 0, true, 50),
+        Error::<TestStorage>::ProposalOnCoolOffPeriod
+    );
+    fast_forward_to(101);
+    TestStorage::set_payer_context(Some(bob_acc));
+    assert_ok!(Pips::vote(bob_signer.clone(), 0, true, 50));
+
+    // Cannot prune proposal at this stage
+    assert_err!(
+        Pips::prune_proposal(root.clone(), 0),
+        Error::<TestStorage>::IncorrectProposalState
+    );
+
+    assert_eq!(
+        Pips::proposal_result(0),
+        VotingResult {
+            ayes_count: 2,
+            ayes_stake: 100,
+            nays_count: 0,
+            nays_stake: 0,
+        }
+    );
+
+    assert_eq!(Balances::free_balance(&alice_acc), 168);
+    assert_eq!(Balances::free_balance(&bob_acc), 109);
+
+    fast_forward_to(120);
+
+    // Cannot prune referendum at this stage
+    assert_err!(
+        Pips::prune_proposal(root.clone(), 0),
+        Error::<TestStorage>::IncorrectReferendumState
+    );
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Pending,
+            referendum_type: ReferendumType::Community,
+            enactment_period: 0,
+        })
+    );
+
+    assert_eq!(Balances::free_balance(&alice_acc), 218);
+    assert_eq!(Balances::free_balance(&bob_acc), 159);
 }
 
 #[test]
-fn enact_snapshot_results_id_mismatch() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
+fn enacting_a_referendum_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(enacting_a_referendum_works_we);
+}
 
-        let user = User::new(AccountKeyring::Bob);
-        set_members(vec![user.did]);
+fn enacting_a_referendum_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
 
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Alice, 300).unwrap();
+    let bob_signer = Origin::signed(AccountKeyring::Bob.public());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Bob, 100).unwrap();
 
-        assert_ok!(alice_proposal(0));
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_noop!(
-            Pips::enact_snapshot_results(root(), vec![(1, SnapshotResult::Skip)]),
-            Error::SnapshotIdMismatch,
-        );
-        assert_noop!(
-            Pips::enact_snapshot_results(
-                root(),
-                vec![(0, SnapshotResult::Reject), (2, SnapshotResult::Approve)]
-            ),
-            Error::SnapshotIdMismatch,
-        );
-    });
+    // Voting majority
+    let root = Origin::from(frame_system::RawOrigin::Root);
+
+    assert_ok!(Pips::propose(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        Some(proposal_url.clone()),
+        Some(proposal_desc),
+        None
+    ));
+
+    assert_err!(
+        Pips::vote(bob_signer.clone(), 0, true, 50),
+        Error::<TestStorage>::ProposalOnCoolOffPeriod
+    );
+    fast_forward_to(101);
+
+    assert_ok!(Pips::vote(bob_signer.clone(), 0, true, 50));
+
+    assert_eq!(
+        Pips::proposal_result(0),
+        VotingResult {
+            ayes_count: 2,
+            ayes_stake: 100,
+            nays_count: 0,
+            nays_stake: 0,
+        }
+    );
+
+    fast_forward_to(120);
+
+    // Cannot prune referendum at this stage
+    assert_err!(
+        Pips::prune_proposal(root.clone(), 0),
+        Error::<TestStorage>::IncorrectReferendumState
+    );
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Pending,
+            referendum_type: ReferendumType::Community,
+            enactment_period: 0,
+        })
+    );
+
+    assert_err!(
+        Pips::enact_referendum(bob_signer.clone(), 0),
+        DispatchError::BadOrigin
+    );
+    assert_ok!(Pips::enact_referendum(root.clone(), 0));
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::Community,
+            enactment_period: 220,
+        })
+    );
+
+    // Cannot prune referendum at this stage
+    assert_err!(
+        Pips::prune_proposal(root.clone(), 0),
+        Error::<TestStorage>::IncorrectReferendumState
+    );
+
+    fast_forward_to(221);
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Executed,
+            referendum_type: ReferendumType::Community,
+            enactment_period: 220,
+        })
+    );
+
+    // Can now prune referendum
+    assert_ok!(Pips::prune_proposal(root.clone(), 0));
+
+    assert_eq!(Pips::referendums(0), None);
+    assert_eq!(Pips::proposals(0), None);
+    assert_eq!(Pips::proposal_metadata(0), None);
 }
 
 #[test]
-fn enact_snapshot_results_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
+fn fast_tracking_a_proposal_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(fast_tracking_a_proposal_works_we);
+}
 
-        let user = User::new(AccountKeyring::Bob);
-        set_members(vec![user.did]);
+fn fast_tracking_a_proposal_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let index = 0;
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
 
-        assert_ok!(Pips::set_prune_historical_pips(root(), false));
-        assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
-        assert_ok!(Pips::set_proposal_cool_off_period(root(), 0));
+    let root = Origin::from(frame_system::RawOrigin::Root);
 
-        let mk_queue = |ids: &[PipId]| {
-            ids.iter()
-                .map(|&id| SnapshottedPip {
-                    id,
-                    weight: (true, 0),
-                })
-                .collect::<Vec<_>>()
-        };
+    // Alice and Bob are committee members
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account_with_balance(AccountKeyring::Alice, 100).unwrap();
+    let bob_signer = Origin::signed(AccountKeyring::Bob.public());
+    let bob_did = register_keyring_account_with_balance(AccountKeyring::Bob, 100).unwrap();
 
-        // Make 3 PIPs, snapshot, and enact results for all, emptying the queue.
-        assert_ok!(alice_proposal(0));
-        assert_ok!(alice_proposal(0));
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_eq!(Pips::snapshot_queue(), mk_queue(&[2, 1, 0]));
-        assert_eq!(Pips::pip_skip_count(1), 0);
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![
-                (0, SnapshotResult::Reject),
-                (1, SnapshotResult::Skip),
-                (2, SnapshotResult::Approve)
-            ],
-        ));
-        assert_state(0, false, ProposalState::Rejected);
-        assert_state(1, false, ProposalState::Pending);
-        assert_eq!(Pips::pip_skip_count(1), 1);
-        assert_state(2, false, ProposalState::Scheduled);
-        assert_eq!(Pips::snapshot_queue(), vec![]);
-        assert_ne!(Pips::snapshot_metadata(), None);
+    let charlie_signer = Origin::signed(AccountKeyring::Charlie.public());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Charlie, 300).unwrap();
 
-        // Add another proposal; we previously skipped one, so queue size is 2.
-        // Only enact for 1 proposal, leaving the last added PIP in the queue.
-        assert_ok!(alice_proposal(0));
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_eq!(Pips::snapshot_queue(), mk_queue(&[3, 1]));
-        assert_ok!(Pips::enact_snapshot_results(
-            root(),
-            vec![(1, SnapshotResult::Approve)]
-        ));
-        assert_state(1, false, ProposalState::Scheduled);
-        assert_eq!(Pips::snapshot_queue(), mk_queue(&[3]));
+    Group::reset_members(root.clone(), vec![alice_did, bob_did]).unwrap();
 
-        // Cleared queue + enacting zero-length results => noop.
-        assert_ok!(Pips::clear_snapshot(user.signer()));
-        assert_ok!(Pips::enact_snapshot_results(root(), vec![]));
-        assert_last_event!(
-            Event::SnapshotResultsEnacted(_, a, b, c),
-            a.is_empty() && b.is_empty() && c.is_empty()
-        )
-    });
+    assert_eq!(Committee::members(), vec![bob_did, alice_did]);
+
+    assert_ok!(Pips::propose(
+        charlie_signer.clone(),
+        Box::new(proposal.clone()),
+        50,
+        Some(proposal_url.clone()),
+        Some(proposal_desc),
+        None
+    ));
+
+    assert_err!(
+        Pips::vote(bob_signer.clone(), index, true, 50),
+        Error::<TestStorage>::ProposalOnCoolOffPeriod
+    );
+
+    // only a committee member can fast track a proposal
+    assert_err!(
+        Pips::fast_track_proposal(charlie_signer.clone(), index),
+        Error::<TestStorage>::NotACommitteeMember
+    );
+
+    // Alice can fast track because she is a GC member
+    assert_ok!(Pips::fast_track_proposal(alice_signer.clone(), index));
+    assert_err!(
+        Pips::enact_referendum(bob_signer.clone(), 0),
+        DispatchError::BadOrigin
+    );
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Pending,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 0,
+        })
+    );
+
+    assert_ok!(Pips::enact_referendum(root, 0));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 101,
+        })
+    );
+
+    // It executes automatically the referendum at block 101.
+    fast_forward_to(120);
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Executed,
+            referendum_type: ReferendumType::FastTracked,
+            enactment_period: 101,
+        })
+    );
+}
+
+#[test]
+
+fn emergency_referendum_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(emergency_referendum_works_we);
+}
+
+fn emergency_referendum_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let root = Origin::from(frame_system::RawOrigin::Root);
+
+    // Alice and Bob are committee members
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account_with_balance(AccountKeyring::Alice, 60).unwrap();
+
+    Group::reset_members(root.clone(), vec![alice_did]).unwrap();
+
+    assert_eq!(Committee::members(), vec![alice_did]);
+
+    // Alice is a committee member
+
+    assert_ok!(Pips::emergency_referendum(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        Some(proposal_url.clone()),
+        Some(proposal_desc),
+        None,
+    ));
+
+    fast_forward_to(20);
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Pending,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 0,
+        })
+    );
+
+    assert_err!(
+        Pips::enact_referendum(alice_signer.clone(), 0),
+        DispatchError::BadOrigin
+    );
+
+    fast_forward_to(101);
+    assert_ok!(Pips::enact_referendum(root, 0));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 201,
+        })
+    );
+
+    fast_forward_to(202);
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Executed,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 201,
+        })
+    );
+}
+
+#[test]
+fn reject_referendum_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(reject_referendum_works_we);
+}
+
+fn reject_referendum_works_we() {
+    System::set_block_number(1);
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let root = Origin::from(frame_system::RawOrigin::Root);
+
+    // Alice and Bob are committee members
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let alice_did = register_keyring_account_with_balance(AccountKeyring::Alice, 60).unwrap();
+
+    Group::reset_members(root.clone(), vec![alice_did]).unwrap();
+
+    assert_eq!(Committee::members(), vec![alice_did]);
+
+    // Alice is a committee member
+    assert_ok!(Pips::emergency_referendum(
+        alice_signer.clone(),
+        Box::new(proposal.clone()),
+        Some(proposal_url.clone()),
+        Some(proposal_desc),
+        None,
+    ));
+
+    fast_forward_to(20);
+
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Pending,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 0,
+        })
+    );
+
+    assert_err!(
+        Pips::enact_referendum(alice_signer.clone(), 0),
+        DispatchError::BadOrigin
+    );
+
+    fast_forward_to(101);
+    assert_ok!(Pips::reject_referendum(root, 0));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Rejected,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 0,
+        })
+    );
+}
+
+#[test]
+fn updating_pips_variables_works() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(updating_pips_variables_works_we);
+}
+
+fn updating_pips_variables_works_we() {
+    let root = Origin::from(frame_system::RawOrigin::Root);
+
+    let alice_signer = Origin::signed(AccountKeyring::Alice.public());
+    let _ = register_keyring_account_with_balance(AccountKeyring::Alice, 60).unwrap();
+    // config variables can be updated only through committee
+    assert_eq!(Pips::min_proposal_deposit(), 50);
+    assert_err!(
+        Pips::set_min_proposal_deposit(alice_signer.clone(), 10),
+        DispatchError::BadOrigin
+    );
+    assert_ok!(Pips::set_min_proposal_deposit(root.clone(), 10));
+    assert_eq!(Pips::min_proposal_deposit(), 10);
+
+    assert_eq!(Pips::quorum_threshold(), 70);
+    assert_ok!(Pips::set_quorum_threshold(root.clone(), 100));
+    assert_eq!(Pips::quorum_threshold(), 100);
+
+    assert_eq!(Pips::proposal_duration(), 10);
+    assert_ok!(Pips::set_proposal_duration(root.clone(), 100));
+    assert_eq!(Pips::proposal_duration(), 100);
+
+    assert_eq!(Pips::proposal_cool_off_period(), 100);
+    assert_ok!(Pips::set_proposal_cool_off_period(root.clone(), 10));
+    assert_eq!(Pips::proposal_cool_off_period(), 10);
+
+    assert_eq!(Pips::default_enactment_period(), 100);
+    assert_ok!(Pips::set_default_enactment_period(root.clone(), 10));
+    assert_eq!(Pips::default_enactment_period(), 10);
+}
+
+#[test]
+fn amend_pips_details_during_cool_off_period() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(amend_pips_details_during_cool_off_period_we);
+}
+
+fn amend_pips_details_during_cool_off_period_we() {
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let alice_acc = AccountKeyring::Alice.public();
+    let alice = Origin::signed(alice_acc.clone());
+    let _ = register_keyring_account(AccountKeyring::Alice).unwrap();
+    let bob = Origin::signed(AccountKeyring::Bob.public());
+    let _ = register_keyring_account(AccountKeyring::Bob).unwrap();
+    print!(
+        "Block no - {:?}",
+        <frame_system::Module<TestStorage>>::block_number()
+    );
+    // 1. Create Pips proposal
+    assert_ok!(Pips::propose(
+        alice.clone(),
+        Box::new(proposal),
+        60,
+        Some(proposal_url),
+        Some(proposal_desc),
+        None
+    ));
+    fast_forward_to(50);
+
+    // 2. Amend proposal during cool-off.
+    let new_url: Url = b"www.xyz.com".into();
+    let new_desc: PipDescription = b"New description".into();
+    assert_ok!(Pips::amend_proposal(
+        alice.clone(),
+        0,
+        Some(new_url.clone()),
+        Some(new_desc.clone())
+    ));
+
+    assert_err!(
+        Pips::amend_proposal(bob.clone(), 0, None, None),
+        Error::<TestStorage>::BadOrigin
+    );
+
+    assert_eq!(
+        Pips::proposal_metadata(0),
+        Some(PipsMetadata {
+            proposer: alice_acc.clone(),
+            id: 0,
+            cool_off_until: 100,
+            end: 110,
+            url: Some(new_url),
+            description: Some(new_desc),
+        })
+    );
+
+    // 3. Bound/Unbound additional POLYX.
+    assert_eq!(
+        Pips::deposits(0, &alice_acc),
+        DepositInfo {
+            owner: alice_acc.clone(),
+            amount: 60
+        }
+    );
+    assert_ok!(Pips::bond_additional_deposit(alice.clone(), 0, 100));
+    assert_eq!(
+        Pips::deposits(0, &alice_acc),
+        DepositInfo {
+            owner: alice_acc.clone(),
+            amount: 160
+        }
+    );
+    assert_ok!(Pips::unbond_deposit(alice.clone(), 0, 50));
+    assert_eq!(
+        Pips::deposits(0, &alice_acc),
+        DepositInfo {
+            owner: alice_acc.clone(),
+            amount: 110
+        }
+    );
+    assert_err!(
+        Pips::unbond_deposit(alice.clone(), 0, 90),
+        Error::<TestStorage>::IncorrectDeposit
+    );
+
+    // 4. Move out the cool-off period and ensure Pips is inmutable.
+    fast_forward_to(103);
+    assert_err!(
+        Pips::amend_proposal(alice.clone(), 0, None, None),
+        Error::<TestStorage>::ProposalIsImmutable
+    );
+}
+
+#[test]
+fn cancel_pips_during_cool_off_period() {
+    ExtBuilder::default()
+        .build()
+        .execute_with(cancel_pips_during_cool_off_period_we);
+}
+
+fn cancel_pips_during_cool_off_period_we() {
+    let alice_proposal = make_proposal(42);
+    let bob_proposal = make_proposal(1);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let alice = Origin::signed(AccountKeyring::Alice.public());
+    let _ = register_keyring_account(AccountKeyring::Alice).unwrap();
+    let bob = Origin::signed(AccountKeyring::Bob.public());
+    let _ = register_keyring_account(AccountKeyring::Bob).unwrap();
+    let root = Origin::from(frame_system::RawOrigin::Root);
+
+    // 1. Create Pips proposals
+    assert_ok!(Pips::propose(
+        alice.clone(),
+        Box::new(alice_proposal),
+        60,
+        Some(proposal_url),
+        Some(proposal_desc),
+        None
+    ));
+
+    assert_ok!(Pips::propose(
+        bob.clone(),
+        Box::new(bob_proposal.clone()),
+        60,
+        None,
+        None,
+        None
+    ));
+
+    // 2. Cancel Alice's proposal during cool-off period.
+    fast_forward_to(50);
+    assert_ok!(Pips::cancel_proposal(alice.clone(), 0));
+
+    // Can prune cancelled proposals
+    assert_ok!(Pips::prune_proposal(root.clone(), 0));
+
+    // Check proposal is pruned from storage
+    assert_eq!(Pips::referendums(0), None);
+    assert_eq!(Pips::proposals(0), None);
+    assert_eq!(Pips::proposal_metadata(0), None);
+
+    // 3. Try to cancel Bob's proposal after cool-off period.
+    fast_forward_to(101);
+    assert_err!(
+        Pips::cancel_proposal(bob.clone(), 1),
+        Error::<TestStorage>::ProposalIsImmutable
+    );
+
+    // 4. Double check current proposals
+    assert_eq!(
+        Pips::proposal_metadata(1),
+        Some(PipsMetadata {
+            proposer: AccountKeyring::Bob.public(),
+            id: 1,
+            cool_off_until: 100,
+            end: 110,
+            url: None,
+            description: None,
+        })
+    );
+}
+
+#[test]
+fn update_referendum_enactment_period() {
+    let committee = [AccountKeyring::Alice.public(), AccountKeyring::Bob.public()].to_vec();
+    ExtBuilder::default()
+        .governance_committee(committee)
+        .governance_committee_vote_threshold((2, 3))
+        .build()
+        .execute_with(update_referendum_enactment_period_we);
+}
+
+fn update_referendum_enactment_period_we() {
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    let alice = Origin::signed(AccountKeyring::Alice.public());
+    let bob = Origin::signed(AccountKeyring::Bob.public());
+
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+
+    let proposal_a = make_proposal(42);
+    let proposal_b = make_proposal(107);
+
+    // Bob is the release coordinator.
+    let bob_id = get_identity_id(AccountKeyring::Bob).expect("Bob is part of the committee");
+    assert_ok!(Committee::set_release_coordinator(root.clone(), bob_id));
+
+    // Alice submit 2 referendums in different moments.
+
+    assert_ok!(Pips::emergency_referendum(
+        alice.clone(),
+        Box::new(proposal_a.clone()),
+        None,
+        None,
+        None,
+    ));
+    assert_ok!(Pips::enact_referendum(root.clone(), 0));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 100,
+        })
+    );
+
+    fast_forward_to(50);
+
+    assert_ok!(Pips::emergency_referendum(
+        alice.clone(),
+        Box::new(proposal_b.clone()),
+        Some(proposal_url),
+        Some(proposal_desc),
+        None,
+    ));
+    assert_ok!(Pips::enact_referendum(root.clone(), 1));
+    assert_eq!(
+        Pips::referendums(1),
+        Some(Referendum {
+            id: 1,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 150,
+        })
+    );
+
+    // Alice cannot update the enact period.
+    assert_err!(
+        Pips::override_referendum_enactment_period(alice.clone(), 0, Some(200)),
+        Error::<TestStorage>::BadOrigin
+    );
+
+    // Bob updates referendum to execute `b` now(next block), and `a` in the future.
+    assert_ok!(Pips::override_referendum_enactment_period(
+        bob.clone(),
+        1,
+        None
+    ));
+    fast_forward_to(52);
+    assert_eq!(
+        Pips::referendums(1),
+        Some(Referendum {
+            id: 1,
+            state: ReferendumState::Executed,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 51,
+        })
+    );
+
+    assert_ok!(Pips::override_referendum_enactment_period(
+        bob.clone(),
+        0,
+        Some(200)
+    ));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Scheduled,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 200,
+        })
+    );
+
+    // Bob cannot update if referendum is already executed.
+    fast_forward_to(201);
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            state: ReferendumState::Executed,
+            referendum_type: ReferendumType::Emergency,
+            enactment_period: 200,
+        })
+    );
+    assert_err!(
+        Pips::override_referendum_enactment_period(bob.clone(), 0, Some(300)),
+        Error::<TestStorage>::IncorrectReferendumState
+    );
+}
+
+#[test]
+fn proposal_with_beneficiares() {
+    let committee = [AccountKeyring::Alice.public(), AccountKeyring::Bob.public()].to_vec();
+    ExtBuilder::default()
+        .governance_committee(committee)
+        .governance_committee_vote_threshold((2, 3))
+        .balance_factor(10)
+        .build()
+        .execute_with(proposal_with_beneficiares_we);
+}
+
+fn proposal_with_beneficiares_we() {
+    // 0. Create accounts
+    System::set_block_number(1);
+    let root = Origin::from(frame_system::RawOrigin::Root);
+    let alice = AccountKeyring::Alice.public();
+    let charlie = AccountKeyring::Charlie.public();
+    let dave = AccountKeyring::Dave.public();
+    let eve = AccountKeyring::Eve.public();
+    TestStorage::set_payer_context(Some(charlie));
+    let charlie_id = register_keyring_account_with_balance(AccountKeyring::Charlie, 200).unwrap();
+    TestStorage::set_payer_context(Some(dave));
+    let dave_id = register_keyring_account_with_balance(AccountKeyring::Dave, 200).unwrap();
+    TestStorage::set_payer_context(Some(eve));
+    let _ = register_keyring_account_with_balance(AccountKeyring::Eve, 1_000_000).unwrap();
+    let eve_acc = Origin::signed(AccountKeyring::Eve.public());
+
+    // 2. Charlie creates a new proposal with 2 beneificiares
+    let proposal = make_proposal(42);
+    let proposal_url: Url = b"www.abc.com".into();
+    let proposal_desc: PipDescription = b"Test description".into();
+    let beneficiaries = vec![
+        Beneficiary {
+            id: charlie_id,
+            amount: 200,
+        },
+        Beneficiary {
+            id: dave_id,
+            amount: 800,
+        },
+    ];
+
+    TestStorage::set_payer_context(Some(charlie));
+    assert_ok!(Pips::propose(
+        Origin::signed(charlie.clone()),
+        Box::new(proposal),
+        60,
+        Some(proposal_url),
+        Some(proposal_desc),
+        Some(beneficiaries),
+    ));
+
+    // 2. Alice can fast track because she is a GC member
+    TestStorage::set_payer_context(Some(alice));
+    assert_ok!(Pips::fast_track_proposal(Origin::signed(alice), 0));
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            referendum_type: ReferendumType::FastTracked,
+            state: ReferendumState::Pending,
+            enactment_period: 0,
+        })
+    );
+    assert_ok!(Pips::enact_referendum(root, 0));
+
+    // 3. It executes automatically the referendum at block 101.
+    assert_eq!(Balances::free_balance(&charlie), 118);
+    assert_eq!(Balances::free_balance(&dave), 159);
+
+    // Top up the treasury account so it can disburse
+    assert_ok!(Treasury::reimbursement(eve_acc.clone(), 1_000));
+
+    fast_forward_to(120);
+    assert_eq!(
+        Pips::referendums(0),
+        Some(Referendum {
+            id: 0,
+            referendum_type: ReferendumType::FastTracked,
+            state: ReferendumState::Executed,
+            enactment_period: 101,
+        })
+    );
 }

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -17,8 +17,8 @@ use pallet_balances as balances;
 use pallet_committee as committee;
 use pallet_group as group;
 use pallet_pips::{
-    self as pips, DepositInfo, Pip, PipDescription, PipsMetadata, ProposalState, Proposer,
-    RawEvent as Event, SnapshotMetadata, SnapshotResult, SnapshottedPip, Url, Vote, VotingResult,
+    self as pips, DepositInfo, Pip, PipDescription, ProposalState, Proposer, RawEvent as Event,
+    SnapshotMetadata, SnapshotResult, SnapshottedPip, Url, Vote, VotingResult,
 };
 use pallet_treasury as treasury;
 use polymesh_common_utilities::pip::PipId;
@@ -494,7 +494,7 @@ fn assert_votes(id: PipId, owner: Public, amount: u128) {
 #[test]
 fn proposal_details_are_correct() {
     ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(42);
+        System::set_block_number(1);
 
         let alice = User::new(AccountKeyring::Alice).balance(300);
 
@@ -525,13 +525,10 @@ fn proposal_details_are_correct() {
             System::block_number() + Pips::proposal_cool_off_period()
         );
 
-        let expected = PipsMetadata {
-            id: 0,
-            created_at: 42,
-            url: Some(proposal_url),
-            description: Some(proposal_desc),
-        };
-        assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
+        let meta = Pips::proposal_metadata(0).unwrap();
+        assert_eq!(meta.id, 0);
+        assert_eq!(meta.url, Some(proposal_url));
+        assert_eq!(meta.description, Some(proposal_desc));
 
         assert_balance(alice.acc(), 300, 60);
         assert_votes(0, alice.acc(), 60);
@@ -613,20 +610,11 @@ fn amend_proposal_works() {
         assert_ok!(alice_proposal(Pips::min_proposal_deposit()));
         let signer = Origin::signed(AccountKeyring::Alice.public());
         let url = Some("https:://example.com".into());
-        let description = Some("foo bar baz".into());
-        assert_ok!(Pips::amend_proposal(
-            signer,
-            0,
-            url.clone(),
-            description.clone()
-        ));
-        let expected = PipsMetadata {
-            id: 0,
-            created_at: 1,
-            url,
-            description,
-        };
-        assert_eq!(Pips::proposal_metadata(0).unwrap(), expected);
+        let desc = Some("foo bar baz".into());
+        assert_ok!(Pips::amend_proposal(signer, 0, url.clone(), desc.clone()));
+        let meta = Pips::proposal_metadata(0).unwrap();
+        assert_eq!(meta.url, url);
+        assert_eq!(meta.description, desc);
     });
 }
 
@@ -1852,10 +1840,6 @@ fn enact_snapshot_results_works() {
             root(),
             vec![(1, SnapshotResult::Approve)]
         ));
-        assert_last_event!(
-            Event::SnapshotResultsEnacted(_, Some(1), a, b, c),
-            a.is_empty() && b.is_empty() && c == &[1]
-        );
         assert_state(1, false, ProposalState::Scheduled);
         assert_eq!(Pips::snapshot_queue(), mk_queue(&[3]));
 
@@ -1863,7 +1847,7 @@ fn enact_snapshot_results_works() {
         assert_ok!(Pips::clear_snapshot(user.signer()));
         assert_ok!(Pips::enact_snapshot_results(root(), vec![]));
         assert_last_event!(
-            Event::SnapshotResultsEnacted(_, None, a, b, c),
+            Event::SnapshotResultsEnacted(_, a, b, c),
             a.is_empty() && b.is_empty() && c.is_empty()
         )
     });

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -125,21 +125,11 @@ fn proposal(
     let before = Pips::pip_id_sequence();
     let active = Pips::active_pip_count();
     let signer = signer.clone();
-    let result = Pips::propose(
-        signer,
-        proposer.clone(),
-        Box::new(proposal),
-        deposit,
-        url,
-        desc,
-    );
+    let proposer = proposer.clone();
+    let result = Pips::propose(signer, proposer, Box::new(proposal), deposit, url, desc);
     let add = result.map_or(0, |_| 1);
     if let Ok(_) = result {
         assert_last_event!(Event::ProposalCreated(_, _, id, ..), *id == before);
-        assert_eq!(
-            Pips::committee_pips().contains(&before),
-            matches!(proposer, Proposer::Committee(_))
-        );
     }
     assert_eq!(Pips::pip_id_sequence(), before + add);
     assert_eq!(Pips::active_pip_count(), active + add);
@@ -299,7 +289,7 @@ fn min_deposit_works() {
         assert_ok!(alice_proposal(deposit + 1));
         assert_state(0, false, ProposalState::Pending);
         assert_eq!(
-            Pips::proposals(0).unwrap().proposer,
+            Pips::proposal_metadata(0).unwrap().proposer,
             Proposer::Community(alice.acc())
         );
 
@@ -307,7 +297,7 @@ fn min_deposit_works() {
         assert_ok!(committee_proposal(0));
         assert_state(1, false, ProposalState::Pending);
         let prop_committee = Proposer::Committee(pallet_pips::Committee::Technical);
-        assert_eq!(Pips::proposals(1).unwrap().proposer, prop_committee);
+        assert_eq!(Pips::proposal_metadata(1).unwrap().proposer, prop_committee);
         assert_vote_details(1, VotingResult::default(), vec![], vec![]);
     })
 }
@@ -360,7 +350,7 @@ fn cool_off_period_works() {
             assert_ok!(alice_proposal(0));
             assert_eq!(
                 block + cooling_until,
-                Pips::proposals(Pips::pip_id_sequence() - 1)
+                Pips::proposal_metadata(Pips::pip_id_sequence() - 1)
                     .unwrap()
                     .cool_off_until,
             );
@@ -519,16 +509,16 @@ fn proposal_details_are_correct() {
         assert_eq!(prop.id, 0);
         assert_eq!(prop.proposal, call);
         assert_eq!(prop.state, ProposalState::Pending);
-        assert_eq!(prop.proposer, proposer);
-        assert_eq!(
-            prop.cool_off_until,
-            System::block_number() + Pips::proposal_cool_off_period()
-        );
 
         let meta = Pips::proposal_metadata(0).unwrap();
         assert_eq!(meta.id, 0);
+        assert_eq!(meta.proposer, proposer);
         assert_eq!(meta.url, Some(proposal_url));
         assert_eq!(meta.description, Some(proposal_desc));
+        assert_eq!(
+            meta.cool_off_until,
+            System::block_number() + Pips::proposal_cool_off_period()
+        );
 
         assert_balance(alice.acc(), 300, 60);
         assert_votes(0, alice.acc(), 60);
@@ -724,7 +714,7 @@ fn vote_on_cool_off() {
         assert_ok!(Pips::set_min_proposal_deposit(root(), 0));
         assert_ok!(Pips::set_proposal_cool_off_period(root(), 42));
         assert_ok!(alice_proposal(0));
-        assert!(Pips::proposals(0).unwrap().cool_off_until > System::block_number());
+        assert!(Pips::proposal_metadata(0).unwrap().cool_off_until > System::block_number());
         // Alice made the PIP, so they can vote during cool-off period.
         let signer = User::new(AccountKeyring::Alice).signer();
         assert_ok!(Pips::vote(signer, 0, false, 0));
@@ -947,7 +937,7 @@ fn approve_committee_proposal_on_cool_off() {
         System::set_block_number(1);
         assert_ok!(Pips::set_proposal_cool_off_period(root(), 42));
         assert_ok!(committee_proposal(0));
-        assert!(Pips::proposals(0).unwrap().cool_off_until > System::block_number());
+        assert!(Pips::proposal_metadata(0).unwrap().cool_off_until > System::block_number());
         assert_noop!(
             Pips::approve_committee_proposal(root(), 0),
             Error::ProposalOnCoolOffPeriod,
@@ -1348,8 +1338,6 @@ fn reject_proposal_works() {
                 id: 0,
                 proposal: make_proposal(42),
                 state: ProposalState::Rejected,
-                proposer: Proposer::Community(alice.acc()),
-                cool_off_until: 1 + Pips::proposal_cool_off_period(),
             }
         );
         assert_balance(alice.acc(), init_bal, 0);
@@ -1388,8 +1376,6 @@ fn reject_proposal_works() {
                 id: 1,
                 proposal: make_proposal(42),
                 state: ProposalState::Rejected,
-                proposer: Proposer::Community(alice.acc()),
-                cool_off_until: 1 + Pips::proposal_cool_off_period(),
             }
         );
         assert_balance(alice.acc(), init_bal, 0);
@@ -1631,7 +1617,7 @@ fn snapshot_only_pending_hot_community() {
         let p = Pips::pip_id_sequence() - 1;
         for id in &[c, r, e, f, s, p] {
             assert!(matches!(
-                Pips::proposals(*id).unwrap().proposer,
+                Pips::proposal_metadata(*id).unwrap().proposer,
                 Proposer::Community(_)
             ));
         }
@@ -1700,23 +1686,13 @@ fn snapshot_works() {
                 },
             ]
         );
-        let assert_snapshot = |id| {
-            assert_eq!(
-                Pips::snapshot_metadata(),
-                Some(SnapshotMetadata {
-                    created_at: 1,
-                    made_by: user.acc(),
-                    id,
-                })
-            );
-        };
-        assert_snapshot(0);
-
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_snapshot(1);
-
-        assert_ok!(Pips::snapshot(user.signer()));
-        assert_snapshot(2);
+        assert_eq!(
+            Pips::snapshot_metadata(),
+            Some(SnapshotMetadata {
+                created_at: 1,
+                made_by: user.acc(),
+            })
+        );
     });
 }
 

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -1,5 +1,5 @@
 use super::{
-    storage::{register_keyring_account, TestStorage},
+    storage::{make_account, register_keyring_account, TestStorage},
     ExtBuilder,
 };
 use frame_support::{assert_err, assert_noop, assert_ok};

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -342,7 +342,6 @@ impl pallet_timestamp::Trait for Test {
 
 impl group::Trait<group::Instance2> for Test {
     type Event = MetaEvent;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -754,7 +753,6 @@ impl ExtBuilder {
         .assimilate_storage(&mut storage);
 
         let _ = group::GenesisConfig::<Test, group::Instance2> {
-            active_members_limit: u32::MAX,
             active_members: vec![IdentityId::from(1), IdentityId::from(2)],
             phantom: Default::default(),
         }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -190,12 +190,9 @@ impl_outer_origin! {
     pub enum Origin for Test  where system = frame_system {}
 }
 
-type Pips = pallet_pips::Module<Test>;
-
 impl_outer_dispatch! {
     pub enum Call for Test where origin: Origin {
         staking::Staking,
-        pallet_pips::Pips,
     }
 }
 
@@ -208,8 +205,6 @@ impl_outer_event! {
         system<T>,
         balances<T>,
         session,
-        pallet_pips<T>,
-        pallet_treasury<T>,
         staking<T>,
         protocol_fee<T>,
         identity<T>,
@@ -308,22 +303,6 @@ impl pallet_session::historical::Trait for Test {
     type FullIdentification = Exposure<AccountId, Balance>;
     type FullIdentificationOf = ExposureOf<Test>;
 }
-
-impl pallet_pips::Trait for Test {
-    type Currency = pallet_balances::Module<Self>;
-    type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
-    type VotingMajorityOrigin = frame_system::EnsureRoot<AccountId>;
-    type GovernanceCommittee = crate::storage::Committee;
-    type TechnicalCommitteeVMO = frame_system::EnsureRoot<AccountId>;
-    type UpgradeCommitteeVMO = frame_system::EnsureRoot<AccountId>;
-    type Treasury = pallet_treasury::Module<Self>;
-    type Event = MetaEvent;
-}
-impl pallet_treasury::Trait for Test {
-    type Event = MetaEvent;
-    type Currency = pallet_balances::Module<Self>;
-}
-
 impl pallet_authorship::Trait for Test {
     type FindAuthor = Author11;
     type UncleGenerations = UncleGenerations;

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -3774,7 +3774,6 @@ mod offchain_phragmen {
             let call = extrinsic.call;
             let inner = match call {
                 mock::Call::Staking(inner) => inner,
-                _ => panic!(),
             };
 
             assert_eq!(
@@ -3818,7 +3817,6 @@ mod offchain_phragmen {
             let call = extrinsic.call;
             let inner = match call {
                 mock::Call::Staking(inner) => inner,
-                _ => panic!(),
             };
 
             assert_eq!(
@@ -3861,7 +3859,6 @@ mod offchain_phragmen {
             let call = extrinsic.call;
             let inner = match call {
                 mock::Call::Staking(inner) => inner,
-                _ => panic!(),
             };
 
             // pass this call to ValidateUnsigned
@@ -5371,46 +5368,4 @@ fn check_whether_nominator_selected_or_not_when_its_cdd_claim_expired() {
                 197
             );
         });
-}
-
-#[test]
-fn voting_for_pip_overlays_with_staking() {
-    type Pips = pallet_pips::Module<Test>;
-    type Error = pallet_pips::Error<Test>;
-    use crate::staking::mock::Call;
-    use pallet_pips::Proposer;
-
-    ExtBuilder::default().build().execute_with(|| {
-        System::set_block_number(1);
-
-        assert_ok!(Pips::set_min_proposal_deposit(
-            Origin::from(frame_system::RawOrigin::Root),
-            0
-        ));
-
-        // Initialize with 100 POLYX.
-        let alice_acc = 500;
-        let (alice_signer, _) = make_account_with_balance(alice_acc, 100).unwrap();
-
-        let alice_proposal = |deposit: u128| {
-            let signer = Origin::signed(alice_acc);
-            let proposal = Box::new(Call::Pips(pallet_pips::Call::set_min_proposal_deposit(0)));
-            let proposer = Proposer::Community(alice_acc);
-            Pips::propose(signer, proposer, proposal, deposit, None, None)
-        };
-
-        // Bond all but 10.
-        assert_ok!(Staking::bond(
-            alice_signer,
-            alice_acc,
-            90,
-            RewardDestination::Stash
-        ));
-        // OK, because we're overlaying with 90 tokens already locked.
-        assert_ok!(alice_proposal(50));
-        // OK, because we're still overlaying, but also increasing it by 10.
-        assert_ok!(alice_proposal(50));
-        // Error, because we don't have 101 tokens to bond.
-        assert_noop!(alice_proposal(1), Error::InsufficientDeposit);
-    });
 }

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -5378,6 +5378,7 @@ fn voting_for_pip_overlays_with_staking() {
     type Pips = pallet_pips::Module<Test>;
     type Error = pallet_pips::Error<Test>;
     use crate::staking::mock::Call;
+    use pallet_pips::Proposer;
 
     ExtBuilder::default().build().execute_with(|| {
         System::set_block_number(1);
@@ -5394,7 +5395,8 @@ fn voting_for_pip_overlays_with_staking() {
         let alice_proposal = |deposit: u128| {
             let signer = Origin::signed(alice_acc);
             let proposal = Box::new(Call::Pips(pallet_pips::Call::set_min_proposal_deposit(0)));
-            Pips::propose(signer, proposal, deposit, None, None)
+            let proposer = Proposer::Community(alice_acc);
+            Pips::propose(signer, proposer, proposal, deposit, None, None)
         };
 
         // Bond all but 10.

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -49,7 +49,6 @@ use smallvec::smallvec;
 use sp_core::{
     crypto::{key_types, Pair as PairTrait},
     sr25519::{Pair, Public},
-    u32_trait::{_1, _2},
     H256,
 };
 use sp_runtime::{
@@ -77,12 +76,7 @@ impl From<UintAuthorityId> for MockSessionKeys {
 }
 
 impl_outer_origin! {
-    pub enum Origin for TestStorage {
-        committee Instance1 <T>,
-        committee DefaultInstance <T>,
-        committee Instance3 <T>,
-        committee Instance4 <T>
-    }
+    pub enum Origin for TestStorage {}
 }
 
 impl_outer_dispatch! {
@@ -361,17 +355,20 @@ impl group::Trait<group::Instance2> for TestStorage {
 
 pub type CommitteeOrigin<T, I> = committee::RawOrigin<<T as frame_system::Trait>::AccountId, I>;
 
+impl<I> From<CommitteeOrigin<TestStorage, I>> for Origin {
+    fn from(_co: CommitteeOrigin<TestStorage, I>) -> Origin {
+        Origin::from(frame_system::RawOrigin::Root)
+    }
+}
+
 parameter_types! {
     pub const MotionDuration: BlockNumber = 0u64;
 }
 
-/// Voting majority origin for `Instance`.
-type VMO<Instance> = committee::EnsureProportionAtLeast<_1, _2, AccountId, Instance>;
-
 impl committee::Trait<committee::Instance1> for TestStorage {
     type Origin = Origin;
     type Proposal = Call;
-    type CommitteeOrigin = VMO<committee::Instance1>;
+    type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
     type Event = Event;
     type MotionDuration = MotionDuration;
 }
@@ -568,10 +565,10 @@ impl dividend::Trait for TestStorage {
 impl pips::Trait for TestStorage {
     type Currency = balances::Module<Self>;
     type CommitteeOrigin = frame_system::EnsureRoot<AccountId>;
-    type VotingMajorityOrigin = VMO<committee::Instance1>;
+    type VotingMajorityOrigin = frame_system::EnsureRoot<AccountId>;
     type GovernanceCommittee = Committee;
-    type TechnicalCommitteeVMO = VMO<committee::Instance3>;
-    type UpgradeCommitteeVMO = VMO<committee::Instance4>;
+    type TechnicalCommitteeVMO = frame_system::EnsureRoot<AccountId>;
+    type UpgradeCommitteeVMO = frame_system::EnsureRoot<AccountId>;
     type Treasury = treasury::Module<Self>;
     type Event = Event;
 }

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -321,7 +321,6 @@ impl pallet_transaction_payment::Trait for TestStorage {
 
 impl group::Trait<group::DefaultInstance> for TestStorage {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -333,7 +332,6 @@ impl group::Trait<group::DefaultInstance> for TestStorage {
 /// PolymeshCommittee as an instance of group
 impl group::Trait<group::Instance1> for TestStorage {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;
@@ -344,7 +342,6 @@ impl group::Trait<group::Instance1> for TestStorage {
 
 impl group::Trait<group::Instance2> for TestStorage {
     type Event = Event;
-    type LimitOrigin = frame_system::EnsureRoot<AccountId>;
     type AddOrigin = frame_system::EnsureRoot<AccountId>;
     type RemoveOrigin = frame_system::EnsureRoot<AccountId>;
     type SwapOrigin = frame_system::EnsureRoot<AccountId>;

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -477,7 +477,7 @@ impl Default for RewardDestination {
 }
 
 /// Preference of what happens regarding validation.
-#[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 pub struct ValidatorPrefs {
     /// Reward that validator takes up-front; only the rest is split between themselves and
     /// nominators.
@@ -485,6 +485,13 @@ pub struct ValidatorPrefs {
     pub commission: Perbill,
 }
 
+impl Default for ValidatorPrefs {
+    fn default() -> Self {
+        ValidatorPrefs {
+            commission: Default::default(),
+        }
+    }
+}
 // Polymesh-Note: Polymesh specific changes to allow flexibility in commission
 /// Commission can be set globally or by validator
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -506,9 +506,13 @@
         "Url": "Text",
         "PipDescription": "Text",
         "PipsMetadata": {
+            "proposer": "AccountId",
             "id": "PipId",
+            "end": "u32",
             "url": "Option<Url>",
-            "description": "Option<PipDescription>"
+            "description": "Option<PipDescription>",
+            "cool_off_until": "u32",
+            "beneficiaries": "Vec<Beneficiary>"
         },
         "Proposer": {
             "_enum": {
@@ -527,11 +531,9 @@
             "id": "PipId",
             "weight": "(bool, Balance)"
         },
-        "SnapshotId": "u32",
         "SnapshotMetadata": {
             "created_at": "BlockNumber",
-            "made_by": "AccountId",
-            "id": "SnapshotId"
+            "made_by": "AccountId"
         },
         "SnapshotResult": {
             "_enum": {
@@ -582,9 +584,7 @@
         "Pip": {
             "id": "PipId",
             "proposal": "Call",
-            "state": "ProposalState",
-            "proposer": "Proposer",
-            "cool_off_until": "u32"
+            "state": "ProposalState"
         },
         "ProposalData": {
             "_enum": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -508,8 +508,7 @@
         "PipsMetadata": {
             "id": "PipId",
             "url": "Option<Url>",
-            "description": "Option<PipDescription>",
-            "created_at": "BlockNumber"
+            "description": "Option<PipDescription>"
         },
         "Proposer": {
             "_enum": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1,7 +1,7 @@
 {
     "types": {
-        "IdentityId": "[u8; 32]",
-        "InvestorUid": "[u8; 32]",
+        "IdentityId":"[u8; 32]",
+        "InvestorUid":"[u8; 32]",
         "Ticker": "[u8; 12]",
         "CddId": "[u8; 32]",
         "ScopeId": "[u8; 32]",
@@ -67,7 +67,7 @@
                 "SpendFunds"
             ]
         },
-        "Signatory": {
+        "Signatory":{
             "_enum": {
                 "Identity": "IdentityId",
                 "Account": "AccountId"
@@ -77,7 +77,7 @@
             "signer": "Signatory",
             "permissions": "Vec<Permission>"
         },
-        "SecondaryKeyWithAuth": {
+        "SecondaryKeyWithAuth":{
             "secondary_key": "SecondaryKey",
             "auth_signature": "Signature"
         },
@@ -378,7 +378,7 @@
                 "Jurisdiction": "(CountryCode, Scope)",
                 "Exempted": "Scope",
                 "Blocked": "Scope",
-                "InvestorZKProof": "(Scope, ScopeId, CddId, InvestorZKProofData)",
+                "InvestorZKProof":"(Scope, ScopeId, CddId, InvestorZKProofData)",
                 "NoData": ""
             }
         },
@@ -420,7 +420,7 @@
         },
         "ConditionType": {
             "_enum": {
-                "IsPresent": "Claim",
+                "IsPresent" : "Claim",
                 "IsAbsent": "Claim",
                 "IsAnyOf": "Vec<Claim>",
                 "IsNoneOf": "Vec<Claim>",
@@ -514,34 +514,6 @@
             "cool_off_until": "u32",
             "beneficiaries": "Vec<Beneficiary>"
         },
-        "Proposer": {
-            "_enum": {
-                "Community": "AccountId",
-                "Committee": "Committee"
-            }
-        },
-        "Committee": {
-            "_enum": {
-                "Technical": "",
-                "Upgrade": ""
-            }
-        },
-        "SkippedCount": "u8",
-        "SnapshottedPip": {
-            "id": "PipId",
-            "weight": "(bool, Balance)"
-        },
-        "SnapshotMetadata": {
-            "created_at": "BlockNumber",
-            "made_by": "AccountId"
-        },
-        "SnapshotResult": {
-            "_enum": {
-                "Approve": "",
-                "Reject": "",
-                "Skip": ""
-            }
-        },
         "Beneficiary": {
             "id": "IdentityId",
             "amount": "Balance"
@@ -583,10 +555,10 @@
         },
         "Pip": {
             "id": "PipId",
-            "proposal": "Call",
-            "state": "ProposalState"
+            "proposal":"Call",
+            "state":"ProposalState"
         },
-        "ProposalData": {
+        "ProposalData" : {
             "_enum": {
                 "Hash": "Hash",
                 "Proposal": "Vec<u8>"
@@ -717,12 +689,12 @@
             "target": "IdentityId",
             "claim": "Claim"
         },
-        "InactiveMember": {
+        "InactiveMember" : {
             "id": "IdentityId",
             "deactivated_at": "Moment",
             "expiry": "Option<Moment>"
         },
-        "VotingResult": {
+        "VotingResult" : {
             "ayes_count": "u32",
             "ayes_stake": "Balance",
             "nays_count": "u32",
@@ -758,7 +730,7 @@
             }
         },
         "DidRecordsSuccess": {
-            "primary_key": "AccountId",
+            "primary_key" : "AccountId",
             "secondary_key": "Vec<SecondaryKey>"
         },
         "DidRecords": {
@@ -838,7 +810,7 @@
                 "ActiveOrExpired": "",
                 "ExecutionSuccessful": "",
                 "ExecutionFailed": "",
-                "Rejected": ""
+                "Rejected":""
             }
         },
         "DidStatus": {
@@ -860,7 +832,7 @@
                 "User": "PortfolioNumber"
             }
         },
-        "PortfolioId": {
+        "PortfolioId" : {
             "did": "IdentityId",
             "kind": "PortfolioKind"
         },
@@ -1003,7 +975,7 @@
             }
         },
         "identity": {
-            "isIdentityHasValidCdd": {
+            "isIdentityHasValidCdd" : {
                 "description": "use to tell whether the given did has valid cdd claim or not",
                 "params": [
                     {
@@ -1060,14 +1032,14 @@
                 "description": "Retrieve status of the DID",
                 "params": [
                     {
-                        "name": "did",
-                        "type": "Vec<IdentityId>",
+                        "name":"did",
+                        "type":"Vec<IdentityId>",
                         "isOptional": false
                     },
                     {
-                        "name": "blockHash",
-                        "type": "Hash",
-                        "isOptional": true
+                        "name":"blockHash",
+                        "type":"Hash",
+                        "isOptional":true
                     }
                 ],
                 "type": "Vec<DidStatus>"
@@ -1115,7 +1087,7 @@
                 "type": "Option<KeyIdentityData<IdentityId>>"
             }
         },
-        "pips": {
+        "pips":{
             "getVotes": {
                 "description": "Summary of votes of a proposal given by index",
                 "params": [
@@ -1228,7 +1200,7 @@
                 "type": "Vec<(Perbill, Perbill)>"
             }
         },
-        "asset": {
+        "asset" : {
             "canTransfer": {
                 "description": "Checks whether a transaction with given parameters can take place or not",
                 "params": [

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -553,10 +553,9 @@
             "_enum": [
                 "Pending",
                 "Cancelled",
+                "Killed",
                 "Rejected",
-                "Scheduled",
-                "Failed",
-                "Executed"
+                "Referendum"
             ]
         },
         "ReferendumState": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -424,7 +424,14 @@
                 "IsAbsent": "Claim",
                 "IsAnyOf": "Vec<Claim>",
                 "IsNoneOf": "Vec<Claim>",
-                "IsIdentity": "TargetIdentity"
+                "IsIdentity": "TargetIdentity",
+                "HasValidProofOfInvestor": "Ticker"
+            }
+        },
+        "ImplicitRequirementStatus": {
+            "_enum": {
+                "Active":"",
+                "Inactive":""
             }
         },
         "Condition": {
@@ -502,8 +509,7 @@
             "id": "PipId",
             "url": "Option<Url>",
             "description": "Option<PipDescription>",
-            "created_at": "BlockNumber",
-            "transaction_version": "u32"
+            "created_at": "BlockNumber"
         },
         "Proposer": {
             "_enum": {

--- a/rpc/runtime-api/src/pips.rs
+++ b/rpc/runtime-api/src/pips.rs
@@ -65,6 +65,7 @@ pub mod capped {
     #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
     #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
     pub enum Vote {
+        None,
         Yes(u64),
         No(u64),
     }
@@ -75,8 +76,9 @@ pub mod capped {
     {
         fn from(core_vote: CoreVote<Balance>) -> Self {
             match core_vote {
-                CoreVote(true, amount) => Vote::Yes(amount.saturated_into()),
-                CoreVote(false, amount) => Vote::No(amount.saturated_into()),
+                CoreVote::None => Vote::None,
+                CoreVote::Yes(amount) => Vote::Yes(amount.saturated_into()),
+                CoreVote::No(amount) => Vote::No(amount.saturated_into()),
             }
         }
     }

--- a/scripts/cli/tests/11_governance_management.js
+++ b/scripts/cli/tests/11_governance_management.js
@@ -26,13 +26,14 @@ async function main() {
   await sendTx(alice, api.tx.staking.bond(bob.publicKey, 20000, "Staked"));
 
   // Create a PIP which is then amended.
+  const proposer = { "Community": bob.address };
   const setLimit = api.tx.pips.setActivePipLimit(42);
-  await sendTx(bob, api.tx.pips.propose(setLimit, 10000000000, "google.com", "first"));
+  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "first"));
   await sendTx(bob, api.tx.pips.amendProposal(0, "www.facebook.com", null));
 
   // Create a PIP, but first remove the cool-off period.
   await sendTx(alice, api.tx.sudo.sudo(api.tx.pips.setProposalCoolOffPeriod(0)));
-  await sendTx(bob, api.tx.pips.propose(setLimit, 10000000000, "google.com", "second"));
+  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "second"));
 
   // GC needs some funds to use.
   await reqImports.distributePolyBatch(api, [govCommittee1, govCommittee2], reqImports.transfer_amount, alice);

--- a/scripts/cli/tests/11_governance_management.js
+++ b/scripts/cli/tests/11_governance_management.js
@@ -11,42 +11,35 @@ const testKeyring = require('@polkadot/keyring/testing');
 process.exitCode = 1;
 
 async function main() {
-
+  
   const api = await reqImports.createApi();
-
+  
   const testEntities = await reqImports.initMain(api);
-
+  
   let alice = testEntities[0];
   let bob = testEntities[1];
   let govCommittee1 = testEntities[5];
   let govCommittee2 = testEntities[6];
 
-  await reqImports.createIdentities(api, [bob, govCommittee1, govCommittee2], alice);
+  let proposalId = 0;
+  
+  await reqImports.createIdentities( api, [bob, govCommittee1, govCommittee2], alice );
+  
+  await bondPoly(api, alice, bob);
+  
+  await proposePIP( api, bob );
 
-  await sendTx(alice, api.tx.staking.bond(bob.publicKey, 20000, "Staked"));
+  await amendProposal(api, bob);
 
-  // Create a PIP which is then amended.
-  const proposer = { "Community": bob.address };
-  const setLimit = api.tx.pips.setActivePipLimit(42);
-  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "first"));
-  await sendTx(bob, api.tx.pips.amendProposal(0, "www.facebook.com", null));
+  await fastTrackProposal(api, proposalId, alice);
 
-  // Create a PIP, but first remove the cool-off period.
-  await sendTx(alice, api.tx.sudo.sudo(api.tx.pips.setProposalCoolOffPeriod(0)));
-  await sendTx(bob, api.tx.pips.propose(proposer, setLimit, 10000000000, "google.com", "second"));
+  await reqImports.distributePolyBatch( api, [govCommittee1, govCommittee2], reqImports.transfer_amount, alice );
 
-  // GC needs some funds to use.
-  await reqImports.distributePolyBatch(api, [govCommittee1, govCommittee2], reqImports.transfer_amount, alice);
+  await voteEnactReferendum(api, proposalId, govCommittee1);
 
-  // Snapshot and approve second PIP.
-  await sendTx(govCommittee1, api.tx.pips.snapshot());
-  const approvePIP = api.tx.pips.enactSnapshotResults([[1, { "Approve": "" }]]);
-  const voteApprove = api.tx.polymeshCommittee.voteOrPropose(true, approvePIP);
-  await sendTx(govCommittee1, voteApprove);
-  await sendTx(govCommittee2, voteApprove);
+  await voteEnactReferendum(api, proposalId, govCommittee2);
 
-  // Finally reschedule, demonstrating that it had been scheduled.
-  await sendTx(alice, api.tx.pips.rescheduleExecution(1, null));
+  await overrideReferendumEnactmentPeriod(api, proposalId, null, alice);
 
   if (reqImports.fail_count > 0) {
     console.log("Failed");
@@ -58,12 +51,78 @@ async function main() {
   process.exit();
 }
 
-async function sendTx(signer, tx) {
-  let nonceObj = { nonce: reqImports.nonces.get(signer.address) };
-  const result = await reqImports.sendTransaction(tx, signer, nonceObj);
+async function voteEnactReferendum(api, proposalId, signer) {
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.polymeshCommittee.voteEnactReferendum(proposalId);
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
   const passed = result.findRecord('system', 'ExtrinsicSuccess');
   if (passed) reqImports.fail_count--;
-  reqImports.nonces.set(signer.address, reqImports.nonces.get(signer.address).addn(1));
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+}
+
+async function overrideReferendumEnactmentPeriod(api, proposalId, until, signer) {
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.pips.overrideReferendumEnactmentPeriod(proposalId, until);
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
+  const passed = result.findRecord('system', 'ExtrinsicSuccess');
+  if (passed) reqImports.fail_count--;
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+}
+
+async function fastTrackProposal(api, proposalId, signer) {
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.pips.fastTrackProposal(proposalId);
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
+  const passed = result.findRecord('system', 'ExtrinsicSuccess');
+  if (passed) reqImports.fail_count--;
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+}
+
+async function amendProposal(api, signer) {
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.pips.amendProposal(0, "www.facebook.com", null);
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
+  const passed = result.findRecord('system', 'ExtrinsicSuccess');
+  if (passed) reqImports.fail_count--;
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+}
+
+
+async function bondPoly(api, signer, bob) {
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.staking.bond(bob.publicKey, 20000, "Staked");
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
+  const passed = result.findRecord('system', 'ExtrinsicSuccess');
+  if (passed) reqImports.fail_count--;
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+}
+
+
+async function proposePIP(api, signer) {
+
+  let proposal = await api.tx.pips.setProposalDuration(10);
+  let deposit = 10000000000;
+  let url = "www.google.com";
+  let description = "test proposal";
+
+  let nonceObj = {nonce: reqImports.nonces.get(signer.address)};
+  const transaction = await api.tx.pips.propose(proposal, deposit, url, description, null);
+  const result = await reqImports.sendTransaction(transaction, signer, nonceObj);  
+  const passed = result.findRecord('system', 'ExtrinsicSuccess');
+  if (passed) reqImports.fail_count--;
+
+  reqImports.nonces.set( signer.address, reqImports.nonces.get(signer.address).addn(1));
+  
 }
 
 main().catch(console.error);

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -321,11 +321,11 @@ fn general_testnet_genesis(
         }),
         pallet_pips: Some(GeneralConfig::PipsConfig {
             prune_historical_pips: false,
-            min_proposal_deposit: 0,
+            min_proposal_deposit: 5_000 * POLY,
+            quorum_threshold: 100_000,
+            proposal_duration: generalTime::MINUTES,
             proposal_cool_off_period: generalTime::MINUTES,
             default_enactment_period: generalTime::MINUTES,
-            max_pip_skip_count: 1,
-            active_pip_limit: 25,
         }),
         pallet_im_online: Some(GeneralConfig::ImOnlineConfig {
             slashing_params: general::OfflineSlashingParams {
@@ -344,7 +344,6 @@ fn general_testnet_genesis(
                 ..Default::default()
             },
         }),
-        // Governance Council:
         group_Instance1: Some(general::runtime::CommitteeMembershipConfig {
             active_members: vec![
                 IdentityId::from(3),
@@ -367,28 +366,6 @@ fn general_testnet_genesis(
                 IdentityId::from(2),
                 IdentityId::from(6),
             ],
-            phantom: Default::default(),
-        }),
-        // Technical Committee:
-        group_Instance3: Some(general::runtime::TechnicalCommitteeMembershipConfig {
-            active_members: vec![IdentityId::from(3)],
-            phantom: Default::default(),
-        }),
-        committee_Instance3: Some(GeneralConfig::TechnicalCommitteeConfig {
-            vote_threshold: (1, 2),
-            members: vec![],
-            release_coordinator: IdentityId::from(3),
-            phantom: Default::default(),
-        }),
-        // Upgrade Committee:
-        group_Instance4: Some(general::runtime::UpgradeCommitteeMembershipConfig {
-            active_members: vec![IdentityId::from(4)],
-            phantom: Default::default(),
-        }),
-        committee_Instance4: Some(GeneralConfig::UpgradeCommitteeConfig {
-            vote_threshold: (1, 2),
-            members: vec![],
-            release_coordinator: IdentityId::from(4),
             phantom: Default::default(),
         }),
         protocol_fee: Some(GeneralConfig::ProtocolFeeConfig {
@@ -693,11 +670,11 @@ fn alcyone_testnet_genesis(
         }),
         pallet_pips: Some(AlcyoneConfig::PipsConfig {
             prune_historical_pips: false,
-            min_proposal_deposit: 0,
+            min_proposal_deposit: 5_000 * POLY,
+            quorum_threshold: 100_000_000_000,
+            proposal_duration: alcyoneTime::DAYS * 7,
             proposal_cool_off_period: alcyoneTime::HOURS * 6,
             default_enactment_period: alcyoneTime::DAYS * 7,
-            max_pip_skip_count: 1,
-            active_pip_limit: 1000,
         }),
         pallet_im_online: Some(AlcyoneConfig::ImOnlineConfig {
             slashing_params: alcyone::OfflineSlashingParams {
@@ -737,28 +714,6 @@ fn alcyone_testnet_genesis(
                 IdentityId::from(2),
                 IdentityId::from(3),
             ],
-            phantom: Default::default(),
-        }),
-        // Technical Committee:
-        group_Instance3: Some(alcyone::runtime::TechnicalCommitteeMembershipConfig {
-            active_members: vec![IdentityId::from(4)],
-            phantom: Default::default(),
-        }),
-        committee_Instance3: Some(alcyone::runtime::TechnicalCommitteeConfig {
-            vote_threshold: (1, 2),
-            members: vec![],
-            release_coordinator: IdentityId::from(4),
-            phantom: Default::default(),
-        }),
-        // Upgrade Committee:
-        group_Instance4: Some(alcyone::runtime::UpgradeCommitteeMembershipConfig {
-            active_members: vec![IdentityId::from(5)],
-            phantom: Default::default(),
-        }),
-        committee_Instance4: Some(alcyone::runtime::UpgradeCommitteeConfig {
-            vote_threshold: (1, 2),
-            members: vec![],
-            release_coordinator: IdentityId::from(5),
             phantom: Default::default(),
         }),
         protocol_fee: Some(AlcyoneConfig::ProtocolFeeConfig {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -346,7 +346,6 @@ fn general_testnet_genesis(
         }),
         // Governance Council:
         group_Instance1: Some(general::runtime::CommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![
                 IdentityId::from(3),
                 IdentityId::from(4),
@@ -362,7 +361,6 @@ fn general_testnet_genesis(
             phantom: Default::default(),
         }),
         group_Instance2: Some(general::runtime::CddServiceProvidersConfig {
-            active_members_limit: u32::MAX,
             // sp1, sp2, first authority
             active_members: vec![
                 IdentityId::from(1),
@@ -373,7 +371,6 @@ fn general_testnet_genesis(
         }),
         // Technical Committee:
         group_Instance3: Some(general::runtime::TechnicalCommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![IdentityId::from(3)],
             phantom: Default::default(),
         }),
@@ -385,7 +382,6 @@ fn general_testnet_genesis(
         }),
         // Upgrade Committee:
         group_Instance4: Some(general::runtime::UpgradeCommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![IdentityId::from(4)],
             phantom: Default::default(),
         }),
@@ -721,7 +717,6 @@ fn alcyone_testnet_genesis(
             },
         }),
         group_Instance1: Some(alcyone::runtime::CommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![
                 IdentityId::from(4),
                 IdentityId::from(5),
@@ -736,7 +731,6 @@ fn alcyone_testnet_genesis(
             phantom: Default::default(),
         }),
         group_Instance2: Some(alcyone::runtime::CddServiceProvidersConfig {
-            active_members_limit: u32::MAX,
             // sp1, sp2, sp3
             active_members: vec![
                 IdentityId::from(1),
@@ -747,7 +741,6 @@ fn alcyone_testnet_genesis(
         }),
         // Technical Committee:
         group_Instance3: Some(alcyone::runtime::TechnicalCommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![IdentityId::from(4)],
             phantom: Default::default(),
         }),
@@ -759,7 +752,6 @@ fn alcyone_testnet_genesis(
         }),
         // Upgrade Committee:
         group_Instance4: Some(alcyone::runtime::UpgradeCommitteeMembershipConfig {
-            active_members_limit: 20,
             active_members: vec![IdentityId::from(5)],
             phantom: Default::default(),
         }),


### PR DESCRIPTION
- reverts the `tooling` branch to governance V1
- previous `tooling` branch is now at `tooling_v2.2.0`