### PR TITLE
MESH-1270: Link Documentation to Corporate Actions

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1322,7 +1322,9 @@ decl_error! {
         /// checkpoints.
         FailedToComputeNextCheckpoint,
         /// The duration of a checkpoint period is too short.
-        CheckpointDurationTooShort
+        CheckpointDurationTooShort,
+        /// The given Document does not exist.
+        NoSuchDoc,
     }
 }
 
@@ -1442,6 +1444,15 @@ impl<T: Trait> Module<T> {
     /// Ensure that `ticker` is a valid created asset.
     fn ensure_asset_exists(ticker: &Ticker) -> DispatchResult {
         ensure!(<Tokens<T>>::contains_key(&ticker), Error::<T>::NoSuchAsset);
+        Ok(())
+    }
+
+    /// Ensure that the document `doc` exists for `ticker`.
+    pub fn ensure_doc_exists(ticker: &Ticker, doc: &DocumentName) -> DispatchResult {
+        ensure!(
+            AssetDocuments::contains_key(ticker, doc),
+            Error::<T>::NoSuchDoc
+        );
         Ok(())
     }
 

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -110,9 +110,9 @@ use polymesh_common_utilities::{
     CommonTrait, Context, SystematicIssuers,
 };
 use polymesh_primitives::{
-    calendar::CheckpointSchedule, AssetIdentifier, AuthorizationData, Document, DocumentName,
-    IdentityId, MetaVersion as ExtVersion, PortfolioId, ScopeId, Signatory, SmartExtension,
-    SmartExtensionName, SmartExtensionType, Ticker,
+    calendar::CheckpointSchedule, AssetIdentifier, AuthorizationData, Document, DocumentId,
+    DocumentName, IdentityId, MetaVersion as ExtVersion, PortfolioId, ScopeId, Signatory,
+    SmartExtension, SmartExtensionName, SmartExtensionType, Ticker,
 };
 use polymesh_primitives_derive::VecU8StrongTyped;
 use sp_runtime::traits::{CheckedAdd, SaturatedConversion, Saturating, Zero};
@@ -348,9 +348,12 @@ decl_storage! {
         pub AssetOwnershipRelations get(fn asset_ownership_relation):
             double_map hasher(twox_64_concat) IdentityId, hasher(blake2_128_concat) Ticker => AssetOwnershipRelation;
         /// Documents attached to an Asset
-        /// (ticker, document_name) -> document
+        /// (ticker, doc_id) -> document
         pub AssetDocuments get(fn asset_documents):
-            double_map hasher(blake2_128_concat) Ticker, hasher(blake2_128_concat) DocumentName => Document;
+            double_map hasher(blake2_128_concat) Ticker, hasher(blake2_128_concat) DocumentId => Document;
+        /// Per-ticker document ID counter.
+        /// (ticker) -> doc_id
+        pub AssetDocumentsIdSequence get(fn asset_documents_id_sequence): map hasher(blake2_128_concat) Ticker => DocumentId;
         /// Ticker registration details on Polymath Classic / Ethereum.
         pub ClassicTickers get(fn classic_ticker_registration): map hasher(blake2_128_concat) Ticker => Option<ClassicTickerRegistration>;
         /// Checkpoint schedules for tickers.
@@ -432,7 +435,26 @@ decl_module! {
         fn deposit_event() = default;
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {
-            <Identifiers>::remove_all();
+            Identifiers::remove_all();
+
+            // Migrate `AssetDocuments`.
+            use frame_support::Blake2_128Concat;
+            use polymesh_primitives::migrate::{migrate_double_map, Migrate};
+            use polymesh_primitives::document::DocumentOld;
+            use sp_std::collections::btree_map::BTreeMap;
+            let mut id_map = BTreeMap::<_, u32>::new();
+            migrate_double_map::<_, _, Blake2_128Concat, _, _, _, _, _>(
+                b"Assets", b"AssetDocuments",
+                |ticker: Ticker, name: DocumentName, doc: DocumentOld| {
+                    let count = id_map.entry(ticker).or_default();
+                    let id = DocumentId(mem::replace(count, *count + 1));
+                    Some((ticker, id, doc.migrate(name)?))
+                }
+            );
+            for (ticker, id) in id_map {
+                AssetDocumentsIdSequence::insert(ticker, DocumentId(id));
+            }
+
             1_000
         }
 
@@ -443,12 +465,11 @@ decl_module! {
         /// * `origin` It contains the secondary key of the caller (i.e who signed the transaction to execute this function).
         /// * `ticker` ticker to register.
         #[weight = T::DbWeight::get().reads_writes(4, 3) + 500_000_000]
-        pub fn register_ticker(origin, ticker: Ticker) -> DispatchResult {
-            let to_did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+        pub fn register_ticker(origin, ticker: Ticker) {
+            let to_did = Identity::<T>::ensure_perms(origin)?;
             let expiry = Self::ticker_registration_checks(&ticker, to_did, false, || Self::ticker_registration_config())?;
             T::ProtocolFee::charge_fee(ProtocolOp::AssetRegisterTicker)?;
             Self::_register_ticker(&ticker, to_did, expiry);
-            Ok(())
         }
 
         /// This function is used to accept a ticker transfer.
@@ -459,7 +480,7 @@ decl_module! {
         /// * `auth_id` Authorization ID of ticker transfer authorization.
         #[weight = T::DbWeight::get().reads_writes(4, 5) + 200_000_000]
         pub fn accept_ticker_transfer(origin, auth_id: u64) -> DispatchResult {
-            let to_did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+            let to_did = Identity::<T>::ensure_perms(origin)?;
             Self::_accept_ticker_transfer(to_did, auth_id)
         }
 
@@ -471,7 +492,7 @@ decl_module! {
         /// * `auth_id` Authorization ID of primary issuance agent transfer authorization.
         #[weight = 300_000_000]
         pub fn accept_primary_issuance_agent_transfer(origin, auth_id: u64) -> DispatchResult {
-            let to_did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+            let to_did = Identity::<T>::ensure_perms(origin)?;
             Self::_accept_primary_issuance_agent_transfer(to_did, auth_id)
         }
 
@@ -483,7 +504,7 @@ decl_module! {
         /// * `auth_id` Authorization ID of the token ownership transfer authorization.
         #[weight = T::DbWeight::get().reads_writes(4, 5) + 200_000_000]
         pub fn accept_asset_ownership_transfer(origin, auth_id: u64) -> DispatchResult {
-            let to_did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+            let to_did = Identity::<T>::ensure_perms(origin)?;
             Self::_accept_token_ownership_transfer(to_did, auth_id)
         }
 
@@ -514,7 +535,7 @@ decl_module! {
             identifiers: Vec<AssetIdentifier>,
             funding_round: Option<FundingRoundName>,
         ) -> DispatchResult {
-            let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+            let did = Identity::<T>::ensure_perms(origin)?;
             Self::ensure_create_asset_parameters(&ticker, total_supply)?;
 
             // Ensure its registered by DID or at least expired, thus available.
@@ -627,14 +648,13 @@ decl_module! {
         /// * `origin` - the secondary key of the sender.
         /// * `ticker` - the ticker of the token.
         #[weight = T::DbWeight::get().reads_writes(4, 1) + 300_000_000]
-        pub fn freeze(origin, ticker: Ticker) -> DispatchResult {
+        pub fn freeze(origin, ticker: Ticker) {
             // Verify the ownership of the token
             let sender_did = Self::ensure_perms_owner(origin, &ticker)?;
             Self::ensure_asset_exists(&ticker)?;
             ensure!(!Self::frozen(&ticker), Error::<T>::AlreadyFrozen);
             Frozen::insert(&ticker, true);
             Self::deposit_event(RawEvent::AssetFrozen(sender_did, ticker));
-            Ok(())
         }
 
         /// Unfreezes transfers and minting of a given token.
@@ -643,14 +663,13 @@ decl_module! {
         /// * `origin` - the secondary key of the sender.
         /// * `ticker` - the ticker of the frozen token.
         #[weight = T::DbWeight::get().reads_writes(4, 1) + 300_000_000]
-        pub fn unfreeze(origin, ticker: Ticker) -> DispatchResult {
+        pub fn unfreeze(origin, ticker: Ticker) {
             // Verify the ownership of the token
             let sender_did = Self::ensure_perms_owner(origin, &ticker)?;
             Self::ensure_asset_exists(&ticker)?;
             ensure!(Self::frozen(&ticker), Error::<T>::NotFrozen);
             Frozen::insert(&ticker, false);
             Self::deposit_event(RawEvent::AssetUnfrozen(sender_did, ticker));
-            Ok(())
         }
 
         /// Renames a given token.
@@ -660,13 +679,12 @@ decl_module! {
         /// * `ticker` - the ticker of the token.
         /// * `name` - the new name of the token.
         #[weight = T::DbWeight::get().reads_writes(2, 1) + 300_000_000]
-        pub fn rename_asset(origin, ticker: Ticker, name: AssetName) -> DispatchResult {
+        pub fn rename_asset(origin, ticker: Ticker, name: AssetName) {
             // Verify the ownership of the token
             let sender_did = Self::ensure_perms_owner(origin, &ticker)?;
             Self::ensure_asset_exists(&ticker)?;
             <Tokens<T>>::mutate(&ticker, |token| token.name = name.clone());
             Self::deposit_event(RawEvent::AssetRenamed(sender_did, ticker, name));
-            Ok(())
         }
 
         /// Creates a single checkpoint.
@@ -699,7 +717,7 @@ decl_module! {
             origin,
             ticker: Ticker,
             schedule: CheckpointSchedule
-        ) -> DispatchResult {
+        ) {
             let primary_did = Self::ensure_perms_owner(origin, &ticker)?;
             ensure!(
                 !CheckpointSchedules::contains_key(&ticker),
@@ -736,7 +754,6 @@ decl_module! {
                 primary_did,
                 schedule,
             ));
-            Ok(())
         }
 
         /// Removes the checkpoint schedule of an asset. Can only be called by the token owner
@@ -752,7 +769,7 @@ decl_module! {
         pub fn remove_checkpoint_schedule(
             origin,
             ticker: Ticker,
-        ) -> DispatchResult {
+        ) {
             let primary_did = Self::ensure_perms_owner(origin, &ticker)?;
             ensure!(
                 CheckpointSchedules::contains_key(&ticker),
@@ -767,7 +784,6 @@ decl_module! {
                 primary_did,
                 schedule,
             ));
-            Ok(())
         }
 
         /// Function is used to issue(or mint) new tokens to the primary issuance agent.
@@ -802,8 +818,8 @@ decl_module! {
         /// - `InvalidGranularity` If the amount is not divisible by 10^6 for non-divisible tokens
         /// - `InsufficientPortfolioBalance` If the PIA's default portfolio doesn't have enough free balance
         #[weight = T::DbWeight::get().reads_writes(6, 3) + 800_000_000]
-        pub fn redeem(origin, ticker: Ticker, value: T::Balance) -> DispatchResult {
-            let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+        pub fn redeem(origin, ticker: Ticker, value: T::Balance) {
+            let did = Identity::<T>::ensure_perms(origin)?;
 
             // Ensure that the sender is the PIA or the token owner and returns the PIA address.
             let pia = Self::ensure_pia_or_owner(&ticker, did)?;
@@ -852,8 +868,6 @@ decl_module! {
                 pia,
                 value
             ));
-
-            Ok(())
         }
 
         /// Makes an indivisible token divisible. Only called by the token owner.
@@ -862,7 +876,7 @@ decl_module! {
         /// * `origin` Secondary key of the token owner.
         /// * `ticker` Ticker of the token.
         #[weight = T::DbWeight::get().reads_writes(2, 1) + 300_000_000]
-        pub fn make_divisible(origin, ticker: Ticker) -> DispatchResult {
+        pub fn make_divisible(origin, ticker: Ticker) {
             let did = Self::ensure_perms_owner(origin, &ticker)?;
             // Read the token details
             let mut token = Self::token_details(&ticker);
@@ -870,7 +884,6 @@ decl_module! {
             token.divisible = true;
             <Tokens<T>>::insert(&ticker, token);
             Self::deposit_event(RawEvent::DivisibilityChanged(did, ticker, true));
-            Ok(())
         }
 
         /// Add documents for a given token. To be called only by the token owner.
@@ -878,24 +891,23 @@ decl_module! {
         /// # Arguments
         /// * `origin` Secondary key of the token owner.
         /// * `ticker` Ticker of the token.
-        /// * `documents` Documents to be attached to `ticker`.
+        /// * `docs` Documents to be attached to `ticker`.
         ///
         /// # Weight
-        /// `500_000_000 + 600_000 * documents.len()`
-        #[weight = T::DbWeight::get().reads_writes(2, 1) + 500_000_000 + 600_000 * u64::try_from(documents.len()).unwrap_or_default()]
-        pub fn add_documents(origin, documents: Vec<(DocumentName, Document)>, ticker: Ticker) -> DispatchResult {
-            let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+        /// `500_000_000 + 600_000 * docs.len()`
+        #[weight = T::DbWeight::get().reads_writes(2, 1) + 500_000_000 + 600_000 * u64::try_from(docs.len()).unwrap_or_default()]
+        pub fn add_documents(origin, docs: Vec<Document>, ticker: Ticker) {
+            let did = Self::ensure_perms_owner(origin, &ticker)?;
+            let len = docs.len();
+            T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocument, len)?;
 
-            ensure!(Self::is_owner(&ticker, did), Error::<T>::NotAnOwner);
-
-            T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocument, documents.len())?;
-
-            for (document_name, document) in documents {
-                <AssetDocuments>::insert(ticker, &document_name, document.clone());
-                Self::deposit_event(RawEvent::DocumentAdded(ticker, document_name, document));
-            }
-
-            Ok(())
+            AssetDocumentsIdSequence::mutate(ticker, |DocumentId(ref mut id)| {
+                for (id, doc) in (*id..).map(DocumentId).zip(docs) {
+                    AssetDocuments::insert(ticker, id, doc.clone());
+                    Self::deposit_event(RawEvent::DocumentAdded(did, ticker, id, doc));
+                }
+                *id += len as u32;
+            });
         }
 
         /// Remove documents for a given token. To be called only by the token owner.
@@ -903,21 +915,17 @@ decl_module! {
         /// # Arguments
         /// * `origin` Secondary key of the token owner.
         /// * `ticker` Ticker of the token.
-        /// * `doc_names` Documents to be removed from `ticker`.
+        /// * `ids` Documents ids to be removed from `ticker`.
         ///
         /// # Weight
-        /// `500_000_000 + 600_000 * do_ids.len()`
-        #[weight = T::DbWeight::get().reads_writes(2, 1) + 500_000_000 + 600_000 * u64::try_from(doc_names.len()).unwrap_or_default()]
-        pub fn remove_documents(origin, doc_names: Vec<DocumentName>, ticker: Ticker) -> DispatchResult {
-            let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
-            ensure!(Self::is_owner(&ticker, did), Error::<T>::NotAnOwner);
-
-            for document_name in doc_names {
-                <AssetDocuments>::remove(ticker, &document_name);
-                Self::deposit_event(RawEvent::DocumentRemoved(ticker, document_name));
+        /// `500_000_000 + 600_000 * ids.len()`
+        #[weight = T::DbWeight::get().reads_writes(2, 1) + 500_000_000 + 600_000 * u64::try_from(ids.len()).unwrap_or_default()]
+        pub fn remove_documents(origin, ids: Vec<DocumentId>, ticker: Ticker) {
+            let did = Self::ensure_perms_owner(origin, &ticker)?;
+            for id in ids {
+                AssetDocuments::remove(ticker, id);
+                Self::deposit_event(RawEvent::DocumentRemoved(did, ticker, id));
             }
-
-            Ok(())
         }
 
         /// Sets the name of the current funding round.
@@ -927,14 +935,10 @@ decl_module! {
         /// * `ticker` - the ticker of the token.
         /// * `name` - the desired name of the current funding round.
         #[weight = T::DbWeight::get().reads_writes(2, 1) + 600_000_000]
-        pub fn set_funding_round(origin, ticker: Ticker, name: FundingRoundName) ->
-            DispatchResult
-        {
-            let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
-            ensure!(Self::is_owner(&ticker, did), Error::<T>::NotAnOwner);
-            <FundingRound>::insert(ticker, name.clone());
+        pub fn set_funding_round(origin, ticker: Ticker, name: FundingRoundName) {
+            let did = Self::ensure_perms_owner(origin, &ticker)?;
+            FundingRound::insert(ticker, name.clone());
             Self::deposit_event(RawEvent::FundingRoundSet(did, ticker, name));
-            Ok(())
         }
 
         /// Updates the asset identifiers. Can only be called by the token owner.
@@ -952,15 +956,14 @@ decl_module! {
             origin,
             ticker: Ticker,
             identifiers: Vec<AssetIdentifier>
-        ) -> DispatchResult {
+        ) {
             let did = Self::ensure_perms_owner(origin, &ticker)?;
             let identifiers: Vec<AssetIdentifier> = identifiers
                 .into_iter()
                 .filter_map(|identifier| identifier.validate())
                 .collect();
-            <Identifiers>::insert(ticker, identifiers.clone());
+            Identifiers::insert(ticker, identifiers.clone());
             Self::deposit_event(RawEvent::IdentifiersUpdated(did, ticker, identifiers));
-            Ok(())
         }
 
         /// Permissioning the Smart-Extension address for a given ticker.
@@ -970,7 +973,7 @@ decl_module! {
         /// * `ticker` - ticker for whom extension get added.
         /// * `extension_details` - Details of the smart extension.
         #[weight = T::DbWeight::get().reads_writes(2, 2) + 600_000_000]
-        pub fn add_extension(origin, ticker: Ticker, extension_details: SmartExtension<T::AccountId>) -> DispatchResult {
+        pub fn add_extension(origin, ticker: Ticker, extension_details: SmartExtension<T::AccountId>) {
             let my_did = Self::ensure_perms_owner(origin, &ticker)?;
 
             // Verify the details of smart extension & store it
@@ -986,7 +989,6 @@ decl_module! {
                 ids.push(extension_details.extension_id.clone())
             });
             Self::deposit_event(RawEvent::ExtensionAdded(my_did, ticker, extension_details.extension_id, extension_details.extension_name, extension_details.extension_type));
-            Ok(())
         }
 
         /// Archived the extension. Extension is use to verify the compliance or any smart logic it posses.
@@ -996,7 +998,7 @@ decl_module! {
         /// * `ticker` - Ticker symbol of the asset.
         /// * `extension_id` - AccountId of the extension that need to be archived.
         #[weight = T::DbWeight::get().reads_writes(3, 1) + 800_000_000]
-        pub fn archive_extension(origin, ticker: Ticker, extension_id: T::AccountId) -> DispatchResult {
+        pub fn archive_extension(origin, ticker: Ticker, extension_id: T::AccountId) {
             // Ensure the extrinsic is signed and have valid extension id.
             let did = Self::ensure_signed_and_validate_extension_id(origin, &ticker, &extension_id)?;
 
@@ -1004,7 +1006,6 @@ decl_module! {
             ensure!(!(<ExtensionDetails<T>>::get((ticker, &extension_id))).is_archive, Error::<T>::AlreadyArchived);
             <ExtensionDetails<T>>::mutate((ticker, &extension_id), |details| details.is_archive = true);
             Self::deposit_event(RawEvent::ExtensionArchived(did, ticker, extension_id));
-            Ok(())
         }
 
         /// Un-archived the extension. Extension is use to verify the compliance or any smart logic it posses.
@@ -1014,7 +1015,7 @@ decl_module! {
         /// * `ticker` - Ticker symbol of the asset.
         /// * `extension_id` - AccountId of the extension that need to be un-archived.
         #[weight = T::DbWeight::get().reads_writes(2, 2) + 800_000_000]
-        pub fn unarchive_extension(origin, ticker: Ticker, extension_id: T::AccountId) -> DispatchResult {
+        pub fn unarchive_extension(origin, ticker: Ticker, extension_id: T::AccountId) {
             // Ensure the extrinsic is signed and have valid extension id.
             let did = Self::ensure_signed_and_validate_extension_id(origin, &ticker, &extension_id)?;
 
@@ -1022,7 +1023,6 @@ decl_module! {
             ensure!((<ExtensionDetails<T>>::get((ticker, &extension_id))).is_archive, Error::<T>::AlreadyUnArchived);
             <ExtensionDetails<T>>::mutate((ticker, &extension_id), |details| details.is_archive = false);
             Self::deposit_event(RawEvent::ExtensionUnArchived(did, ticker, extension_id));
-            Ok(())
         }
 
         /// Sets the primary issuance agent to None. The caller must be the asset issuer. The asset
@@ -1038,11 +1038,10 @@ decl_module! {
         pub fn remove_primary_issuance_agent(
             origin,
             ticker: Ticker,
-        ) -> DispatchResult {
+        ) {
             let did = Self::ensure_perms_owner(origin, &ticker)?;
             let old_pia = <Tokens<T>>::mutate(&ticker, |t| mem::replace(&mut t.primary_issuance_agent, None));
             Self::deposit_event(RawEvent::PrimaryIssuanceAgentTransferred(did, ticker, old_pia, None));
-            Ok(())
         }
 
         /// Remove the given smart extension id from the list of extension under a given ticker.
@@ -1051,7 +1050,7 @@ decl_module! {
         /// * `origin` - The asset issuer.
         /// * `ticker` - Ticker symbol of the asset.
         #[weight = 250_000_000]
-        pub fn remove_smart_extension(origin, ticker: Ticker, extension_id: T::AccountId) -> DispatchResult {
+        pub fn remove_smart_extension(origin, ticker: Ticker, extension_id: T::AccountId) {
             // Ensure the extrinsic is signed and have valid extension id.
             let did = Self::ensure_signed_and_validate_extension_id(origin, &ticker, &extension_id)?;
 
@@ -1065,7 +1064,6 @@ decl_module! {
             });
             <ExtensionDetails<T>>::remove((&ticker, &extension_id));
             Self::deposit_event(RawEvent::ExtensionRemoved(did, ticker, extension_id));
-            Ok(())
         }
 
         /// Claim a systematically reserved Polymath Classic (PMC) `ticker`
@@ -1083,7 +1081,7 @@ decl_module! {
         /// - `InvalidEthereumSignature` if the `ethereum_signature` is not valid.
         /// - `NotAnOwner` if the ethereum account is not the owner of the PMC ticker.
         #[weight = 250_000_000]
-        pub fn claim_classic_ticker(origin, ticker: Ticker, ethereum_signature: ethereum::EcdsaSignature) -> DispatchResult {
+        pub fn claim_classic_ticker(origin, ticker: Ticker, ethereum_signature: ethereum::EcdsaSignature) {
             // Ensure the ticker is a classic one and fetch details.
             let ClassicTickerRegistration { eth_owner, .. } = ClassicTickers::get(ticker)
                 .ok_or(Error::<T>::NoSuchClassicTicker)?;
@@ -1097,7 +1095,7 @@ decl_module! {
             }
 
             // Ensure we're signed & get did.
-            let owner_did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
+            let owner_did = Identity::<T>::ensure_perms(origin)?;
 
             // Have the caller prove that they own *some* Ethereum account
             // by having the signed signature contain the `owner_did`.
@@ -1117,8 +1115,6 @@ decl_module! {
 
             // Emit event.
             Self::deposit_event(RawEvent::ClassicTickerClaimed(owner_did, ticker, eth_signer));
-
-            Ok(())
         }
     }
 }
@@ -1201,9 +1197,9 @@ decl_event! {
         /// First DID is the old primary issuance agent and the second DID is the new primary issuance agent.
         PrimaryIssuanceAgentTransferred(IdentityId, Ticker, Option<IdentityId>, Option<IdentityId>),
         /// A new document attached to an asset
-        DocumentAdded(Ticker, DocumentName, Document),
+        DocumentAdded(IdentityId, Ticker, DocumentId, Document),
         /// A document removed from an asset
-        DocumentRemoved(Ticker, DocumentName),
+        DocumentRemoved(IdentityId, Ticker, DocumentId),
         /// A extension got removed.
         /// caller DID, ticker, AccountId
         ExtensionRemoved(IdentityId, Ticker, AccountId),
@@ -1448,7 +1444,7 @@ impl<T: Trait> Module<T> {
     }
 
     /// Ensure that the document `doc` exists for `ticker`.
-    pub fn ensure_doc_exists(ticker: &Ticker, doc: &DocumentName) -> DispatchResult {
+    pub fn ensure_doc_exists(ticker: &Ticker, doc: &DocumentId) -> DispatchResult {
         ensure!(
             AssetDocuments::contains_key(ticker, doc),
             Error::<T>::NoSuchDoc

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -53,7 +53,7 @@ use polymesh_common_utilities::{
     identity::{IdentityToCorporateAction, Trait as IdentityTrait},
     GC_DID,
 };
-use polymesh_primitives::{AuthorizationData, DocumentName, IdentityId, Moment, Ticker};
+use polymesh_primitives::{AuthorizationData, DocumentId, IdentityId, Moment, Ticker};
 use polymesh_primitives_derive::VecU8StrongTyped;
 use sp_arithmetic::Permill;
 #[cfg(feature = "std")]
@@ -247,11 +247,11 @@ decl_storage! {
             double_map hasher(blake2_128_concat) Ticker, hasher(blake2_128_concat) LocalCAId => Option<CorporateAction>;
 
         /// Associations from CAs to `Document`s via their IDs.
-        /// (CAId => [DocumentName])
+        /// (CAId => [DocumentId])
         ///
         /// The `CorporateActions` map stores `Ticker => LocalId => The CA`,
         /// so we can infer `Ticker => CAId`. Therefore, we don't need a double map.
-        pub CADocLink get(fn ca_doc_link): map hasher(blake2_128_concat) CAId => Vec<DocumentName>;
+        pub CADocLink get(fn ca_doc_link): map hasher(blake2_128_concat) CAId => Vec<DocumentId>;
     }
 }
 
@@ -449,7 +449,7 @@ decl_module! {
         /// - `NoSuchCA` if `id` does not identify an existing CA.
         /// - `NoSuchDoc` if any of `docs` does not identify an existing document.
         #[weight = <T as Trait>::WeightInfo::link_ca_doc(docs.len() as u32)]
-        pub fn link_ca_doc(origin, id: CAId, docs: Vec<DocumentName>) {
+        pub fn link_ca_doc(origin, id: CAId, docs: Vec<DocumentId>) {
             // Ensure that CAA is calling and that CA and the docs exists.
             let caa = Self::ensure_ca_agent(origin, id.ticker)?;
             Self::ensure_ca_exists(id)?;
@@ -496,7 +496,7 @@ decl_event! {
         ),
         /// A CA was linked to a set of docs.
         /// (CAA, CA Id, List of doc identifiers)
-        CALinkedToDoc(IdentityId, CAId, Vec<DocumentName>),
+        CALinkedToDoc(IdentityId, CAId, Vec<DocumentId>),
     }
 }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -261,7 +261,7 @@ decl_module! {
             use polymesh_primitives::{
                 identity_claim::IdentityClaimOld,
                 identity::IdentityOld,
-                migrate::{migrate_map,  migrate_double_map_keys, Empty},
+                migrate::{migrate_map,  migrate_double_map, Empty},
             };
             use polymesh_common_utilities::traits::identity::runtime_upgrade::LinkedKeyInfo;
 
@@ -275,12 +275,13 @@ decl_module! {
             });
 
             // Covert old scopes to new scopes
-            migrate_double_map_keys::<IdentityClaim, Blake2_128Concat, _, _, _, _, _>(
+            migrate_double_map::<_, _, Blake2_128Concat, _, _, _, _, _>(
                 b"Identity", b"Claims",
-                |k1: Claim1stKey, k2: Claim2ndKeyOld| (
+                |k1: Claim1stKey, k2: Claim2ndKeyOld, val: IdentityClaim| Some((
                     k1,
-                    Claim2ndKey { issuer: k2.issuer, scope: k2.scope.map(Scope::Identity) }
-                )
+                    Claim2ndKey { issuer: k2.issuer, scope: k2.scope.map(Scope::Identity) },
+                    val
+                ))
             );
 
             migrate_map::<LinkedKeyInfo, _>(

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -33,7 +33,7 @@ use polymesh_common_utilities::{
 use polymesh_contracts::NonceBasedAddressDeterminer;
 use polymesh_primitives::{
     calendar::{CalendarPeriod, CalendarUnit, CheckpointSchedule, FixedOrVariableCalendarUnit},
-    AssetIdentifier, AuthorizationData, Claim, Condition, ConditionType, Document, DocumentName,
+    AssetIdentifier, AuthorizationData, Claim, Condition, ConditionType, Document, DocumentId,
     IdentityId, InvestorUid, PortfolioId, Signatory, SmartExtension, SmartExtensionType, Ticker,
 };
 use rand::Rng;
@@ -949,20 +949,20 @@ fn adding_removing_documents() {
         ));
 
         let documents = vec![
-            (
-                b"A".into(),
-                Document {
-                    uri: b"www.a.com".into(),
-                    content_hash: b"0x1".into(),
-                },
-            ),
-            (
-                b"B".into(),
-                Document {
-                    uri: b"www.b.com".into(),
-                    content_hash: b"0x2".into(),
-                },
-            ),
+            Document {
+                name: b"A".into(),
+                uri: b"www.a.com".into(),
+                content_hash: b"0x1".into(),
+                doc_type: Some(b"foo".into()),
+                filing_date: Some(42),
+            },
+            Document {
+                name: b"B".into(),
+                uri: b"www.b.com".into(),
+                content_hash: b"0x2".into(),
+                doc_type: None,
+                filing_date: None,
+            },
         ];
 
         assert_ok!(Asset::add_documents(
@@ -971,18 +971,12 @@ fn adding_removing_documents() {
             ticker
         ));
 
-        assert_eq!(
-            Asset::asset_documents(ticker, DocumentName::from(b"A")),
-            documents[0].1
-        );
-        assert_eq!(
-            Asset::asset_documents(ticker, DocumentName::from(b"B")),
-            documents[1].1
-        );
+        assert_eq!(Asset::asset_documents(ticker, DocumentId(0)), documents[0]);
+        assert_eq!(Asset::asset_documents(ticker, DocumentId(1)), documents[1]);
 
         assert_ok!(Asset::remove_documents(
             owner_signed.clone(),
-            vec![b"A".into(), b"B".into()],
+            (0..=1).map(DocumentId).collect(),
             ticker
         ));
 

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1559,7 +1559,7 @@ decl_module! {
 
             if StorageVersion::get() == Releases::V4_0_0 {
                 migrate_map_keys_and_value::<_,_,Twox64Concat,T::AccountId,IdentityId,_>(b"Staking", b"PermissionedValidators", b"PermissionedIdentity", |k: T::AccountId, v: bool| {
-                    (<Identity<T>>::get_identity(&k).unwrap_or_default(), v)
+                    Some((<Identity<T>>::get_identity(&k).unwrap_or_default(), v))
                 });
 
                 // Sets the value for `ValidatorCommissionCap` from the old storage variant i.e `ValidatorCommission`.

--- a/pallets/weights/src/pallet_corporate_actions.rs
+++ b/pallets/weights/src/pallet_corporate_actions.rs
@@ -20,4 +20,7 @@ impl pallet_corporate_actions::WeightInfo for WeightInfo {
     fn initiate_corporate_action() -> Weight {
         999_999_999_999
     }
+    fn link_ca_doc(_: u32) -> Weight {
+        999_999_999_999
+    }
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -6,6 +6,7 @@
         "CddId": "[u8; 32]",
         "ScopeId": "[u8; 32]",
         "PosRatio": "(u32, u32)",
+        "DocumentId": "u32",
         "DocumentName": "Text",
         "DocumentUri": "Text",
         "DocumentHash": "Text",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -214,7 +214,7 @@ pub use smart_extension::{
 };
 
 pub mod document;
-pub use document::{Document, DocumentHash, DocumentName, DocumentUri};
+pub use document::{Document, DocumentHash, DocumentId, DocumentName, DocumentUri};
 
 /// Rules for claims.
 pub mod condition;

--- a/primitives/src/migrate.rs
+++ b/primitives/src/migrate.rs
@@ -17,7 +17,7 @@
 
 use codec::{Decode, Encode};
 use frame_support::migration::{put_storage_value, StorageIterator, StorageKeyIterator};
-use frame_support::ReversibleStorageHasher;
+use frame_support::{ReversibleStorageHasher, StorageHasher};
 use sp_std::vec::Vec;
 
 /// A data type which is migrating through `migrate` to a new type as defined by `Into`.
@@ -96,7 +96,7 @@ pub fn migrate_map_keys_and_value<VO, VN, H, KO, KN, F>(
     new_item: &[u8],
     mut map: F,
 ) where
-    F: FnMut(KO, VO) -> (KN, VN),
+    F: FnMut(KO, VO) -> Option<(KN, VN)>,
     VO: Decode + Encode,
     VN: Encode + Decode,
     H: ReversibleStorageHasher,
@@ -105,7 +105,7 @@ pub fn migrate_map_keys_and_value<VO, VN, H, KO, KN, F>(
 {
     StorageKeyIterator::<KO, VO, H>::new(module, item)
         .drain()
-        .map(|(key, val)| map(key, val))
+        .filter_map(|(key, val)| map(key, val))
         .for_each(|(kn, vn)| {
             let kn = kn.using_encoded(H::hash);
             let kn = kn.as_ref();
@@ -113,38 +113,55 @@ pub fn migrate_map_keys_and_value<VO, VN, H, KO, KN, F>(
         })
 }
 
-/// Migrate the keys of a double map `K1, K2` to keys of type `KN1, KN2` via `map`.
-/// The double map is located in `module::item` and the value of type `V` is ontouched.
+/// Decode, if possible, the keys of a double map,
+/// with K1 & K2 as keys, hashed with `H`, from `raw`.
+pub fn decode_double_key<H: ReversibleStorageHasher, K1: Decode, K2: Decode>(
+    raw: &[u8],
+) -> Option<(K1, K2)> {
+    let mut unhashed_key = H::reverse(&raw);
+    let k1 = K1::decode(&mut unhashed_key).ok()?;
+    let mut raw_k2 = H::reverse(unhashed_key);
+    let k2 = K2::decode(&mut raw_k2).ok()?;
+    Some((k1, k2))
+}
+
+/// Encode keys of a double map `k1` & `k2` using hasher `H`.
+pub fn encode_double_key<H: StorageHasher, K1: Encode, K2: Encode>(k1: K1, k2: K2) -> Vec<u8> {
+    let k1 = k1.using_encoded(H::hash);
+    let k2 = k2.using_encoded(H::hash);
+    let k1 = k1.as_ref();
+    let k2 = k2.as_ref();
+    let mut key = Vec::with_capacity(k1.len() + k2.len());
+    key.extend_from_slice(k1);
+    key.extend_from_slice(k2);
+    key
+}
+
+/// Migrate the keys and values of a double map `K1, K2` + `V1` to
+/// keys and values of type `KN1, KN2` + `V2` via `map`.
+/// The `map` function may fail, in which entries are dropped silently.
+/// The double map is located in `module::item`.
 /// This assumes that the hashers are all the same, which is the common case.
-pub fn migrate_double_map_keys<V, H, K1, K2, KN1, KN2, F>(module: &[u8], item: &[u8], mut map: F)
+pub fn migrate_double_map<V1, V2, H, K1, K2, KN1, KN2, F>(module: &[u8], item: &[u8], mut map: F)
 where
-    F: FnMut(K1, K2) -> (KN1, KN2),
-    V: Decode + Encode,
+    F: FnMut(K1, K2, V1) -> Option<(KN1, KN2, V2)>,
+    V1: Decode,
+    V2: Encode,
     H: ReversibleStorageHasher,
     K1: Decode,
     K2: Decode,
     KN1: Encode,
     KN2: Encode,
 {
-    let old_map = StorageIterator::<V>::new(module, item)
+    let old_map = StorageIterator::<V1>::new(module, item)
         .drain()
         .collect::<Vec<(Vec<u8>, _)>>();
 
-    for (raw_key, value) in old_map.iter() {
-        let mut unhashed_key = H::reverse(&raw_key);
-        if let Ok(k1) = K1::decode(&mut unhashed_key) {
-            let mut raw_k2 = H::reverse(unhashed_key);
-            if let Ok(k2) = K2::decode(&mut raw_k2) {
-                let (kn1, kn2) = map(k1, k2);
-                let kn1 = kn1.using_encoded(H::hash);
-                let kn2 = kn2.using_encoded(H::hash);
-                let kn1 = kn1.as_ref();
-                let kn2 = kn2.as_ref();
-                let mut key = Vec::with_capacity(kn1.len() + kn2.len());
-                key.extend_from_slice(kn1);
-                key.extend_from_slice(kn2);
-                put_storage_value(module, item, &key, value);
-            }
-        }
+    for (key, value) in old_map.into_iter().filter_map(|(raw_key, value)| {
+        let (k1, k2) = decode_double_key::<H, _, _>(&raw_key)?;
+        let (kn1, kn2, value) = map(k1, k2, value)?;
+        Some((encode_double_key::<H, _, _>(kn1, kn2), value))
+    }) {
+        put_storage_value(module, item, &key, value);
     }
 }

--- a/primitives_derive/src/migrate.rs
+++ b/primitives_derive/src/migrate.rs
@@ -155,6 +155,7 @@ pub(crate) fn impl_migrate(mut input: DeriveInput) -> TokenStream2 {
         #where_clause {
             type Into = #name #ty_generics;
             type Context = #context;
+            #[allow(unused_variables)]
             fn migrate(self, context: Self::Context) -> Option<Self::Into> { Some(#migration) }
         }
     }


### PR DESCRIPTION
- `DocumentName` as a key is moved towards `DocumentId`.
- Also some misc refactoring.