### PR TITLE
Mesh 1335/Implicit requirement should not be paused

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1614,6 +1614,14 @@ impl<T: Trait> Module<T> {
             return Ok((ERC1400_TRANSFERS_HALTED, T::DbWeight::get().reads(1)));
         }
 
+        if !Identity::<T>::verify_scope_claims_for_transfer(
+            ticker,
+            from_portfolio.did,
+            to_portfolio.did,
+        ) {
+            return Ok((SCOPE_CLAIM_MISSING, T::DbWeight::get().reads(2)));
+        }
+
         if Portfolio::<T>::ensure_portfolio_transfer_validity(
             &from_portfolio,
             &to_portfolio,
@@ -2184,6 +2192,14 @@ impl<T: Trait> Module<T> {
 
         if !Identity::<T>::has_valid_cdd(from_portfolio.did) {
             return Ok(INVALID_SENDER_DID);
+        }
+
+        if !Identity::<T>::verify_scope_claims_for_transfer(
+            ticker,
+            from_portfolio.did,
+            to_portfolio.did,
+        ) {
+            return Ok(SCOPE_CLAIM_MISSING);
         }
 
         if Portfolio::<T>::ensure_portfolio_custody(

--- a/pallets/common/src/constants.rs
+++ b/pallets/common/src/constants.rs
@@ -57,6 +57,7 @@ pub const APP_FUNDS_LOCKED: u8 = 0xa7;
 pub const APP_FUNDS_LIMIT_REACHED: u8 = 0xa8;
 pub const PORTFOLIO_FAILURE: u8 = 0xa9;
 pub const CUSTODIAN_ERROR: u8 = 0xb0;
+pub const SCOPE_CLAIM_MISSING: u8 = 0xb1;
 
 // PIP pallet constants.
 pub const PIP_MAX_REPORTING_SIZE: usize = 1024;

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -571,9 +571,9 @@ impl<T: Trait> Module<T> {
         primary_issuance_agent: Option<IdentityId>,
     ) -> proposition::Context<impl 'a + Iterator<Item = Claim>> {
         // Because of `-> impl Iterator`, we need to return a **single type** in each of the branches below.
-        // To do this, we use `Either<Either<MatchArm1, MatchArm2>, Either<MatchArm3, MatchArm4>>`,
-        // equivalent to a 4-variant enum with iterators in each variant corresponding to the branches below.
-        // For example, `Left(Left(arm1))` and `Right(Left(arm3))` correspond to arms 1 and 3 respectively.
+        // To do this, we use `Either<Either<MatchArm1, MatchArm2>, MatchArm3>`,
+        // equivalent to a 3-variant enum with iterators in each variant corresponding to the branches below.
+        // `Left(Left(arm1))`, `Left(Right(arm2))` and `Right(arm3)` correspond to arms 1, 2 and 3 respectively.
         use either::Either::{Left, Right};
 
         let claims = match &condition.condition_type {

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -91,8 +91,7 @@ use polymesh_common_utilities::{
     protocol_fee::{ChargeProtocolFee, ProtocolOp},
 };
 use polymesh_primitives::{
-    proposition, Claim, ClaimType, Condition, ConditionType, IdentityId, Scope, Ticker,
-    TrustedIssuer,
+    proposition, Claim, Condition, ConditionType, IdentityId, Ticker, TrustedIssuer,
 };
 use polymesh_primitives_derive::Migrate;
 
@@ -210,16 +209,6 @@ pub struct AssetCompliance {
     pub requirements: Vec<ComplianceRequirement>,
 }
 
-/// Implicit requirement result.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct ImplicitRequirementResult {
-    /// Result of implicit condition for the sender of the extrinsic.
-    pub from_result: bool,
-    /// Result of implicit condition for the receiver of the extrinsic.
-    pub to_result: bool,
-}
-
 type Identity<T> = identity::Module<T>;
 
 /// Asset compliance and it's evaluation result
@@ -230,14 +219,6 @@ pub struct AssetComplianceResult {
     pub paused: bool,
     /// List of compliance requirements.
     pub requirements: Vec<ComplianceRequirementResult>,
-    /// It is treated differently from other compliance requirements because
-    /// it doesn't successfully execute the transaction even if it succeed. As txn
-    /// also depends on the successful verification of one of the `requirement` set by
-    /// the asset issuer. But it can fail the txn if it gets failed independently from
-    /// the result of other requirements.
-    ///
-    /// Implicit requirements result.
-    pub implicit_requirements_result: ImplicitRequirementResult,
     // Final evaluation result of the asset compliance
     pub result: bool,
 }
@@ -251,8 +232,7 @@ impl From<AssetCompliance> for AssetComplianceResult {
                 .into_iter()
                 .map(ComplianceRequirementResult::from)
                 .collect(),
-            implicit_requirements_result: ImplicitRequirementResult::default(),
-            result: false,
+            result: asset_compliance.paused,
         }
     }
 }
@@ -566,18 +546,6 @@ impl<T: Trait> Module<T> {
             })
     }
 
