### PR TITLE
Fixed identity migration

### DIFF
--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -26,11 +26,10 @@ use sp_std::{convert::From, prelude::Vec};
 
 /// Identity information.
 #[allow(missing_docs)]
-#[derive(Encode, Decode, Default, Clone, PartialEq, Debug, Migrate)]
+#[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Identity<AccountId: Encode + Decode> {
     pub primary_key: AccountId,
-    #[migrate_from(Vec<SecondaryKeyOld<AccountId>>)]
     pub secondary_keys: Vec<SecondaryKey<AccountId>>,
 }
 


### PR DESCRIPTION
The issue was that we were decoding the Identity as `IdentityOld` instead of `IdentityWithRolesOld` before migrating the `IdentityWithRolesOld` to `IdentityOld`.