### PR TITLE
MESH-1298: protocol-fee benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
 name = "pallet-protocol-fee"
 version = "0.1.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-identity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5624,6 +5624,7 @@ dependencies = [
  "pallet-corporate-actions",
  "pallet-identity",
  "pallet-portfolio",
+ "pallet-protocol-fee",
  "pallet-timestamp",
 ]
 

--- a/pallets/protocol-fee/Cargo.toml
+++ b/pallets/protocol-fee/Cargo.toml
@@ -21,11 +21,15 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 
+# benchmark-only
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0", optional = true }
+
 [features]
 default = ["std"]
 no_std = []
 std = [
     "codec/std",
+    "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",
     "pallet-identity/std",
@@ -36,4 +40,7 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
+]
+runtime-benchmarks = [
+    "frame-benchmarking",
 ]

--- a/pallets/protocol-fee/src/benchmarking.rs
+++ b/pallets/protocol-fee/src/benchmarking.rs
@@ -17,7 +17,6 @@
 use crate::*;
 use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
-//use pallet_balances as balances;
 use polymesh_common_utilities::protocol_fee::ProtocolOp;
 use polymesh_primitives::PosRatio;
 use sp_std::prelude::*;

--- a/pallets/protocol-fee/src/benchmarking.rs
+++ b/pallets/protocol-fee/src/benchmarking.rs
@@ -1,0 +1,43 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymathNetwork/Polymesh).
+// Copyright (c) 2020 Polymath
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "runtime-benchmarks")]
+use crate::*;
+use frame_benchmarking::benchmarks;
+use frame_system::RawOrigin;
+//use pallet_balances as balances;
+use polymesh_common_utilities::protocol_fee::ProtocolOp;
+use polymesh_primitives::PosRatio;
+use sp_std::prelude::*;
+
+benchmarks! {
+    _ {}
+
+    change_coefficient {
+        let n in 0 .. u32::MAX;
+        let d in 0 .. u32::MAX;
+
+        let origin = RawOrigin::Root;
+        let coefficient = PosRatio::from((n, d));
+    }: _(origin, coefficient)
+
+    change_base_fee {
+        let b in 0 .. u32::MAX;
+
+        let origin = RawOrigin::Root;
+        let op = ProtocolOp::AssetRegisterTicker;
+        let base_fee = b.into();
+    }: _(origin, op, base_fee)
+}

--- a/pallets/protocol-fee/src/lib.rs
+++ b/pallets/protocol-fee/src/lib.rs
@@ -42,7 +42,7 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
     traits::{Currency, ExistenceRequirement, Imbalance, OnUnbalanced, WithdrawReason},
-    weights::{DispatchClass, Pays},
+    weights::Weight,
 };
 use frame_system::ensure_root;
 use pallet_identity as identity;
@@ -66,12 +66,19 @@ type NegativeImbalanceOf<T> =
 type WithdrawFeeResult<T> = sp_std::result::Result<NegativeImbalanceOf<T>, DispatchError>;
 type Identity<T> = identity::Module<T>;
 
+pub trait WeightInfo {
+    fn change_coefficient() -> Weight;
+    fn change_base_fee() -> Weight;
+}
+
 pub trait Trait: frame_system::Trait + IdentityTrait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     /// The currency type in which fees will be paid.
     type Currency: Currency<Self::AccountId> + Send + Sync;
     /// Handler for the unbalanced reduction when taking protocol fees.
     type OnProtocolFeePayment: OnUnbalanced<NegativeImbalanceOf<Self>>;
