### PR TITLE
Renaming and minor fixes

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -975,18 +975,18 @@ decl_module! {
         ///
         /// # Arguments
         /// * `origin` which must be root.
-        /// * `import` specification for the PMC ticker.
-        /// * `contract_did` to reserve the ticker to if `import.is_contract` holds.
+        /// * `classic_ticker_import` specification for the PMC ticker.
+        /// * `contract_did` to reserve the ticker to if `classic_ticker_import.is_contract` holds.
         /// * `config` to use for expiry and ticker length.
         ///
         /// # Errors
-        /// * `AssetAlreadyCreated` if `import.ticker` was created as an asset.
-        /// * `TickerTooLong` if the `config` considers the `import.ticker` too long.
-        /// * `TickerAlreadyRegistered` if `import.ticker` was already registered.
+        /// * `AssetAlreadyCreated` if `classic_ticker_import.ticker` was created as an asset.
+        /// * `TickerTooLong` if the `config` considers the `classic_ticker_import.ticker` too long.
+        /// * `TickerAlreadyRegistered` if `classic_ticker_import.ticker` was already registered.
         #[weight = 250_000_000]
         pub fn reserve_classic_ticker(
             origin,
-            import: ClassicTickerImport,
+            classic_ticker_import: ClassicTickerImport,
             contract_did: IdentityId,
             config: TickerRegistrationConfig<T::Moment>,
         ) {
@@ -994,18 +994,18 @@ decl_module! {
 
             let cm_did = SystematicIssuers::ClassicMigration.as_id();
             // Use DID of someone at Polymath if it's a contract-made ticker registration.
-            let did = if import.is_contract { contract_did } else { cm_did };
+            let did = if classic_ticker_import.is_contract { contract_did } else { cm_did };
 
             // Register the ticker...
-            let expiry = Self::ticker_registration_checks(&import.ticker, did, true, || config)?;
-            Self::_register_ticker(&import.ticker, did, expiry);
+            let expiry = Self::ticker_registration_checks(&classic_ticker_import.ticker, did, true, || config)?;
+            Self::_register_ticker(&classic_ticker_import.ticker, did, expiry);
 
             // ..and associate it with additional info needed for claiming.
             let classic_ticker = ClassicTickerRegistration {
-                eth_owner: import.eth_owner,
-                is_created: import.is_created,
+                eth_owner: classic_ticker_import.eth_owner,
+                is_created: classic_ticker_import.is_created,
             };
-            ClassicTickers::insert(&import.ticker, classic_ticker);
+            ClassicTickers::insert(&classic_ticker_import.ticker, classic_ticker);
         }
     }
 }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -600,14 +600,9 @@ decl_module! {
             } = Self::ensure_origin_call_permissions(origin)?;
             let record = Self::grant_check_only_primary_key(&sender, did)?;
 
-            // You are trying to add a permission to did's primary key. It is not needed.
-            match signer {
-                Signatory::Account(ref key) if record.primary_key == *key => Ok(()),
-                _ if record.secondary_keys.iter().any(|si| si.signer == signer) => {
-                    Self::update_secondary_key_permissions(did, &signer, permissions)
-                }
-                _ => Err(Error::<T>::InvalidSender.into()),
-            }
+            // Ensure that the signer is a secondary key of the caller's Identity
+            ensure!(record.secondary_keys.iter().any(|si| si.signer == signer), Error::<T>::NotASigner);
+            Self::update_secondary_key_permissions(did, &signer, permissions)
         }
 
         /// This function is a workaround for https://github.com/polkadot-js/apps/issues/3632
@@ -974,8 +969,6 @@ decl_error! {
         AlreadyLinked,
         /// Missing current identity on the transaction
         MissingCurrentIdentity,
-        /// Sender is not part of did's secondary keys
-        InvalidSender,
         /// No did linked to the user
         NoDIDFound,
         /// Signatory is not pre authorized by the identity

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2663,15 +2663,17 @@ decl_module! {
             Self::do_payout_stakers(validator_stash, era)
         }
 
-        /// Switch slashing status on the basis of given `SlashingSwitch`. Only be called by the root.
+        /// Switch slashing status on the basis of given `SlashingSwitch`. Can only be called by root.
+        ///
         /// # Arguments
         /// * origin - AccountId of root.
+        /// * slashing_switch - Switch used to set the targets for slashing.
         #[weight = 5_000_000 + T::DbWeight::get().reads_writes(2, 1)]
-        pub fn change_slashing_allowed_for(origin, switch: SlashingSwitch) {
+        pub fn change_slashing_allowed_for(origin, slashing_switch: SlashingSwitch) {
             // Ensure origin should be root.
             ensure_root(origin)?;
-            SlashingAllowedFor::put(switch);
-            Self::deposit_event(RawEvent::SlashingAllowedForChanged(switch));
+            SlashingAllowedFor::put(slashing_switch);
+            Self::deposit_event(RawEvent::SlashingAllowedForChanged(slashing_switch));
         }
     }
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1075,7 +1075,7 @@
         },
         "Tax": "Permill",
         "TargetIdentities": {
-            "identities": "Vec<IdentitityId>",
+            "identities": "Vec<IdentityId>",
             "treatment": "TargetTreatment"
         },
         "TargetTreatment": {


### PR DESCRIPTION
- `import` and `switch` are reserved keywords in Javascript and were creating troubles with our types generation system. This PR renames them to avoid the clash.
- Updated the errors in `set_permission_to_signer`.
- Fixed a typo in the schema.