### PR TITLE
MESH-1367: Fix `remove_authorization` logic

### DIFF
--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -284,7 +284,7 @@ benchmarks! {
             AuthorizationData::JoinIdentity(Permissions::default()),
             Some(666.into()),
         );
-    }: _(origin, Signatory::Identity(did), auth_id)
+    }: _(origin, Signatory::Identity(did), auth_id, true)
 
     // TODO: accept_authorization. The worst case of `accept_authorization` will be whatever authorization type takes most resources.
     // A defensive weight has been hardcoded for now but it should be updated once we've done benchmarks for all auth types.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -678,11 +678,13 @@ decl_module! {
         }
 
         /// Removes an authorization.
+        /// _auth_issuer_pays determines whether the issuer of the authorisation pays the transaction fee
         #[weight = <T as Trait>::WeightInfo::remove_authorization()]
         pub fn remove_authorization(
             origin,
             target: Signatory<T::AccountId>,
-            auth_id: u64
+            auth_id: u64,
+            _auth_issuer_pays: bool,
         ) -> DispatchResult {
             let PermissionedCallOriginData {
                 sender,

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -61,7 +61,6 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
     /// However, this does not set the payer context since that is meant to remain constant
     /// throughout the transaction. This function can also be used to simply check CDD and update identity context.
     fn get_valid_payer(call: &Call, caller: &AccountId) -> ValidPayerResult {
-        sp_runtime::print("here");
         let missing_id = || {
             Err(InvalidTransaction::Custom(
                 TransactionError::MissingIdentity as u8,
@@ -101,7 +100,6 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(identity::Call::remove_authorization(_, auth_id, true)) => {
-                sp_runtime::print("there");
                 is_auth_valid(caller, auth_id, CallType::RemoveAuthorization)
             }
             // Call made by an Account key to propose or approve a multisig transaction.

--- a/pallets/runtime/testnet/src/fee_details.rs
+++ b/pallets/runtime/testnet/src/fee_details.rs
@@ -34,7 +34,7 @@ type Call = runtime::Call;
 #[derive(Encode, Decode)]
 enum CallType {
     AcceptMultiSigSigner,
-    AcceptIdentitySigner,
+    AcceptIdentitySecondary,
     AcceptIdentityPrimary,
     /// Matches any call to `remove_authorization`,
     /// where the authorization is available for `auth.authorized_by` payer redirection.
@@ -90,7 +90,7 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
             // Call made by a new Account key to accept invitation to become a secondary key
             // of an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(identity::Call::join_identity_as_key(auth_id, ..)) => {
-                is_auth_valid(caller, auth_id, CallType::AcceptIdentitySigner)
+                is_auth_valid(caller, auth_id, CallType::AcceptIdentitySecondary)
             }
             // Call made by a new Account key to accept invitation to become the primary key
             // of an existing identity that has a valid CDD. The auth should be valid.
@@ -99,7 +99,7 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
             }
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
-            Call::Identity(identity::Call::remove_authorization(_, auth_id)) => {
+            Call::Identity(identity::Call::remove_authorization(_, auth_id, true)) => {
                 is_auth_valid(caller, auth_id, CallType::RemoveAuthorization)
             }
             // Call made by an Account key to propose or approve a multisig transaction.
@@ -164,18 +164,10 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
         // Business logic for authorisations can be checked post-Signed Extension.
         Some((
             by,
-            (
-                AuthorizationData::AddMultiSigSigner(_),
-                CallType::RemoveAuthorization | CallType::AcceptMultiSigSigner,
-            )
-            | (
-                AuthorizationData::JoinIdentity(_),
-                CallType::RemoveAuthorization | CallType::AcceptIdentitySigner,
-            )
-            | (
-                AuthorizationData::RotatePrimaryKey(_),
-                CallType::RemoveAuthorization | CallType::AcceptIdentityPrimary,
-            ),
+            (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
+            | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
+            | (AuthorizationData::RotatePrimaryKey(_), CallType::AcceptIdentityPrimary)
+            | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),
         // None of the above apply, so error.
         _ => Err(InvalidTransaction::Custom(

--- a/pallets/runtime/tests/src/fee_details.rs
+++ b/pallets/runtime/tests/src/fee_details.rs
@@ -2,12 +2,12 @@ use super::{
     storage::{get_last_auth_id, make_account_without_cdd, register_keyring_account, TestStorage},
     ExtBuilder,
 };
-use frame_support::{assert_ok, assert_noop};
+use frame_support::{assert_noop, assert_ok};
 use pallet_balances as balances;
 use pallet_identity as identity;
 use pallet_multisig as multisig;
-use polymesh_common_utilities::Context;
 use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
+use polymesh_common_utilities::Context;
 use polymesh_primitives::{InvestorUid, Signatory, TransactionError};
 use polymesh_runtime_develop::{fee_details::CddHandler, runtime::Call};
 use sp_core::crypto::AccountId32;
@@ -31,16 +31,14 @@ fn cdd_checks() {
                 make_account_without_cdd(AccountKeyring::Alice.public()).unwrap();
             let alice_account = AccountId32::from(AccountKeyring::Alice.public().0);
             let alice_key_signatory = Signatory::Account(AccountKeyring::Alice.public());
-            let alice_account_signatory =
-                Signatory::Account(alice_account.clone());
+            let alice_account_signatory = Signatory::Account(alice_account.clone());
 
             // charlie has valid cdd
             let charlie_signed = Origin::signed(AccountKeyring::Charlie.public());
             let _ = register_keyring_account(AccountKeyring::Charlie).unwrap();
             let charlie_account = AccountId32::from(AccountKeyring::Charlie.public().0);
             let charlie_key_signatory = Signatory::Account(AccountKeyring::Charlie.public());
-            let charlie_account_signatory =
-                Signatory::Account(charlie_account.clone());
+            let charlie_account_signatory = Signatory::Account(charlie_account.clone());
 
             // register did bypasses cdd checks
             assert_eq!(

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -962,7 +962,8 @@ fn removing_authorizations() {
         assert_ok!(Identity::remove_authorization(
             alice.clone(),
             bob_did,
-            auth_id
+            auth_id,
+            false,
         ));
         assert!(!<AuthorizationsGiven>::contains_key(alice_did, auth_id));
         assert!(!<identity::Authorizations<TestStorage>>::contains_key(


### PR DESCRIPTION
Allow caller to specify whether they should pay, or whether the issuer of the authorization should pay.

In both cases, the payer must have a valid CDD check.