### PR TITLE
Simplify compliance_canTransfer RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,8 +4355,8 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0#a200cdb93c6af5763b9c7bf313fa708764ac88ca"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",
@@ -4374,8 +4374,8 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?tag=v2.0.0#a200cdb93c6af5763b9c7bf313fa708764ac88ca"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1351,7 +1351,7 @@ impl<T: Trait> AssetTrait<T::Balance, T::AccountId> for Module<T> {
         Self::balance_of(ticker, &who)
     }
 
-    // Get the total supply of an asset `id`
+    /// Get the total supply of an asset `id`
     fn total_supply(ticker: &Ticker) -> T::Balance {
         Self::token_details(ticker).total_supply
     }
@@ -1360,11 +1360,17 @@ impl<T: Trait> AssetTrait<T::Balance, T::AccountId> for Module<T> {
         Self::get_balance_at(*ticker, did, at)
     }
 
-    fn primary_issuance_agent(ticker: &Ticker) -> IdentityId {
+    /// Returns the PIA if it's assigned or else the owner of the token
+    fn primary_issuance_agent_or_owner(ticker: &Ticker) -> IdentityId {
         let token_details = Self::token_details(ticker);
         token_details
             .primary_issuance_agent
             .unwrap_or(token_details.owner_did)
+    }
+
+    /// Returns the PIA of the token
+    fn primary_issuance_agent(ticker: &Ticker) -> Option<IdentityId> {
+        Self::token_details(ticker).primary_issuance_agent
     }
 
     fn max_number_of_tm_extension() -> u32 {

--- a/pallets/basic-sto/src/lib.rs
+++ b/pallets/basic-sto/src/lib.rs
@@ -101,7 +101,7 @@ decl_module! {
             let sender = ensure_signed(origin)?;
             CallPermissions::<T>::ensure_call_permissions(&sender)?;
             let did = Context::current_identity_or::<Identity<T>>(&sender)?;
-            ensure!(T::Asset::primary_issuance_agent(&offering_token) == did, Error::<T>::Unauthorized);
+            ensure!(T::Asset::primary_issuance_agent_or_owner(&offering_token) == did, Error::<T>::Unauthorized);
             // TODO: Take custodial ownership of $sell_amount of $offering_token from primary issuance agent?
             let fundraiser_id = Self::fundraiser_count(offering_token) + 1;
             <Fundraisers<T>>::insert(
@@ -135,7 +135,7 @@ decl_module! {
                 .saturating_add((ONE_UNIT - 1).into())
                 / ONE_UNIT.into();
 
-            let primary_issuance_agent = T::Asset::primary_issuance_agent(&offering_token);
+            let primary_issuance_agent = T::Asset::primary_issuance_agent_or_owner(&offering_token);
             let legs = vec![
                 Leg {
                     // TODO: Replace with did that actually hold the offering token

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -64,7 +64,8 @@ pub trait Trait<V, U> {
     ) -> DispatchResult;
     fn is_owner(ticker: &Ticker, did: IdentityId) -> bool;
     fn get_balance_at(ticker: &Ticker, did: IdentityId, at: u64) -> V;
-    fn primary_issuance_agent(ticker: &Ticker) -> IdentityId;
+    fn primary_issuance_agent_or_owner(ticker: &Ticker) -> IdentityId;
+    fn primary_issuance_agent(ticker: &Ticker) -> Option<IdentityId>;
     fn max_number_of_tm_extension() -> u32;
     fn base_transfer(
         from_portfolio: PortfolioId,

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -701,8 +701,8 @@ impl<T: Trait> Module<T> {
         ticker: &Ticker,
         from_did_opt: Option<IdentityId>,
         to_did_opt: Option<IdentityId>,
-        primary_issuance_agent: Option<IdentityId>,
     ) -> AssetComplianceResult {
+        let primary_issuance_agent = T::Asset::primary_issuance_agent(ticker);
         let asset_compliance = Self::asset_compliance(ticker);
 
         let mut asset_compliance_with_results = AssetComplianceResult::from(asset_compliance);

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -1207,10 +1207,9 @@ impl_runtime_apis! {
             ticker: Ticker,
             from_did: Option<IdentityId>,
             to_did: Option<IdentityId>,
-            primary_issuance_agent: Option<IdentityId>,
         ) -> AssetComplianceResult
         {
-            ComplianceManager::granular_verify_restriction(&ticker, from_did, to_did, primary_issuance_agent)
+            ComplianceManager::granular_verify_restriction(&ticker, from_did, to_did)
         }
     }
 

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -1175,10 +1175,9 @@ impl_runtime_apis! {
             ticker: Ticker,
             from_did: Option<IdentityId>,
             to_did: Option<IdentityId>,
-            primary_issuance_agent: Option<IdentityId>,
         ) -> AssetComplianceResult
         {
-            ComplianceManager::granular_verify_restriction(&ticker, from_did, to_did, primary_issuance_agent)
+            ComplianceManager::granular_verify_restriction(&ticker, from_did, to_did)
         }
     }
 

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -210,7 +210,6 @@ fn should_add_and_verify_compliance_requirement_we() {
             &ticker,
             Some(token_owner_did),
             Some(token_rec_did),
-            None,
         )
     };
     let second_unpassed = |result: AssetComplianceResult| {
@@ -1056,12 +1055,8 @@ fn cm_test_case_9_we() {
         None
     ));
     assert_valid_transfer!(ticker, owner_did, charlie, 100);
-    let result = ComplianceManager::granular_verify_restriction(
-        &ticker,
-        Some(owner_did),
-        Some(charlie),
-        None,
-    );
+    let result =
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(charlie));
     assert!(result.result);
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1075,7 +1070,7 @@ fn cm_test_case_9_we() {
     ));
     assert_valid_transfer!(ticker, owner_did, dave, 100);
     let result =
-        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(dave), None);
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(dave));
     assert!(result.result);
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1088,18 +1083,14 @@ fn cm_test_case_9_we() {
         None
     ));
     let result =
-        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve), None);
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve));
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
 
     // 3.4 Ferdie has none of the required claims
     assert_invalid_transfer!(ticker, owner_did, ferdie, 100);