-    /// It fetches the `ConfidentialScopeClaim` of users `id` for the given ticker.
-    /// Note that this vector could be 0 or 1 items.
-    fn fetch_confidential_claims(id: IdentityId, ticker: &Ticker) -> impl Iterator<Item = Claim> {
-        let claim_type = ClaimType::InvestorUniqueness;
-        // NOTE: Ticker length is less by design that IdentityId.
-        let asset_scope = Scope::from(*ticker);
-
-        <identity::Module<T>>::fetch_claim(id, claim_type, id, Some(asset_scope))
-            .into_iter()
-            .map(|id_claim| id_claim.claim)
-    }
-
     /// Returns trusted issuers specified in `condition` if any,
     /// or otherwise returns the default trusted issuers for `ticker`.
     /// Defaults are cached in `slot`.
@@ -618,10 +586,7 @@ impl<T: Trait> Module<T> {
                     Self::fetch_claims(id, claim, issuers)
                 })))
             }
-            ConditionType::HasValidProofOfInvestor(proof_ticker) => {
-                Right(Left(Self::fetch_confidential_claims(id, proof_ticker)))
-            }
-            ConditionType::IsIdentity(_) => Right(Right(core::iter::empty())),
+            ConditionType::IsIdentity(_) => Right(core::iter::empty()),
         };
 
         proposition::Context {
@@ -706,16 +671,6 @@ impl<T: Trait> Module<T> {
         let asset_compliance = Self::asset_compliance(ticker);
 
         let mut asset_compliance_with_results = AssetComplianceResult::from(asset_compliance);
-        // It is to know the result of the scope claim (i.e investor does posses the valid `InvestorZKProof` claim or not).
-        let from_has_scope_claim = Self::has_scope_claim(ticker, from_did_opt);
-        let to_has_scope_claim = Self::has_scope_claim(ticker, to_did_opt);
-        // Assigning the implicit requirement result.
-        asset_compliance_with_results.implicit_requirements_result = ImplicitRequirementResult {
-            from_result: from_has_scope_claim,
-            to_result: to_has_scope_claim,
-        };
-
-        let implicit_result = from_has_scope_claim && to_has_scope_claim;
 
         for requirements in &mut asset_compliance_with_results.requirements {
             if let Some(from_did) = from_did_opt {
@@ -742,10 +697,8 @@ impl<T: Trait> Module<T> {
                     requirements.result = false;
                 }
             }
-            // If the requirements result is positive, update the final result.
-            if requirements.result {
-                asset_compliance_with_results.result = implicit_result;
-            }
+
+            asset_compliance_with_results.result |= requirements.result;
         }
         asset_compliance_with_results
     }
@@ -791,26 +744,6 @@ impl<T: Trait> Module<T> {
         }
         Err(Error::<T>::ComplianceRequirementTooComplex.into())
     }
