### PR TITLE
Committee: embed `DispatchResult` in `Executed`

### DIFF
--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -178,9 +178,9 @@ decl_event!(
         /// tally (yes votes, no votes and total seats given respectively as `MemberCount`).
         /// Parameters: caller DID, proposal hash, yay vote count, nay vote count, total seats.
         Rejected(IdentityId, Hash, MemberCount, MemberCount, MemberCount),
-        /// A motion was executed; `bool` is true if returned without error.
-        /// Parameters: caller DID, proposal hash, status of proposal dispatch.
-        Executed(IdentityId, Hash, bool),
+        /// A motion was executed; `DispatchResult` is `Ok(())` if returned without error.
+        /// Parameters: caller DID, proposal hash, result of proposal dispatch.
+        Executed(IdentityId, Hash, DispatchResult),
         /// A proposal was closed after its duration was up.
         /// Parameters: caller DID, proposal hash, yay vote count, nay vote count.
         Closed(IdentityId, Hash, MemberCount, MemberCount),
@@ -577,8 +577,8 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         seats: MemberCount,
     ) {
         let origin = RawOrigin::Members(ayes, seats).into();
-        let ok = proposal.dispatch(origin).is_ok();
-        Self::deposit_event(RawEvent::Executed(did, hash, ok));
+        let res = proposal.dispatch(origin).map_err(|e| e.error).map(drop);
+        Self::deposit_event(RawEvent::Executed(did, hash, res));
     }
 
     /// Any committee member proposes a dispatchable.

--- a/pallets/runtime/tests/src/committee_test.rs
+++ b/pallets/runtime/tests/src/committee_test.rs
@@ -134,7 +134,7 @@ fn single_member_committee_works_we() {
     let hash = hash_enact_snapshot_results();
     let expected_event = EventRecord {
         phase: Phase::Initialization,
-        event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(alice_did, hash, true)),
+        event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(alice_did, hash, Ok(()))),
         topics: vec![],
     };
     assert_eq!(System::events().contains(&expected_event), true);
@@ -431,7 +431,7 @@ fn rage_quit_we() {
     let did = IdentityId::default();
     let expected_event = EventRecord {
         phase: Phase::Initialization,
-        event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(did, hash, true)),
+        event: EventTest::committee_Instance1(CommitteeRawEvent::Executed(did, hash, Ok(()))),
         topics: vec![],
     };
     assert_eq!(System::events().contains(&expected_event), true);


### PR DESCRIPTION
As requested by @maxsam4 