-    let result = ComplianceManager::granular_verify_restriction(
-        &ticker,
-        Some(owner_did),
-        Some(ferdie),
-        None,
-    );
+    let result =
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(ferdie));
     assert!(!result.result);
     assert!(!result.requirements[0].result);
     assert!(!result.requirements[0].receiver_conditions[0].result);
@@ -1166,12 +1157,8 @@ fn cm_test_case_11_we() {
         None
     ));
     assert_valid_transfer!(ticker, owner_did, charlie, 100);
-    let result = ComplianceManager::granular_verify_restriction(
-        &ticker,
-        Some(owner_did),
-        Some(charlie),
-        None,
-    );
+    let result =
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(charlie));
     assert!(result.result);
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1193,7 +1180,7 @@ fn cm_test_case_11_we() {
 
     assert_invalid_transfer!(ticker, owner_did, dave, 100);
     let result =
-        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(dave), None);
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(dave));
     assert!(!result.result);
     assert!(!result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1215,7 +1202,7 @@ fn cm_test_case_11_we() {
 
     assert_valid_transfer!(ticker, owner_did, eve, 100);
     let result =
-        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve), None);
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve));
     assert!(result.result);
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1291,7 +1278,7 @@ fn cm_test_case_13_we() {
     ));
 
     assert_invalid_transfer!(ticker, owner_did, charlie, 100);
-    let result = ComplianceManager::granular_verify_restriction(&ticker, None, Some(charlie), None);
+    let result = ComplianceManager::granular_verify_restriction(&ticker, None, Some(charlie));
     assert!(!result.result);
     assert!(!result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1315,7 +1302,7 @@ fn cm_test_case_13_we() {
     );
 
     assert_invalid_transfer!(ticker, owner_did, dave, 100);
-    let result = ComplianceManager::granular_verify_restriction(&ticker, None, Some(dave), None);
+    let result = ComplianceManager::granular_verify_restriction(&ticker, None, Some(dave));
     assert!(!result.result);
     assert!(!result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1339,7 +1326,7 @@ fn cm_test_case_13_we() {
 
     assert_valid_transfer!(ticker, owner_did, eve, 100);
     let result =
-        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve), None);
+        ComplianceManager::granular_verify_restriction(&ticker, Some(owner_did), Some(eve));
     assert!(result.result);
     assert!(result.requirements[0].result);
     assert!(result.requirements[0].receiver_conditions[0].result);
@@ -1589,7 +1576,6 @@ fn check_new_return_type_of_rpc() {
             &ticker,
             Some(token_owner_did),
             Some(receiver_did),
-            None,
         );
 
         let expected_result = ImplicitRequirementResult {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1057,11 +1057,6 @@
                         "isOptional": false
                     },
                     {
-                        "name": "primary_issuance_agent",
-                        "type": "Option<IdentityId>",
-                        "isOptional": false
-                    },
-                    {
                         "name": "blockHash",
                         "type": "Hash",
                         "isOptional": true

--- a/rpc/runtime-api/src/compliance_manager.rs
+++ b/rpc/runtime-api/src/compliance_manager.rs
@@ -58,7 +58,6 @@ sp_api::decl_runtime_apis! {
             ticker: Ticker,
             from_did: Option<IdentityId>,
             to_did: Option<IdentityId>,
-            primary_issuance_agent: Option<IdentityId>,
         ) -> AssetComplianceResult;
     }
 }

--- a/rpc/src/compliance_manager.rs
+++ b/rpc/src/compliance_manager.rs
@@ -41,7 +41,6 @@ pub trait ComplianceManagerApi<BlockHash, AccountId, T> {
         ticker: Ticker,
         from_did: Option<IdentityId>,
         to_did: Option<IdentityId>,
-        primary_issuance_agent: Option<IdentityId>,
         at: Option<BlockHash>,
     ) -> Result<AssetComplianceResult>;
 }
@@ -78,7 +77,6 @@ where
         ticker: Ticker,
         from_did: Option<IdentityId>,
         to_did: Option<IdentityId>,
-        primary_issuance_agent: Option<IdentityId>,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<AssetComplianceResult> {
         let api = self.client.runtime_api();
@@ -86,7 +84,7 @@ where
                 // If the block hash is not supplied assume the best block.
                 self.client.info().best_hash));
 
-        api.can_transfer(&at, ticker, from_did, to_did, primary_issuance_agent)
+        api.can_transfer(&at, ticker, from_did, to_did)
             .map_err(|e| RpcError {
                 code: ErrorCode::ServerError(1),
                 message: "Unable to fetch transfer status from compliance manager.".into(),


### PR DESCRIPTION
The RPC no longer requires the user to input the PIA address. It is fetched from the asset module directly.