### PR TITLE
Mesh 1343/global error event

### DIFF
--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -27,7 +27,7 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
-    dispatch::{DispatchResult, PostDispatchInfo},
+    dispatch::{DispatchError, DispatchResult, PostDispatchInfo},
     traits::{Currency, EnsureOrigin, GetCallMetadata},
     weights::{GetDispatchInfo, Weight},
     Parameter,
@@ -171,8 +171,6 @@ pub trait Trait: CommonTrait + pallet_timestamp::Trait + balances::Trait {
     type CorporateAction: IdentityToCorporateAction;
 }
 
-// rustfmt adds a comma after Option<Moment> in NewAuthorization and it breaks compilation
-#[rustfmt::skip]
 decl_event!(
     pub enum Event<T>
     where
@@ -220,7 +218,7 @@ decl_event!(
             Option<AccountId>,
             u64,
             AuthorizationData<AccountId>,
-            Option<Moment>
+            Option<Moment>,
         ),
 
         /// Authorization revoked by the authorizer.
@@ -251,6 +249,9 @@ decl_event!(
 
         /// All Secondary keys of the identity ID are unfrozen.
         SecondaryKeysUnfrozen(IdentityId),
+
+        /// An unexpected error happened that should be investigated.
+        UnexpectedError(Option<DispatchError>),
     }
 );
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -2073,6 +2073,11 @@ impl<T: Trait> Module<T> {
         )
     }
 
+    /// Emit an unexpected error event that should be investigated manually
+    pub fn emit_unexpected_error(error: Option<DispatchError>) {
+        Self::deposit_event(RawEvent::UnexpectedError(error));
+    }
+
     #[cfg(feature = "runtime-benchmarks")]
     /// Links a did with an identity
     pub fn link_did(account: T::AccountId, did: IdentityId) {

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -667,6 +667,8 @@ decl_event!(
         /// Event emitted when a proposal is rejected.
         /// Arguments: caller DID, multisig, proposal ID.
         ProposalRejected(IdentityId, AccountId, u64),
+        /// Event emitted when there's an error in proposal execution
+        ProposalExecutionFailed(DispatchError),
     }
 );
 
@@ -936,7 +938,7 @@ impl<T: Trait> Module<T> {
                 }
                 Err(e) => {
                     let e: DispatchError = e.error;
-                    sp_runtime::print(e);
+                    Self::deposit_event(RawEvent::ProposalExecutionFailed(e));
                     proposal_details.status = ProposalStatus::ExecutionFailed;
                     false
                 }

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -1179,7 +1179,7 @@ decl_module! {
         /// proceed to ratification process.
         fn on_initialize(n: T::BlockNumber) -> Weight {
             Self::end_block(n).unwrap_or_else(|e| {
-                sp_runtime::print(e);
+                <Identity<T>>::emit_unexpected_error(Some(e));
                 0
             })
         }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -11,9 +11,13 @@
         "DocumentName": "Text",
         "DocumentUri": "Text",
         "DocumentHash": "Text",
+        "DocumentType": "Text",
         "Document": {
             "uri": "DocumentUri",
-            "content_hash": "DocumentHash"
+            "content_hash": "DocumentHash",
+            "name": "DocumentName",
+            "doc_type": "Option<DocumentType>",
+            "filing_date": "Option<Moment>"
         },
         "AssetType": {
             "_enum": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -852,12 +852,6 @@
                 "Handled": ""
             }
         },
-        "HandledTxStatus": {
-            "_enum": {
-                "Success": "",
-                "Error": "Text"
-            }
-        },
         "CappedFee": "u64",
         "CanTransferResult": {
             "_enum": {


### PR DESCRIPTION
- Added an event in the Identity module that can be used as the global event for unexpected errors.
- Removed rustfmt skip from one place since it works fine now.