-
-    /// Helper function to know whether the given did has the valid scope claim or not.
-    fn has_scope_claim(ticker: &Ticker, did_opt: Option<IdentityId>) -> bool {
-        did_opt.map_or(false, |did| {
-            // Generate the condition for `HasValidProofOfInvestor` condition type.
-            let condition =
-                &Condition::from_dids(ConditionType::HasValidProofOfInvestor(*ticker), &[did]);
-            Self::is_condition_satisfied(ticker, did, condition, None, &mut None)
-        })
-    }
-
-    /// Know whether sender and receiver has valid scope claim or not before checking the transfer conditions.
-    fn is_sender_and_receiver_has_valid_scope_claim(
-        ticker: &Ticker,
-        from_did_opt: Option<IdentityId>,
-        to_did_opt: Option<IdentityId>,
-    ) -> bool {
-        // Return the final boolean result.
-        Self::has_scope_claim(ticker, to_did_opt) && Self::has_scope_claim(ticker, from_did_opt)
-    }
 }
 
 impl<T: Trait> ComplianceManagerTrait<T::Balance> for Module<T> {
@@ -831,23 +764,11 @@ impl<T: Trait> ComplianceManagerTrait<T::Balance> for Module<T> {
             ));
         }
 
-        // Check for whether sender & receiver has the scope claim or not if not then fail the txn.
-        // To optimize we are not checking it again and again with the respective conditions, it
-        // gets checked only once and if it is valid then its result is tied up with the conditions result.
-        //
-        // Note - Due to this check `ConditionType::HasValidProofOfInvestor` is an implicit transfer condition and it only
-        // lookup for the claims those are provided by the user itself.
         let mut requirement_count: usize = 0;
         let verify_weight = |count| {
             weight_for::weight_for_verify_restriction::<T>(u64::try_from(count).unwrap_or(0))
         };
 
-        if !Self::is_sender_and_receiver_has_valid_scope_claim(ticker, from_did_opt, to_did_opt) {
-            return Ok((
-                ERC1400_TRANSFER_FAILURE,
-                weight_for::weight_for_reading_asset_compliance::<T>(),
-            ));
-        }
         for requirement in asset_compliance.requirements {
             if let Some(from_did) = from_did_opt {
                 requirement_count += requirement.sender_conditions.len();

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1856,6 +1856,19 @@ impl<T: Trait> Module<T> {
         );
         Ok(primary_did)
     }
+
+    /// Checks whether the sender and the receiver of a transfer have valid scope claims
+    pub fn verify_scope_claims_for_transfer(
+        ticker: &Ticker,
+        from_did: IdentityId,
+        to_did: IdentityId,
+    ) -> bool {
+        let verify_scope_claim = |did| {
+            let asset_scope = Some(Scope::from(*ticker));
+            Self::fetch_claim(did, ClaimType::InvestorUniqueness, did, asset_scope).is_some()
+        };
+        verify_scope_claim(from_did) && verify_scope_claim(to_did)
+    }
 }
 
 impl<T: Trait> Module<T> {

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -8,7 +8,7 @@ use pallet_asset::{self as asset, AssetName, AssetType, SecurityToken};
 use pallet_balances as balances;
 use pallet_compliance_manager::{
     self as compliance_manager, AssetComplianceResult, ComplianceRequirement,
-    ComplianceRequirementResult, Error as CMError, ImplicitRequirementResult,
+    ComplianceRequirementResult, Error as CMError,
 };
 use pallet_group as group;
 use pallet_identity::{self as identity};

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -446,6 +446,7 @@ fn should_reset_asset_compliance_we() {
 #[test]
 fn pause_resume_asset_compliance() {
     ExtBuilder::default()
+        .cdd_providers(vec![AccountKeyring::Eve.public()])
         .build()
         .execute_with(pause_resume_asset_compliance_we);
 }
@@ -504,6 +505,13 @@ fn pause_resume_asset_compliance_we() {
         vec![],
         receiver_conditions
     ));
+
+    // Provide scope claim to sender and receiver of the transaction.
+    provide_scope_claim_to_multiple_parties(
+        &[token_owner_did, receiver_did],
+        ticker,
+        AccountKeyring::Eve.public(),
+    );
 
     // 5. Verify pause/resume mechanism.
     // 5.1. Transfer should be cancelled.
@@ -1563,7 +1571,6 @@ fn check_new_return_type_of_rpc() {
             None,
         ));
 
