### PR TITLE
Added LegacyPermissions as a workaround for a polkadot.js bug

### DIFF
--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -33,8 +33,8 @@ use frame_support::{
     Parameter,
 };
 use polymesh_primitives::{
-    secondary_key::api::{Permissions, SecondaryKey},
-    AuthorizationData, IdentityClaim, IdentityId, Signatory, Ticker,
+    secondary_key::api::SecondaryKey, AuthorizationData, IdentityClaim, IdentityId, Permissions,
+    Signatory, Ticker,
 };
 use sp_core::H512;
 use sp_runtime::traits::{Dispatchable, IdentifyAccount, Member, Verify};

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -590,23 +590,21 @@ decl_module! {
         pub fn set_permission_to_signer(
             origin,
             signer: Signatory<T::AccountId>,
-            permissions: secondary_key::api::Permissions
+            permissions: Permissions
         ) -> DispatchResult {
-            let PermissionedCallOriginData {
-                sender,
-                primary_did: did,
-                ..
-            } = Self::ensure_origin_call_permissions(origin)?;
-            let record = Self::grant_check_only_primary_key(&sender, did)?;
+            Self::base_set_permission_to_signer(origin, signer, permissions)
+        }
 
-            // You are trying to add a permission to did's primary key. It is not needed.
-            match signer {
-                Signatory::Account(ref key) if record.primary_key == *key => Ok(()),
-                _ if record.secondary_keys.iter().any(|si| si.signer == signer) => {
-                    Self::update_secondary_key_permissions(did, &signer, permissions.into())
-                }
-                _ => Err(Error::<T>::InvalidSender.into()),
-            }
+        /// This function is a workaround for https://github.com/polkadot-js/apps/issues/3632
+        /// It sets permissions for an specific `target_key` key.
+        /// Only the primary key of an identity is able to set secondary key permissions.
+        #[weight = <T as Trait>::WeightInfo::set_permission_to_signer()]
+        pub fn legacy_set_permission_to_signer(
+            origin,
+            signer: Signatory<T::AccountId>,
+            permissions: secondary_key::api::LegacyPermissions
+        ) -> DispatchResult {
+            Self::base_set_permission_to_signer(origin, signer, permissions.into())
         }
 
         /// It disables all secondary keys at `did` identity.
@@ -2078,6 +2076,30 @@ impl<T: Trait> Module<T> {
     /// Emit an unexpected error event that should be investigated manually
     pub fn emit_unexpected_error(error: Option<DispatchError>) {
         Self::deposit_event(RawEvent::UnexpectedError(error));
+    }
+
+    /// It sets permissions for an specific `target_key` key.
+    /// Only the primary key of an identity is able to set secondary key permissions.
+    fn base_set_permission_to_signer(
+        origin: T::Origin,
+        signer: Signatory<T::AccountId>,
+        permissions: Permissions,
+    ) -> DispatchResult {
+        let PermissionedCallOriginData {
+            sender,
+            primary_did: did,
+            ..
+        } = Self::ensure_origin_call_permissions(origin)?;
+        let record = Self::grant_check_only_primary_key(&sender, did)?;
+
+        // You are trying to add a permission to did's primary key. It is not needed.
+        match signer {
+            Signatory::Account(ref key) if record.primary_key == *key => Ok(()),
+            _ if record.secondary_keys.iter().any(|si| si.signer == signer) => {
+                Self::update_secondary_key_permissions(did, &signer, permissions)
+            }
+            _ => Err(Error::<T>::InvalidSender.into()),
+        }
     }
 
     #[cfg(feature = "runtime-benchmarks")]

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -63,12 +63,21 @@
         "DispatchableName": "Text",
         "PalletPermissions": {
             "pallet_name": "PalletName",
-            "total": "bool",
-            "dispatchable_names": "Vec<DispatchableName>"
+            "dispatchable_names": "Option<Vec<DispatchableName>>"
         },
         "Permissions": {
             "asset": "Option<Vec<Ticker>>",
             "extrinsic": "Option<Vec<PalletPermissions>>",
+            "portfolio": "Option<Vec<PortfolioId>>"
+        },
+        "LegacyPalletPermissions": {
+            "pallet_name": "PalletName",
+            "total": "bool",
+            "dispatchable_names": "Vec<DispatchableName>"
+        },
+        "LegacyPermissions": {
+            "asset": "Option<Vec<Ticker>>",
+            "extrinsic": "Option<Vec<LegacyPalletPermissions>>",
             "portfolio": "Option<Vec<PortfolioId>>"
         },
         "Signatory": {


### PR DESCRIPTION
- `set_permission_to_signer` function and `add_authorization` function now use the standard `Permissions` type.
- `legacy_set_permission_to_signer` function added that can be used as a workaround for https://github.com/polkadot-js/apps/issues/3632 

The main difference between the legacy type and the standard type is in the `PalletPermissions` struct. In the legacy type, we have a dedicated boolean(`total`) to represent the `None` case of an `Option` (`dispatchable_names`) but in the standard format, `dispatchable_names` is directly used as an `Option`.