### PR TITLE
Removed bitmasking from IdentityId

### DIFF
--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -106,7 +106,7 @@ impl SystematicIssuers {
 
     /// It returns the Identity Identifier of this issuer.
     pub const fn as_id(self) -> IdentityId {
-        IdentityId::from_bytes(*self.as_bytes())
+        IdentityId(*self.as_bytes())
     }
 
     pub const fn as_module_id(self) -> ModuleId {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1622,7 +1622,7 @@ impl<T: Trait> Module<T> {
         );
 
         let block_hash = <system::Module<T>>::block_hash(<system::Module<T>>::block_number());
-        let did = IdentityId::from_bytes(blake2_256(&(USER, block_hash, new_nonce).encode()));
+        let did = IdentityId(blake2_256(&(USER, block_hash, new_nonce).encode()));
 
         // 1.3. Make sure there's no pre-existing entry for the DID
         // This should never happen but just being defensive here

--- a/primitives/src/identity_id.rs
+++ b/primitives/src/identity_id.rs
@@ -47,7 +47,7 @@ const UUID_LEN: usize = 32usize;
     feature = "std",
     derive(SerializeU8StrongTyped, DeserializeU8StrongTyped)
 )]
-pub struct IdentityId([u8; UUID_LEN]);
+pub struct IdentityId(pub [u8; UUID_LEN]);
 
 impl IdentityId {
     /// Returns a byte slice of this IdentityId's contents
@@ -103,7 +103,7 @@ impl From<u128> for IdentityId {
         let mut did = [0; UUID_LEN];
         did[16..].copy_from_slice(&encoded_id);
 
-        IdentityId::from_bytes(did)
+        Self(did)
     }
 }
 
@@ -139,7 +139,7 @@ impl TryFrom<&[u8]> for IdentityId {
             // case where a 256 bit hash is being converted
             let mut fixed = [0; 32];
             fixed[(UUID_LEN - did.len())..].copy_from_slice(&did);
-            Ok(IdentityId::from_bytes(fixed))
+            Ok(Self(fixed))
         } else {
             // case where a string represented as u8 is being converted
             let did_str = str::from_utf8(did).map_err(|_| "DID is not valid UTF-8")?;
@@ -150,15 +150,7 @@ impl TryFrom<&[u8]> for IdentityId {
 
 impl From<[u8; UUID_LEN]> for IdentityId {
     fn from(s: [u8; UUID_LEN]) -> Self {
-        Self::from_bytes(s)
-    }
-}
-
-impl IdentityId {
-    /// Ensure DID < 2^255 by masking the high bit, that facilitates its conversion to Scalar.
-    pub const fn from_bytes(mut s: [u8; UUID_LEN]) -> Self {
-        s[UUID_LEN - 1] &= 0b0111_1111;
-        IdentityId(s)
+        Self(s)
     }
 }
 

--- a/primitives/src/identity_id.rs
+++ b/primitives/src/identity_id.rs
@@ -99,9 +99,11 @@ impl sp_std::fmt::Debug for IdentityId {
 
 impl From<u128> for IdentityId {
     fn from(id: u128) -> Self {
-        let encoded_id: [u8; 16] = id.to_le_bytes();
-        let mut did = [0; UUID_LEN];
-        did[16..].copy_from_slice(&encoded_id);
+        let encoded_id = id.encode();
+        let mut did = [0; 32];
+        for (i, n) in encoded_id.into_iter().enumerate() {
+            did[i] = n;
+        }
 
         Self(did)
     }
@@ -264,7 +266,7 @@ mod tests {
         println!("Print the un-serialize value: {:?}", identity);
         let serialize = serde_json::to_string(&identity).unwrap();
         let serialize_data =
-            "\"0x00000000000000000000000000000000e7030000000000000000000000000000\"";
+            "\"0xe703000000000000000000000000000000000000000000000000000000000000\"";
         println!("Print the serialize data {:?}", serialize);
         assert_eq!(serialize_data, serialize);
         let deserialize = serde_json::from_str::<IdentityId>(&serialize).unwrap();
@@ -314,26 +316,5 @@ mod tests {
             IdentityId::try_from(non_utf8.as_slice()),
             "DID is not valid UTF-8"
         );
-    }
-
-    /// This test double check that value is < 255bit, in order to support direct transformation
-    /// to/from Scalar.
-    #[test]
-    fn scalar_direct_transformation() {
-        let mut raw_did = [0u8; 32];
-        raw_did[31] = 0xF0;
-
-        // From<[u8,32]>
-        let did = IdentityId::from(raw_did.clone());
-        assert_eq!(did.as_fixed_bytes()[31], 0x70);
-
-        // From<&[u8]>
-        let did = IdentityId::try_from(&raw_did[..]).expect("Invalid raw DID");
-        assert_eq!(did.as_fixed_bytes()[31], 0x70);
-
-        // From<&str>
-        let str_did = "did:poly:00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF";
-        let did = IdentityId::try_from(str_did).expect("Invalid string DID");
-        assert_eq!(did.as_fixed_bytes()[31], 0x7F);
     }
 }


### PR DESCRIPTION
Bitmasking is no longer required since the scalar conversions are now handled by the cryptography library.