+    /// Weight calaculation.
+    type WeightInfo: WeightInfo;
 }
 
 decl_error! {
@@ -128,7 +135,7 @@ decl_module! {
         ///
         /// # Errors
         /// * `BadOrigin` - Only root allowed.
-        #[weight = (200_000_000, DispatchClass::Operational, Pays::Yes)]
+        #[weight = <T as Trait>::WeightInfo::change_coefficient()]
         pub fn change_coefficient(origin, coefficient: PosRatio) -> DispatchResult {
             ensure_root(origin)?;
             let id = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
@@ -142,7 +149,7 @@ decl_module! {
         ///
         /// # Errors
         /// * `BadOrigin` - Only root allowed.
-        #[weight = (200_000_000, DispatchClass::Operational, Pays::Yes)]
+        #[weight = <T as Trait>::WeightInfo::change_base_fee()]
         pub fn change_base_fee(origin, op: ProtocolOp, base_fee: BalanceOf<T>) ->
             DispatchResult
         {

--- a/pallets/protocol-fee/src/lib.rs
+++ b/pallets/protocol-fee/src/lib.rs
@@ -35,6 +35,9 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "runtime-benchmarks")]
+pub mod benchmarking;
+
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -187,6 +187,7 @@ runtime-benchmarks = [
     "pallet-identity/runtime-benchmarks",
     "pallet-im-online/runtime-benchmarks",
     "pallet-portfolio/runtime-benchmarks",
+    "pallet-protocol-fee/runtime-benchmarks",
     "pallet-staking/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "polymesh-primitives/runtime-benchmarks",

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -292,6 +292,7 @@ impl protocol_fee::Trait for Runtime {
     type Event = Event;
     type Currency = Balances;
     type OnProtocolFeePayment = DealWithFees;
+    type WeightInfo = polymesh_weights::pallet_protocol_fee::WeightInfo;
 }
 
 parameter_types! {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -1268,6 +1268,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, pallet_balances, Balances);
             add_benchmark!(params, batches, pallet_identity, Identity);
             add_benchmark!(params, batches, pallet_portfolio, Portfolio);
+            add_benchmark!(params, batches, pallet_protocol_fee, ProtocolFee);
             add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
             add_benchmark!(params, batches, pallet_timestamp, Timestamp);
 

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -289,6 +289,7 @@ impl protocol_fee::Trait for Runtime {
     type Event = Event;
     type Currency = Balances;
     type OnProtocolFeePayment = DealWithFees;
+    type WeightInfo = polymesh_weights::pallet_protocol_fee::WeightInfo;
 }
 
 parameter_types! {

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -359,6 +359,7 @@ impl protocol_fee::Trait for Test {
     type Event = MetaEvent;
     type Currency = Balances;
     type OnProtocolFeePayment = ();
+    type WeightInfo = polymesh_weights::pallet_protocol_fee::WeightInfo;
 }
 
 impl IdentityTrait for Test {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -482,6 +482,7 @@ impl protocol_fee::Trait for TestStorage {
     type Event = Event;
     type Currency = Balances;
     type OnProtocolFeePayment = DealWithFees<TestStorage>;
+    type WeightInfo = polymesh_weights::pallet_protocol_fee::WeightInfo;
 }
 
 impl portfolio::Trait for TestStorage {

--- a/pallets/weights/Cargo.toml
+++ b/pallets/weights/Cargo.toml
@@ -14,6 +14,7 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-fe
 pallet-corporate-actions = { path = "../corporate-actions", default-features = false }
 pallet-identity = { path = "../identity", default-features = false  }
 pallet-portfolio = { path = "../portfolio", default-features = false  }
+pallet-protocol-fee = { path = "../protocol-fee", default-features = false  }
 
 [features]
 default = ["std"]
@@ -24,5 +25,6 @@ std = [
     "pallet-corporate-actions/std",
     "pallet-identity/std",
     "pallet-portfolio/std",
+    "pallet-protocol-fee/std",
     "pallet-timestamp/std",
 ]

--- a/pallets/weights/src/lib.rs
+++ b/pallets/weights/src/lib.rs
@@ -21,4 +21,5 @@ pub mod frame_system;
 pub mod pallet_corporate_actions;
 pub mod pallet_identity;
 pub mod pallet_portfolio;
+pub mod pallet_protocol_fee;
 pub mod pallet_timestamp;

--- a/pallets/weights/src/pallet_protocol_fee.rs
+++ b/pallets/weights/src/pallet_protocol_fee.rs
@@ -1,0 +1,23 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+pub struct WeightInfo;
+impl pallet_protocol_fee::WeightInfo for WeightInfo {
+    // WARNING! Some components were not used: ["n", "d"]
+    fn change_coefficient() -> Weight {
+        (166_338_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+
+    // WARNING! Some components were not used: ["b"]
+    fn change_base_fee() -> Weight {
+        (146_871_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+}


### PR DESCRIPTION
~I've auto-generated weight source files and can add them to this PR. However I think they need to be generated on the benchmark machine instead and committed separately.~

See the [comment](https://github.com/PolymathNetwork/Polymesh/pull/715#issuecomment-721729057) below.