-        // By default all asset have implicit requirements
         // Add empty rules
         assert_ok!(ComplianceManager::add_compliance_requirement(
             token_owner_signed.clone(),
@@ -1578,11 +1585,6 @@ fn check_new_return_type_of_rpc() {
             Some(receiver_did),
         );
 
-        let expected_result = ImplicitRequirementResult {
-            from_result: false,
-            to_result: false,
-        };
-
         let compliance_requirement = ComplianceRequirementResult {
             sender_conditions: vec![],
             receiver_conditions: vec![],
@@ -1592,8 +1594,7 @@ fn check_new_return_type_of_rpc() {
 
         assert!(result.requirements.len() == 1);
         assert_eq!(result.requirements[0], compliance_requirement);
-        assert_eq!(result.implicit_requirements_result, expected_result);
-        assert_eq!(result.result, false);
+        assert_eq!(result.result, true);
 
         // Should fail txn as implicit requirements are active.
         assert_invalid_transfer!(ticker, token_owner_did, receiver_did, 100);

--- a/pallets/runtime/tests/src/confidential_test.rs
+++ b/pallets/runtime/tests/src/confidential_test.rs
@@ -10,8 +10,8 @@ use pallet_confidential as confidential;
 use pallet_identity as identity;
 use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
 use polymesh_primitives::{
-    AssetIdentifier, Claim, Condition, ConditionType, IdentityId, InvestorUid, InvestorZKProofData,
-    PortfolioId, Scope, Ticker,
+    AssetIdentifier, Claim, IdentityId, InvestorUid, InvestorZKProofData, PortfolioId, Scope,
+    Ticker,
 };
 
 use core::convert::TryFrom;

--- a/pallets/runtime/tests/src/confidential_test.rs
+++ b/pallets/runtime/tests/src/confidential_test.rs
@@ -128,17 +128,13 @@ fn scope_claims_we() {
         None,
     ));
 
-    // 2. Alice defines the asset complain compliance requirements.
+    // 2. Alice defines the asset compliance requirements.
     let st_scope = Scope::Identity(IdentityId::try_from(st_id.as_slice()).unwrap());
-    let sender_conditions = vec![];
-    let receiver_conditions = vec![Condition::from(ConditionType::HasValidProofOfInvestor(
-        st_id,
-    ))];
     assert_ok!(ComplianceManager::add_compliance_requirement(
         Origin::signed(alice),
         st_id,
-        sender_conditions,
-        receiver_conditions
+        vec![],
+        vec![]
     ));
 
     // 2. Investor adds its Confidential Scope claims.
@@ -149,7 +145,7 @@ fn scope_claims_we() {
     let cdd_claim_1 = InvestorZKProofData::make_cdd_claim(&inv_did_1, &investor);
     let cdd_id_1 = compute_cdd_id(&cdd_claim_1).compress().to_bytes().into();
 
-    let conf_scope_claim_error = Claim::InvestorUniqueness(st_scope.clone(), scope_id, cdd_id_1);
+    let conf_scope_claim_error = Claim::InvestorUniqueness(st_scope, scope_id, cdd_id_1);
     let conf_scope_claim_1 = Claim::InvestorUniqueness(st_id.into(), scope_id, cdd_id_1);
 
     assert_err!(

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -424,7 +424,7 @@
                 "IsAbsent": "Claim",
                 "IsAnyOf": "Vec<Claim>",
                 "IsNoneOf": "Vec<Claim>",
-                "IsIdentity": "TargetIdentity",
+                "IsIdentity": "TargetIdentity"
             }
         },
         "TrustedFor": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -424,13 +424,6 @@
                 "IsAnyOf": "Vec<Claim>",
                 "IsNoneOf": "Vec<Claim>",
                 "IsIdentity": "TargetIdentity",
-                "HasValidProofOfInvestor": "Ticker"
-            }
-        },
-        "ImplicitRequirementStatus": {
-            "_enum": {
-                "Active": "",
-                "Inactive": ""
             }
         },
         "TrustedFor": {
@@ -738,7 +731,6 @@
         "AssetComplianceResult": {
             "paused": "bool",
             "requirements": "Vec<ComplianceRequirementResult>",
-            "implicit_requirements_result": "Option<ImplicitRequirementResult>",
             "result": "bool"
         },
         "Claim1stKey": {
@@ -1029,10 +1021,6 @@
                 "Sto",
                 "Exchange"
             ]
-        },
-        "ImplicitRequirementResult": {
-            "from_result": "bool",
-            "to_result": "bool"
         },
         "Payload": {
             "block_number": "BlockNumber",

--- a/primitives/src/condition.rs
+++ b/primitives/src/condition.rs
@@ -17,7 +17,7 @@ use crate as polymesh_primitives;
 use crate::{
     identity_claim::ClaimOld,
     migrate::{Empty, Migrate},
-    Claim, ClaimType, IdentityId, Ticker,
+    Claim, ClaimType, IdentityId,
 };
 use codec::{Decode, Encode};
 use polymesh_primitives_derive::Migrate;
@@ -51,9 +51,6 @@ pub enum ConditionType {
     IsNoneOf(#[migrate(Claim)] Vec<Claim>),
     /// Condition to ensure that the sender/receiver is a particular identity or primary issuance agent
     IsIdentity(TargetIdentity),
-    /// Condition to ensure that the target identity has a valid `InvestorUniqueness` claim for the given
-    /// ticker.
-    HasValidProofOfInvestor(Ticker),
 }
 
 /// Denotes the set of `ClaimType`s for which an issuer is trusted.
@@ -169,10 +166,6 @@ impl Condition {
             ConditionType::IsNoneOf(ref claims) | ConditionType::IsAnyOf(ref claims) => {
                 claims.len()
             }
-            // NOTE: The complexity of this condition implies the use of cryptography libraries, which
-            // are computational expensive.
-            // So we've added a 10 factor here.
-            ConditionType::HasValidProofOfInvestor(..) => 10,
         };
         (claims_count, self.issuers.len())
     }

--- a/primitives/src/proposition/mod.rs
+++ b/primitives/src/proposition/mod.rs
@@ -113,12 +113,6 @@ pub fn not<P: Proposition<C>, C>(proposition: P) -> NotProposition<P> {
     NotProposition::new(proposition)
 }
 
-/// Checks whether the length of the vector of claims of a given context object is > 0.
-#[inline]
-pub fn has_scope_claim_exists(context: Context<impl Iterator<Item = impl Sized>>) -> bool {
-    context.claims.count() > 0
-}
-
 /// Helper function to run propositions from a context.
 pub fn run<C: Iterator<Item = Claim>>(condition: &Condition, context: Context<C>) -> bool {
     match &condition.condition_type {
@@ -126,7 +120,6 @@ pub fn run<C: Iterator<Item = Claim>>(condition: &Condition, context: Context<C>
         ConditionType::IsAbsent(claim) => not::<_, C>(exists(claim)).evaluate(context),
         ConditionType::IsAnyOf(claims) => any(claims).evaluate(context),
         ConditionType::IsNoneOf(claims) => not::<_, C>(any(claims)).evaluate(context),
-        ConditionType::HasValidProofOfInvestor(..) => has_scope_claim_exists(context),
         ConditionType::IsIdentity(id) => {
             equals(id, &context.primary_issuance_agent.unwrap_or_default()).evaluate(context)
         }


### PR DESCRIPTION
- Moved implicit requirement (scope / Investor uniqueness claim) check from Compliance manager to Asset/Identity module.
- `AssetComplianceResult` now respects compliance pause/unpause status.

This PR is tagged as API breaking because it changes the `canTransfer` RPC

We used to return the implicit requirement check as a dedicated boolean in compliance manager's `canTransfer` RPC but we no longer do that. Instead, it's now one of the error codes returned by the asset module's `canTransfer` RPC