### PR TITLE
MESH-1365: Add CA + Ballot tests [Part 1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,8 +4079,11 @@ name = "pallet-compliance-manager"
 version = "0.1.0"
 dependencies = [
  "either",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "pallet-asset",
+ "pallet-balances 0.1.0",
  "pallet-identity",
  "pallet-permissions",
  "pallet-timestamp",
@@ -5624,6 +5627,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-compliance-manager",
  "pallet-corporate-actions",
  "pallet-identity",
  "pallet-portfolio",

--- a/pallets/corporate-actions/src/ballot.rs
+++ b/pallets/corporate-actions/src/ballot.rs
@@ -131,7 +131,7 @@ pub struct Motion {
 
 /// A wrapper for a ballot's title.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Decode, Encode, VecU8StrongTyped)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Default, Decode, Encode, VecU8StrongTyped)]
 pub struct BallotTitle(pub Vec<u8>);
 
 /// Metadata about a ballot.
@@ -142,7 +142,7 @@ pub struct BallotTitle(pub Vec<u8>);
 /// the needed numbers aforementioned are cached away,
 /// and the metadata is not read on-chain again.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, Default)]
 pub struct BallotMeta {
     /// The ballot's title.
     pub title: BallotTitle,

--- a/pallets/corporate-actions/src/ballot.rs
+++ b/pallets/corporate-actions/src/ballot.rs
@@ -599,6 +599,7 @@ impl<T: Trait> Module<T> {
         TimeRanges::remove(ca_id);
         Metas::remove(ca_id);
         MotionNumChoices::remove(ca_id);
+        RCV::remove(ca_id);
         <Results<T>>::remove(ca_id);
         <Votes<T>>::remove_prefix(ca_id);
 

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![feature(proc_macro_hygiene)]
+#![feature(crate_visibility_modifier)]
 
 pub mod storage;
 pub use storage::{

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -162,7 +162,7 @@ type SessionIndex = u32;
 type AuthorityId = <AnySignature as Verify>::Signer;
 type Event = EventTest;
 type Version = ();
-type Balance = u128;
+crate type Balance = u128;
 
 parameter_types! {
     pub const BlockHashCount: u32 = 250;


### PR DESCRIPTION
Based on https://github.com/PolymathNetwork/Polymesh/pull/721.

Adds CA + Ballot tests per https://polymath.atlassian.net/browse/MESH-1365.
Distributions test still remain and will be added in a follow-up PR.