### PR TITLE
Remove executed runtime upgrade code

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -403,7 +403,6 @@ decl_module! {
         fn deposit_event() = default;
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {
-            Identifiers::remove_all();
 
             // Migrate `AssetDocuments`.
             use frame_support::Blake2_128Concat;

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -117,17 +117,12 @@ pub trait Trait:
     type MaxConditionComplexity: Get<u32>;
 }
 
-use polymesh_primitives::condition::ConditionOld;
-
 /// A compliance requirement.
 /// All sender and receiver conditions of the same compliance requirement must be true in order to execute the transfer.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, Migrate)]
-#[migrate_context(Option<polymesh_primitives::CddId>)]
 pub struct ComplianceRequirement {
-    #[migrate(Condition)]
     pub sender_conditions: Vec<Condition>,
-    #[migrate(Condition)]
     pub receiver_conditions: Vec<Condition>,
     /// Unique identifier of the compliance requirement
     pub id: u32,
@@ -200,12 +195,10 @@ impl From<Condition> for ConditionResult {
 /// List of compliance requirements associated to an asset.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Migrate)]
-#[migrate_context(Option<polymesh_primitives::CddId>)]
 pub struct AssetCompliance {
     /// This flag indicates if asset compliance should be enforced
     pub paused: bool,
     /// List of compliance requirements.
-    #[migrate(ComplianceRequirement)]
     pub requirements: Vec<ComplianceRequirement>,
 }
 
@@ -289,12 +282,10 @@ decl_module! {
         fn deposit_event() = default;
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {
-            use polymesh_primitives::migrate::{Empty, migrate_map, migrate_map_rename};
+            use polymesh_primitives::migrate::{Empty, migrate_map};
             use polymesh_primitives::condition::TrustedIssuerOld;
 
-            migrate_map_rename::<AssetComplianceOld, _>(b"ComplianceManager", b"AssetRulesMap", b"AssetCompliance", |_| None);
-
-            migrate_map::<Vec<TrustedIssuerOld>, _>(b"ComplianceManager", b"TrustedClaimIsuer", |_| Empty);
+            migrate_map::<Vec<TrustedIssuerOld>, _>(b"ComplianceManager", b"TrustedClaimIssuer", |_| Empty);
 
             1_000
         }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -144,12 +144,6 @@ pub struct Claim2ndKey {
     pub scope: Option<Scope>,
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
-pub struct Claim2ndKeyOld {
-    pub issuer: IdentityId,
-    pub scope: Option<IdentityId>,
-}
-
 decl_storage! {
     trait Store for Module<T: Trait> as identity {
 
@@ -260,30 +254,10 @@ decl_module! {
         fn on_runtime_upgrade() -> Weight {
             use frame_support::migration::{put_storage_value, StorageIterator};
             use polymesh_primitives::{
-                identity_claim::IdentityClaimOld,
                 identity::IdentityOld,
                 migrate::{migrate_map,  migrate_double_map, Empty},
             };
             use polymesh_common_utilities::traits::identity::runtime_upgrade::LinkedKeyInfo;
-
-            // Rename "master" to "primary".
-            <CddAuthForPrimaryKeyRotation>::put(<CddAuthForMasterKeyRotation>::take());
-
-            migrate_map::<IdentityClaimOld, _>(b"identity", b"Claims", |raw_key| {
-                Claim1stKey::decode(&mut Blake2_128Concat::reverse(&raw_key))
-                    .ok()
-                    .map(|k1| (*k1.target.as_fixed_bytes()).into())
-            });
-
-            // Covert old scopes to new scopes
-            migrate_double_map::<_, _, Blake2_128Concat, _, _, _, _, _>(
-                b"identity", b"Claims",
-                |k1: Claim1stKey, k2: Claim2ndKeyOld, val: IdentityClaim| Some((
-                    k1,
-                    Claim2ndKey { issuer: k2.issuer, scope: k2.scope.map(Scope::Identity) },
-                    val
-                ))
-            );
 
             migrate_map::<LinkedKeyInfo, _>(
                 b"identity",

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -90,7 +90,7 @@ use frame_support::{
     ensure,
     traits::{ChangeMembers, Currency, EnsureOrigin, Get, GetCallMetadata, InitializeMembers},
     weights::{DispatchClass::Operational, GetDispatchInfo, Pays, Weight},
-    Blake2_128Concat, ReversibleStorageHasher, StorageDoubleMap,
+    StorageDoubleMap,
 };
 use frame_system::{self as system, ensure_root, ensure_signed};
 use pallet_permissions::with_call_metadata;
@@ -255,7 +255,7 @@ decl_module! {
             use frame_support::migration::{put_storage_value, StorageIterator};
             use polymesh_primitives::{
                 identity::IdentityOld,
-                migrate::{migrate_map,  migrate_double_map, Empty},
+                migrate::{migrate_map, Empty},
             };
             use polymesh_common_utilities::traits::identity::runtime_upgrade::LinkedKeyInfo;
 

--- a/primitives/src/condition.rs
+++ b/primitives/src/condition.rs
@@ -15,7 +15,6 @@
 
 use crate as polymesh_primitives;
 use crate::{
-    identity_claim::ClaimOld,
     migrate::{Empty, Migrate},
     Claim, ClaimType, IdentityId,
 };
@@ -38,17 +37,16 @@ pub enum TargetIdentity {
 /// It defines the type of condition supported, and the filter information we will use to evaluate as a
 /// predicate.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Migrate)]
-#[migrate_context(Option<crate::CddId>)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum ConditionType {
     /// Condition to ensure that claim filter produces one claim.
-    IsPresent(#[migrate] Claim),
+    IsPresent(Claim),
     /// Condition to ensure that claim filter produces an empty list.
-    IsAbsent(#[migrate] Claim),
+    IsAbsent(Claim),
     /// Condition to ensure that at least one claim is fetched when filter is applied.
-    IsAnyOf(#[migrate(Claim)] Vec<Claim>),
+    IsAnyOf(Vec<Claim>),
     /// Condition to ensure that at none of claims is fetched when filter is applied.
-    IsNoneOf(#[migrate(Claim)] Vec<Claim>),
+    IsNoneOf(Vec<Claim>),
     /// Condition to ensure that the sender/receiver is a particular identity or primary issuance agent
     IsIdentity(TargetIdentity),
 }
@@ -121,10 +119,8 @@ impl Migrate for TrustedIssuerOld {
 /// Type of claim requirements that a condition can have
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Migrate)]
-#[migrate_context(Option<crate::CddId>)]
 pub struct Condition {
     /// Type of condition.
-    #[migrate]
     pub condition_type: ConditionType,
     /// Trusted issuers.
     #[migrate(TrustedIssuer)]

--- a/primitives/src/identity_claim.rs
+++ b/primitives/src/identity_claim.rs
@@ -58,20 +58,6 @@ impl From<Vec<u8>> for Scope {
     }
 }
 
-impl Migrate for ScopeOld {
-    type Into = Scope;
-    type Context = Empty;
-
-    fn migrate(self, _: Self::Context) -> Option<Self::Into> {
-        Some(Scope::Identity(self))
-    }
-}
-
-/// Old country code
-type CountryCodeOld = JurisdictionName;
-/// Scope that was used in the last version
-pub type ScopeOld = IdentityId;
-
 impl From<Option<CddId>> for Empty {
     fn from(_: Option<CddId>) -> Self {
         Self
@@ -81,34 +67,32 @@ impl From<Option<CddId>> for Empty {
 /// All possible claims in polymesh
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Migrate)]
-#[migrate_context(Option<CddId>)]
 pub enum Claim {
     /// User is Accredited
-    Accredited(#[migrate] Scope),
+    Accredited(Scope),
     /// User is Accredited
-    Affiliate(#[migrate] Scope),
+    Affiliate(Scope),
     /// User has an active BuyLockup (end date defined in claim expiry)
-    BuyLockup(#[migrate] Scope),
+    BuyLockup(Scope),
     /// User has an active SellLockup (date defined in claim expiry)
-    SellLockup(#[migrate] Scope),
+    SellLockup(Scope),
     /// User has passed CDD
-    #[migrate_from(#[allow(missing_docs)] CustomerDueDiligence)]
-    CustomerDueDiligence(#[migrate_with(context?)] CddId),
+    CustomerDueDiligence(CddId),
     /// User is KYC'd
-    KnowYourCustomer(#[migrate] Scope),
+    KnowYourCustomer(Scope),
     /// This claim contains a string that represents the jurisdiction of the user
-    Jurisdiction(#[migrate] CountryCode, #[migrate] Scope),
+    Jurisdiction(CountryCode, Scope),
     /// User is exempted
-    Exempted(#[migrate] Scope),
+    Exempted(Scope),
     /// User is Blocked
-    Blocked(#[migrate] Scope),
+    Blocked(Scope),
     /// Confidential claim that will allow an investor to justify that it's identity can be
     /// a potential asset holder of given `scope`.
     ///
     /// All investors must have this claim, which will help the issuer apply compliance rules
     /// on the `ScopeId` instead of the investor's `IdentityId`, as `ScopeId` is unique at the
     /// investor entity level for a given scope (will always be a `Ticker`).
-    InvestorUniqueness(#[migrate] Scope, ScopeId, CddId),
+    InvestorUniqueness(Scope, ScopeId, CddId),
     /// Empty claim
     NoData,
 }
@@ -197,7 +181,6 @@ impl Default for ClaimType {
 /// All information of a particular claim
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Clone, Default, PartialEq, Eq, Migrate)]
-#[migrate_context(Option<CddId>)]
 pub struct IdentityClaim {
     /// Issuer of the claim
     pub claim_issuer: IdentityId,
@@ -208,7 +191,6 @@ pub struct IdentityClaim {
     /// Expiry date
     pub expiry: Option<Moment>,
     /// Claim data
-    #[migrate]
     pub claim: Claim,
 }
 

--- a/primitives/src/identity_claim.rs
+++ b/primitives/src/identity_claim.rs
@@ -13,17 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate as polymesh_primitives;
 use crate::{identity_id::IdentityId, CddId, Moment, Ticker};
 
 use codec::{Decode, Encode};
-use polymesh_primitives_derive::Migrate;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
 use sp_std::{convert::From, prelude::*};
 
-use super::jurisdiction::{CountryCode, JurisdictionName};
-use crate::migrate::{Empty, Migrate};
+use super::jurisdiction::CountryCode;
 
 /// It is the asset Id.
 pub type ScopeId = IdentityId;
@@ -58,15 +55,9 @@ impl From<Vec<u8>> for Scope {
     }
 }
 
-impl From<Option<CddId>> for Empty {
-    fn from(_: Option<CddId>) -> Self {
-        Self
-    }
-}
-
 /// All possible claims in polymesh
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Migrate)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum Claim {
     /// User is Accredited
     Accredited(Scope),
@@ -180,7 +171,7 @@ impl Default for ClaimType {
 
 /// All information of a particular claim
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, Default, PartialEq, Eq, Migrate)]
+#[derive(Encode, Decode, Clone, Default, PartialEq, Eq)]
 pub struct IdentityClaim {
     /// Issuer of the claim
     pub claim_issuer: IdentityId,


### PR DESCRIPTION
This PR removed runtime upgrade code which has already been executed on Alcyone 2.1.

See `alcyone` branch for storage which has already been updated.

Also fixes storage typo in:  
```
migrate_map::<Vec<TrustedIssuerOld>, _>(b"ComplianceManager", b"TrustedClaim**Isuer**", |_| Empty);
```

A companion PR will be made for the `tooling_v2.2.0` branch.