### PR TITLE
MESH-1306

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,8 +4354,8 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0#a200cdb93c6af5763b9c7bf313fa708764ac88ca"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -4373,8 +4373,8 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0#a200cdb93c6af5763b9c7bf313fa708764ac88ca"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -5313,7 +5313,7 @@ version = "2.0.0"
 dependencies = [
  "blake2",
  "chrono",
- "cryptography",
+ "cryptography 0.1.0 (git+https://github.com/PolymathNetwork/cryptography.git?branch=substrate-2)",
  "curve25519-dalek 2.1.0",
  "frame-support",
  "frame-system",

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -177,7 +177,7 @@ decl_module! {
         /// # Additional functionality
         /// 1. Allow origin to pass some meta-details related to template code.
         /// 2. Charge protocol fee for deploying the template.
-        #[weight = 50_000_000.saturating_add(pallet_contracts::Call::<T>::put_code(code.clone()).get_dispatch_info().weight)]
+        #[weight = 50_000_000.saturating_add(pallet_contracts::Call::<T>::put_code(code.to_vec()).get_dispatch_info().weight)]
         pub fn put_code(
             origin,
             meta_info: TemplateMetadata<BalanceOf<T>>,


### PR DESCRIPTION
Initial idea was to pass the `put_code()` as a call to the parent `put_code()` call of the wrapper contract pallet. So we can easily access the weight of the `call` without cloning of the `code`. Unfortunately, this process has one drawback that is I am not able to access the `code` param in `put_code()` in the parent dispatchable to generate the `code_hash`. 

So I had to choose the cheap trick(i.e use `to_vec()`) that does not clone the code directly but it does `memcpy`. So right now it not worst as it was before but we still have room to improve but I don't see any other way to solve this. 