### PR TITLE
Cryp 187/change mercat dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "confidential_identity"
+version = "1.0.0"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
+dependencies = [
+ "blake2",
+ "bulletproofs",
+ "byteorder 1.3.4",
+ "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
+ "failure",
+ "lazy_static",
+ "merlin",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "schnorrkel 0.9.1 (git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue)",
+ "serde",
+ "serde_json",
+ "sha3 0.8.2",
+ "sp-std",
+ "zeroize",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,25 +1158,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "0.1.0"
-source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=develop#b137bb799c1bcbfcfc6fbc190499b94bb3ed5a55"
+name = "cryptography_core"
+version = "1.0.0"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
 dependencies = [
- "blake2",
  "bulletproofs",
  "byteorder 1.3.4",
- "criterion",
  "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "failure",
- "lazy_static",
- "log",
  "merlin",
  "parity-scale-codec",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "schnorrkel 0.9.1 (git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue)",
  "serde",
- "serde_json",
  "sha3 0.8.2",
  "sp-std",
  "zeroize",
@@ -1204,13 +1220,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd#3ad591b06ae0b9ad97f81711296bea8087a345e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder 1.3.4",
  "digest 0.8.1",
- "packed_simd_2",
  "rand_core 0.5.1",
- "serde",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -1218,12 +1233,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+source = "git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd#3ad591b06ae0b9ad97f81711296bea8087a345e9"
 dependencies = [
  "byteorder 1.3.4",
  "digest 0.8.1",
+ "packed_simd_2",
  "rand_core 0.5.1",
+ "serde",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -3457,6 +3473,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
+name = "mercat"
+version = "1.0.0"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
+dependencies = [
+ "bulletproofs",
+ "byteorder 1.3.4",
+ "cryptography_core",
+ "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
+ "failure",
+ "merlin",
+ "parity-scale-codec",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_json",
+ "sha3 0.8.2",
+ "sp-std",
+ "zeroize",
+]
+
+[[package]]
 name = "merlin"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,7 +4252,7 @@ name = "pallet-confidential"
 version = "0.1.0"
 dependencies = [
  "bulletproofs",
- "cryptography",
+ "cryptography_core",
  "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-support",
  "frame-system",
@@ -4241,11 +4278,12 @@ name = "pallet-confidential-asset"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
- "cryptography",
+ "cryptography_core",
  "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "mercat",
  "pallet-balances 0.1.0",
  "pallet-contracts",
  "pallet-identity",
@@ -4446,7 +4484,6 @@ dependencies = [
 name = "pallet-identity"
 version = "0.1.0"
 dependencies = [
- "cryptography",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4694,9 +4731,9 @@ name = "pallet-settlement"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
- "cryptography",
  "frame-support",
  "frame-system",
+ "mercat",
  "pallet-balances 0.1.0",
  "pallet-confidential-asset",
  "pallet-identity",
@@ -5479,7 +5516,7 @@ dependencies = [
  "base64 0.12.3",
  "blake2",
  "chrono",
- "cryptography",
+ "confidential_identity",
  "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-support",
  "frame-system",
@@ -5701,7 +5738,8 @@ version = "1.0.0"
 dependencies = [
  "base64 0.12.3",
  "chrono",
- "cryptography",
+ "confidential_identity",
+ "cryptography_core",
  "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "env_logger",
  "frame-benchmarking",
@@ -5711,6 +5749,7 @@ dependencies = [
  "ink_primitives",
  "lazy_static",
  "libsecp256k1",
+ "mercat",
  "pallet-asset",
  "pallet-authorship",
  "pallet-babe",
@@ -7361,24 +7400,6 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue#ee2eae5ef42e23685931d3cbc9019166775d8fb4"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
- "getrandom 0.1.15",
- "merlin",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "sha2 0.8.2",
- "subtle 2.3.0",
- "zeroize",
-]
-
-[[package]]
-name = "schnorrkel"
-version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
@@ -7389,6 +7410,24 @@ dependencies = [
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
+ "sha2 0.8.2",
+ "subtle 2.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "schnorrkel"
+version = "0.9.1"
+source = "git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue#ee2eae5ef42e23685931d3cbc9019166775d8fb4"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
+ "getrandom 0.1.15",
+ "merlin",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
  "sha2 0.8.2",
  "subtle 2.3.0",
  "zeroize",
@@ -9262,7 +9301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "confidential_identity"
 version = "1.0.0"
-source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=v2-mainnet#e9214224b10de8afdb8d33ebeffc0ec738f65d1f"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "cryptography_core"
 version = "1.0.0"
-source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=v2-mainnet#e9214224b10de8afdb8d33ebeffc0ec738f65d1f"
 dependencies = [
  "bulletproofs",
  "byteorder 1.3.4",
@@ -3475,14 +3475,11 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "mercat"
 version = "1.0.0"
-source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=CRYP-187/cleanup-dir-structure#ac0a27960bddcfc1e913b7f90c4a54dfe8de5552"
+source = "git+https://github.com/PolymathNetwork/cryptography.git?branch=v2-mainnet#e9214224b10de8afdb8d33ebeffc0ec738f65d1f"
 dependencies = [
- "bulletproofs",
  "byteorder 1.3.4",
  "cryptography_core",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "failure",
- "merlin",
  "parity-scale-codec",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -4251,9 +4248,7 @@ dependencies = [
 name = "pallet-confidential"
 version = "0.1.0"
 dependencies = [
- "bulletproofs",
  "cryptography_core",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-support",
  "frame-system",
  "pallet-identity",
@@ -4278,8 +4273,6 @@ name = "pallet-confidential-asset"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
- "cryptography_core",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4294,7 +4287,6 @@ dependencies = [
  "polymesh-common-utilities",
  "polymesh-primitives",
  "polymesh-primitives-derive",
- "schnorrkel 0.9.1 (git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue)",
  "sp-runtime",
  "sp-std",
 ]
@@ -5517,7 +5509,6 @@ dependencies = [
  "blake2",
  "chrono",
  "confidential_identity",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "frame-support",
  "frame-system",
  "hex",
@@ -5525,7 +5516,6 @@ dependencies = [
  "polymesh-primitives-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "schnorrkel 0.9.1 (git+https://github.com/PolymathNetwork/schnorrkel.git?branch=fix-simd-issue)",
  "serde",
  "serde_json",
  "sp-application-crypto",
@@ -5740,7 +5730,6 @@ dependencies = [
  "chrono",
  "confidential_identity",
  "cryptography_core",
- "curve25519-dalek 2.1.0 (git+https://github.com/PolymathNetwork/curve25519-dalek.git?branch=v2-packed-simd)",
  "env_logger",
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5729,7 +5729,6 @@ dependencies = [
  "base64 0.12.3",
  "chrono",
  "confidential_identity",
- "cryptography_core",
  "env_logger",
  "frame-benchmarking",
  "frame-support",

--- a/pallets/confidential-asset/Cargo.toml
+++ b/pallets/confidential-asset/Cargo.toml
@@ -18,7 +18,7 @@ pallet-portfolio = { path = "../portfolio", default-features = false }
 pallet-statistics = { path = "../statistics", default-features = false }
 
 # Crypto
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 
 # Substrate

--- a/pallets/confidential-asset/Cargo.toml
+++ b/pallets/confidential-asset/Cargo.toml
@@ -38,9 +38,28 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 [features]
 equalize = []
 default = ["std", "equalize", "runtime-benchmarks"]
-no_std = []
+no_std = [
+    "cryptography_core/no_std",
+]
 only-staking = []
-std = []
+std = [
+    "codec/std",
+    "cryptography_core/std",
+    "frame-benchmarking/std",
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-balances/std",
+    "pallet-contracts/std",
+    "pallet-identity/std",
+    "pallet-portfolio/std",
+    "pallet-statistics/std",
+    "pallet-session/std",
+    "polymesh-common-utilities/std",
+    "polymesh-primitives/std",
+    "polymesh-primitives-derive/std",
+    "sp-runtime/std",
+    "sp-std/std",
+]
 runtime-benchmarks = [
     "frame-benchmarking",
 ]

--- a/pallets/confidential-asset/Cargo.toml
+++ b/pallets/confidential-asset/Cargo.toml
@@ -48,6 +48,7 @@ std = [
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",
+    "mercat/std",
     "pallet-balances/std",
     "pallet-contracts/std",
     "pallet-identity/std",

--- a/pallets/confidential-asset/Cargo.toml
+++ b/pallets/confidential-asset/Cargo.toml
@@ -18,7 +18,8 @@ pallet-portfolio = { path = "../portfolio", default-features = false }
 pallet-statistics = { path = "../statistics", default-features = false }
 
 # Crypto
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
 schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }

--- a/pallets/confidential-asset/Cargo.toml
+++ b/pallets/confidential-asset/Cargo.toml
@@ -18,10 +18,7 @@ pallet-portfolio = { path = "../portfolio", default-features = false }
 pallet-statistics = { path = "../statistics", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
-schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 
 # Substrate
@@ -38,17 +35,15 @@ frame-benchmarking = { default-features = false, git = "https://github.com/parit
 [features]
 equalize = []
 default = ["std", "equalize", "runtime-benchmarks"]
-no_std = [
-    "cryptography_core/no_std",
-]
+no_std = [ "mercat/no_std" ]
 only-staking = []
 std = [
     "codec/std",
-    "cryptography_core/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",
     "mercat/std",
+    "mercat/avx2_backend",
     "pallet-balances/std",
     "pallet-contracts/std",
     "pallet-identity/std",

--- a/pallets/confidential-asset/src/lib.rs
+++ b/pallets/confidential-asset/src/lib.rs
@@ -104,23 +104,21 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use cryptography::{
-    mercat::{
-        account::{convert_asset_ids, AccountValidator},
-        asset::AssetValidator,
-        transaction::TransactionValidator,
-        AccountCreatorVerifier, AssetTransactionVerifier, EncryptedAmount, EncryptedAssetId,
-        EncryptionPubKey, InitializedAssetTx, JustifiedTransferTx, PubAccount, PubAccountTx,
-        TransferTransactionVerifier,
-    },
-    AssetId,
-};
+use cryptography_core::AssetId;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
     ensure,
 };
 use frame_system::ensure_signed;
+use mercat::{
+    account::{convert_asset_ids, AccountValidator},
+    asset::AssetValidator,
+    transaction::TransactionValidator,
+    AccountCreatorVerifier, AssetTransactionVerifier, EncryptedAmount, EncryptedAssetId,
+    EncryptionPubKey, InitializedAssetTx, JustifiedTransferTx, PubAccount, PubAccountTx,
+    TransferTransactionVerifier,
+};
 use pallet_identity as identity;
 use pallet_statistics::{self as statistics};
 use polymesh_common_utilities::{

--- a/pallets/confidential-asset/src/lib.rs
+++ b/pallets/confidential-asset/src/lib.rs
@@ -104,7 +104,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use cryptography_core::AssetId;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
@@ -114,6 +113,7 @@ use frame_system::ensure_signed;
 use mercat::{
     account::{convert_asset_ids, AccountValidator},
     asset::AssetValidator,
+    cryptography_core::AssetId,
     transaction::TransactionValidator,
     AccountCreatorVerifier, AssetTransactionVerifier, EncryptedAmount, EncryptedAssetId,
     EncryptionPubKey, InitializedAssetTx, JustifiedTransferTx, PubAccount, PubAccountTx,

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime-interface = { git = "https://github.com/paritytech/substrate", defaul
 # Crypto
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", default-features = false, optional = true }
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
 bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "v2-packed-simd", default-features = false, features = ["zeroize"] }
 
@@ -41,19 +41,18 @@ only-staking = []
 default = ["std", "equalize", "u64_backend"]
 
 # Backends
-# u32_backend = ["cryptography/u32_backend"]
-u64_backend = ["cryptography/u64_backend"]
-avx2_backend = ["cryptography/avx2_backend"]
+u64_backend = ["cryptography_core/u64_backend"]
+avx2_backend = ["cryptography_core/avx2_backend"]
 
 no_std = [
-	"cryptography/no_std",
+	"cryptography_core/no_std",
 	"u64_backend"
 ]
 
 std = [
 	"rand/std",
 	"rand_core/std",
-	"cryptography/std",
+	"cryptography_core/std",
 	"codec/std",
 	"sp-core/std",
 	"sp-std/std",

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime-interface = { git = "https://github.com/paritytech/substrate", defaul
 # Crypto
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", default-features = false, optional = true }
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 
 [features]
 equalize = []

--- a/pallets/confidential/Cargo.toml
+++ b/pallets/confidential/Cargo.toml
@@ -30,29 +30,20 @@ sp-runtime-interface = { git = "https://github.com/paritytech/substrate", defaul
 # Crypto
 rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.7.3", default-features = false, optional = true }
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
-bulletproofs = { git = "https://github.com/PolymathNetwork/bulletproofs.git", branch = "v2-packed-simd", default-features = false, features = ["zeroize"] }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
 
 [features]
 equalize = []
 only-staking = []
-# default = ["std", "equalize", "avx2_backend"]
-default = ["std", "equalize", "u64_backend"]
+default = ["std", "equalize"]
 
-# Backends
-u64_backend = ["cryptography_core/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend"]
-
-no_std = [
-	"cryptography_core/no_std",
-	"u64_backend"
-]
+no_std = [ "cryptography_core/no_std" ]
 
 std = [
 	"rand/std",
 	"rand_core/std",
 	"cryptography_core/std",
+	"cryptography_core/avx2_backend",
 	"codec/std",
 	"sp-core/std",
 	"sp-std/std",

--- a/pallets/confidential/src/lib.rs
+++ b/pallets/confidential/src/lib.rs
@@ -21,11 +21,11 @@ use polymesh_primitives_derive::{SliceU8StrongTyped, VecU8StrongTyped};
 
 use pallet_identity as identity;
 
-use bulletproofs::RangeProof;
-use cryptography_core::asset_proofs::range_proof::{
-    prove_within_range, verify_within_range, InRangeProof,
+use cryptography_core::{
+    asset_proofs::range_proof::{prove_within_range, verify_within_range, InRangeProof},
+    bulletproofs::RangeProof,
+    curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
 };
-use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
 
 use codec::{Decode, Encode};
 use frame_support::{

--- a/pallets/confidential/src/lib.rs
+++ b/pallets/confidential/src/lib.rs
@@ -22,7 +22,7 @@ use polymesh_primitives_derive::{SliceU8StrongTyped, VecU8StrongTyped};
 use pallet_identity as identity;
 
 use bulletproofs::RangeProof;
-use cryptography::asset_proofs::range_proof::{
+use cryptography_core::asset_proofs::range_proof::{
     prove_within_range, verify_within_range, InRangeProof,
 };
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -30,7 +30,6 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-fe
 # Only in STD
 schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false, optional = true }
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v2.0.0", optional = true }
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false, optional = true }
 
 [features]
 equalize = []
@@ -56,10 +55,8 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "sp-version/std",
-    "cryptography/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",
-    "cryptography",
     "schnorrkel",
 ]

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -101,10 +101,7 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https:
 [features]
 default = ["std", "equalize"]
 equalize = []
-no_std = [
-    "pallet-confidential/no_std",
-    "pallet-confidential/u64_backend",
-]
+no_std = [ "pallet-confidential/no_std", ]
 std = [
     "codec/std",
     "frame-benchmarking/std",

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -101,7 +101,6 @@ default = ["std", "equalize"]
 equalize = []
 no_std = [
     "pallet-confidential/no_std",
-    "pallet-confidential/u64_backend",
 ]
 std = [
     "codec/std",

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -41,7 +41,6 @@ pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-f
 
 # Crypto
 confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
@@ -97,15 +96,12 @@ only-staking = []
 default = ["std", "equalize"]
 no_std = [
     "confidential_identity/no_std", 
-    "cryptography_core/no_std",
     "mercat/no_std",
 ]
 std = [
     # Crypto
     "confidential_identity/std",
     "confidential_identity/avx2_backend",
-    "cryptography_core/std",
-    "cryptography_core/avx2_backend",
     "mercat/std",
     "mercat/avx2_backend",
     # Other

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -40,11 +40,11 @@ polymesh-contracts = { path = "../../contracts", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
-curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
 
 # Runtime
 polymesh-runtime-develop = { path = "../develop" }
@@ -95,9 +95,20 @@ wat = "1.0"
 equalize = []
 only-staking = []
 default = ["std", "equalize"]
+no_std = [
+    "confidential_identity/no_std", 
+    "cryptography_core/no_std",
+    "mercat/no_std",
+]
 std = [
+    # Crypto
+    "confidential_identity/std",
+    "confidential_identity/avx2_backend",
     "cryptography_core/std",
+    "cryptography_core/avx2_backend",
     "mercat/std",
+    "mercat/avx2_backend",
+    # Other
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -40,7 +40,9 @@ polymesh-contracts = { path = "../../contracts", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 
 # Crypto
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false, features = ["nightly"] }
 
@@ -94,7 +96,8 @@ equalize = []
 only-staking = []
 default = ["std", "equalize"]
 std = [
-    "cryptography/std",
+    "cryptography_core/std",
+    "mercat/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -40,9 +40,9 @@ polymesh-contracts = { path = "../../contracts", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 
 # Crypto
-confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
-cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
+cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 

--- a/pallets/runtime/tests/src/confidential_asset_test.rs
+++ b/pallets/runtime/tests/src/confidential_asset_test.rs
@@ -6,15 +6,15 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography_core::{
-    asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    curve25519_dalek::scalar::Scalar,
-    AssetId,
-};
 use frame_support::{assert_err, assert_ok};
 use mercat::{
     account::{convert_asset_ids, AccountCreator},
     asset::AssetIssuer,
+    cryptography_core::{
+        asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+        curve25519_dalek::scalar::Scalar,
+        AssetId,
+    },
     Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptionKeys, PubAccountTx,
     SecAccount,
 };

--- a/pallets/runtime/tests/src/confidential_asset_test.rs
+++ b/pallets/runtime/tests/src/confidential_asset_test.rs
@@ -6,18 +6,18 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography::{
+use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    mercat::{
-        account::{convert_asset_ids, AccountCreator},
-        asset::AssetIssuer,
-        Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptionKeys, PubAccountTx,
-        SecAccount,
-    },
     AssetId,
 };
 use curve25519_dalek::scalar::Scalar;
 use frame_support::{assert_err, assert_ok};
+use mercat::{
+    account::{convert_asset_ids, AccountCreator},
+    asset::AssetIssuer,
+    Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptionKeys, PubAccountTx,
+    SecAccount,
+};
 use pallet_asset as asset;
 use pallet_confidential_asset as confidential_asset;
 use pallet_identity as identity;

--- a/pallets/runtime/tests/src/confidential_asset_test.rs
+++ b/pallets/runtime/tests/src/confidential_asset_test.rs
@@ -8,9 +8,9 @@ use confidential_asset::{
 use core::convert::{TryFrom, TryInto};
 use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+    curve25519_dalek::scalar::Scalar,
     AssetId,
 };
-use curve25519_dalek::scalar::Scalar;
 use frame_support::{assert_err, assert_ok};
 use mercat::{
     account::{convert_asset_ids, AccountCreator},

--- a/pallets/runtime/tests/src/confidential_test.rs
+++ b/pallets/runtime/tests/src/confidential_test.rs
@@ -3,7 +3,7 @@ use super::{
     ExtBuilder,
 };
 
-use cryptography::claim_proofs::{compute_cdd_id, compute_scope_id};
+use confidential_identity::{compute_cdd_id, compute_scope_id};
 use pallet_asset as asset;
 use pallet_compliance_manager as compliance_manager;
 use pallet_confidential as confidential;

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -11,22 +11,21 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography::{
+use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    mercat::{
-        account::{convert_asset_ids, AccountCreator},
-        asset::AssetIssuer,
-        transaction::{CtxMediator, CtxReceiver, CtxSender},
-        Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount,
-        EncryptionKeys, FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx,
-        SecAccount, TransferTransactionMediator, TransferTransactionReceiver,
-        TransferTransactionSender,
-    },
     AssetId,
 };
 use curve25519_dalek::scalar::Scalar;
 use frame_support::{
     assert_noop, assert_ok, dispatch::GetDispatchInfo, traits::OnInitialize, StorageMap,
+};
+use mercat::{
+    account::{convert_asset_ids, AccountCreator},
+    asset::AssetIssuer,
+    transaction::{CtxMediator, CtxReceiver, CtxSender},
+    Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount, EncryptionKeys,
+    FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx, SecAccount,
+    TransferTransactionMediator, TransferTransactionReceiver, TransferTransactionSender,
 };
 use pallet_asset as asset;
 use pallet_balances as balances;

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -11,17 +11,17 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography_core::{
-    asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    curve25519_dalek::scalar::Scalar,
-    AssetId,
-};
 use frame_support::{
     assert_noop, assert_ok, dispatch::GetDispatchInfo, traits::OnInitialize, StorageMap,
 };
 use mercat::{
     account::{convert_asset_ids, AccountCreator},
     asset::AssetIssuer,
+    cryptography_core::{
+        asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+        curve25519_dalek::scalar::Scalar,
+        AssetId,
+    },
     transaction::{CtxMediator, CtxReceiver, CtxSender},
     Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount, EncryptionKeys,
     FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx, SecAccount,

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -13,9 +13,9 @@ use confidential_asset::{
 use core::convert::{TryFrom, TryInto};
 use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+    curve25519_dalek::scalar::Scalar,
     AssetId,
 };
-use curve25519_dalek::scalar::Scalar;
 use frame_support::{
     assert_noop, assert_ok, dispatch::GetDispatchInfo, traits::OnInitialize, StorageMap,
 };

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -3,7 +3,7 @@ use super::ext_builder::{
     TRANSACTION_BYTE_FEE, WEIGHT_TO_FEE,
 };
 use codec::Encode;
-use cryptography::claim_proofs::{compute_cdd_id, compute_scope_id};
+use confidential_identity::{compute_cdd_id, compute_scope_id};
 use frame_support::{
     assert_ok, impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types,
     traits::{Currency, Imbalance, OnUnbalanced},

--- a/pallets/runtime/tests/src/transaction_ordering_test.rs
+++ b/pallets/runtime/tests/src/transaction_ordering_test.rs
@@ -7,15 +7,15 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography_core::{
-    asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    curve25519_dalek::scalar::Scalar,
-    AssetId,
-};
 use frame_support::assert_ok;
 use mercat::{
     account::{convert_asset_ids, AccountCreator},
     asset::AssetIssuer,
+    cryptography_core::{
+        asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+        curve25519_dalek::scalar::Scalar,
+        AssetId,
+    },
     transaction::{CtxMediator, CtxReceiver, CtxSender},
     Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount, EncryptionKeys,
     FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx, SecAccount,

--- a/pallets/runtime/tests/src/transaction_ordering_test.rs
+++ b/pallets/runtime/tests/src/transaction_ordering_test.rs
@@ -9,9 +9,9 @@ use confidential_asset::{
 use core::convert::{TryFrom, TryInto};
 use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
+    curve25519_dalek::scalar::Scalar,
     AssetId,
 };
-use curve25519_dalek::scalar::Scalar;
 use frame_support::assert_ok;
 use mercat::{
     account::{convert_asset_ids, AccountCreator},

--- a/pallets/runtime/tests/src/transaction_ordering_test.rs
+++ b/pallets/runtime/tests/src/transaction_ordering_test.rs
@@ -7,21 +7,20 @@ use confidential_asset::{
     EncryptedAssetIdWrapper, InitializedAssetTxWrapper, MercatAccountId, PubAccountTxWrapper,
 };
 use core::convert::{TryFrom, TryInto};
-use cryptography::{
+use cryptography_core::{
     asset_proofs::{CommitmentWitness, ElgamalSecretKey},
-    mercat::{
-        account::{convert_asset_ids, AccountCreator},
-        asset::AssetIssuer,
-        transaction::{CtxMediator, CtxReceiver, CtxSender},
-        Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount,
-        EncryptionKeys, FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx,
-        SecAccount, TransferTransactionMediator, TransferTransactionReceiver,
-        TransferTransactionSender,
-    },
     AssetId,
 };
 use curve25519_dalek::scalar::Scalar;
 use frame_support::assert_ok;
+use mercat::{
+    account::{convert_asset_ids, AccountCreator},
+    asset::AssetIssuer,
+    transaction::{CtxMediator, CtxReceiver, CtxSender},
+    Account, AccountCreatorInitializer, AssetTransactionIssuer, EncryptedAmount, EncryptionKeys,
+    FinalizedTransferTx, InitializedTransferTx, PubAccount, PubAccountTx, SecAccount,
+    TransferTransactionMediator, TransferTransactionReceiver, TransferTransactionSender,
+};
 use pallet_asset as asset;
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;

--- a/pallets/settlement/Cargo.toml
+++ b/pallets/settlement/Cargo.toml
@@ -28,7 +28,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 
 [features]

--- a/pallets/settlement/Cargo.toml
+++ b/pallets/settlement/Cargo.toml
@@ -28,7 +28,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 
 [features]

--- a/pallets/settlement/Cargo.toml
+++ b/pallets/settlement/Cargo.toml
@@ -28,19 +28,20 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 
-mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
+mercat = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 
 [features]
 equalize = []
 default = ["std", "equalize"]
-no_std = []
+no_std = [ "mercat/no_std" ]
 only-staking = []
 std = [
     "codec/std",
     "frame-support/std",
     "frame-system/std",
     "mercat/std",
+    "mercat/avx2_backend",
     "pallet-balances/std",
     "pallet-identity/std",
     "pallet-timestamp/std",

--- a/pallets/settlement/Cargo.toml
+++ b/pallets/settlement/Cargo.toml
@@ -16,13 +16,13 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false  }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
 
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-serializer = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
@@ -40,11 +40,13 @@ std = [
     "codec/std",
     "frame-support/std",
     "frame-system/std",
+    "mercat/std",
     "pallet-balances/std",
     "pallet-identity/std",
     "pallet-timestamp/std",
     "polymesh-common-utilities/std",
     "polymesh-primitives/std",
+    "polymesh-primitives-derive/std",
     "serde/std",
     "serde_derive",
     "sp-api/std",

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -37,7 +37,6 @@
 #![recursion_limit = "256"]
 
 use codec::{Decode, Encode};
-use cryptography::mercat::{InitializedTransferTx, JustifiedTransferTx};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo},
@@ -50,6 +49,7 @@ use frame_support::{
     IterableStorageDoubleMap, Parameter, StorageHasher, Twox128,
 };
 use frame_system::{self as system, ensure_root, RawOrigin};
+use mercat::{InitializedTransferTx, JustifiedTransferTx};
 use pallet_confidential_asset::{self as confidential_asset, MercatAccountId};
 use pallet_identity as identity;
 use polymesh_common_utilities::{

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,7 @@ polymesh-primitives-derive = { path = "../primitives_derive", default-features =
 serde = { version = "1.0.104", optional = true, default-features = false, features = ["derive"] }
 
 # Crypto
-confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "v2-mainnet", default-features = false }
 blake2 = { version = "0.9.0", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 rand_core = { version = "0.5", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,7 @@ polymesh-primitives-derive = { path = "../primitives_derive", default-features =
 serde = { version = "1.0.104", optional = true, default-features = false, features = ["derive"] }
 
 # Crypto
-cryptography = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "develop", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
 curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false }
 schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
 blake2 = { version = "0.9.0", default-features = false }
@@ -43,12 +43,12 @@ serde_json = "1.0.48"
 default = ["std"]
 
 # Backends
-u32_backend = [ "cryptography/u32_backend", "schnorrkel/u32_backend"]
-u64_backend = [ "cryptography/u64_backend", "schnorrkel/u64_backend"]
-avx2_backend = [ "cryptography/avx2_backend", "schnorrkel/u64_backend"]
+u32_backend = [ "confidential_identity/u32_backend", "schnorrkel/u32_backend"]
+u64_backend = [ "confidential_identity/u64_backend", "schnorrkel/u64_backend"]
+avx2_backend = [ "confidential_identity/avx2_backend", "schnorrkel/u64_backend"]
 
 no_std = [
-	"cryptography/no_std",
+	"confidential_identity/no_std",
 ]
 
 std = [
@@ -64,7 +64,7 @@ std = [
 	"frame-system/std",
 	"sp-io/std",
 	# Crypto
-	"cryptography/std",
+	"confidential_identity/std",
 	"schnorrkel/std",
 	"blake2/std",
 	"blake2/simd",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,9 +14,7 @@ polymesh-primitives-derive = { path = "../primitives_derive", default-features =
 serde = { version = "1.0.104", optional = true, default-features = false, features = ["derive"] }
 
 # Crypto
-confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure", default-features = false }
-curve25519-dalek = { git = "https://github.com/PolymathNetwork/curve25519-dalek.git", branch = "v2-packed-simd", default-features = false }
-schnorrkel = { git = "https://github.com/PolymathNetwork/schnorrkel.git", branch = "fix-simd-issue", default-features = false }
+confidential_identity = { git = "https://github.com/PolymathNetwork/cryptography.git", branch = "CRYP-187/cleanup-dir-structure_miguel", default-features = false }
 blake2 = { version = "0.9.0", default-features = false }
 base64 = { version = "0.12.1", default-features = false, features = ["alloc"] }
 rand_core = { version = "0.5", default-features = false }
@@ -41,16 +39,7 @@ serde_json = "1.0.48"
 
 [features]
 default = ["std"]
-
-# Backends
-u32_backend = [ "confidential_identity/u32_backend", "schnorrkel/u32_backend"]
-u64_backend = [ "confidential_identity/u64_backend", "schnorrkel/u64_backend"]
-avx2_backend = [ "confidential_identity/avx2_backend", "schnorrkel/u64_backend"]
-
-no_std = [
-	"confidential_identity/no_std",
-]
-
+no_std = [ "confidential_identity/no_std" ]
 std = [
 	"rand/std",
 	"rand_core/std",
@@ -65,16 +54,13 @@ std = [
 	"sp-io/std",
 	# Crypto
 	"confidential_identity/std",
-	"schnorrkel/std",
+	"confidential_identity/avx2_backend",
 	"blake2/std",
 	"blake2/simd",
 	"polymesh-primitives-derive/std",
-	"curve25519-dalek/std",
 	"sp-application-crypto/std",
     "sp-runtime-interface/std",
 ]
 
 runtime-benchmarks = [
-    "sp-io/disable_panic_handler",
-    "sp-io/disable_oom"
 ]

--- a/primitives/src/cdd_id.rs
+++ b/primitives/src/cdd_id.rs
@@ -1,5 +1,5 @@
 use crate::{IdentityId, InvestorZKProofData};
-use cryptography::claim_proofs::compute_cdd_id;
+use confidential_identity::compute_cdd_id;
 use polymesh_primitives_derive::SliceU8StrongTyped;
 
 use codec::{Decode, Encode};

--- a/primitives/src/investor_zkproof_data.rs
+++ b/primitives/src/investor_zkproof_data.rs
@@ -1,10 +1,9 @@
 use crate::{IdentityId, InvestorUid, Ticker};
 use confidential_identity::{
-    build_scope_claim_proof_data, CddClaimData, ProofKeyPair, ScopeClaimData,
+    build_scope_claim_proof_data, schnorrkel::Signature, CddClaimData, ProofKeyPair, ScopeClaimData,
 };
 
 use blake2::{Blake2s, Digest};
-use schnorrkel::Signature;
 
 use codec::{Decode, Encode, Error as CodecError, Input, Output};
 #[cfg(feature = "std")]

--- a/primitives/src/investor_zkproof_data.rs
+++ b/primitives/src/investor_zkproof_data.rs
@@ -1,5 +1,5 @@
 use crate::{IdentityId, InvestorUid, Ticker};
-use cryptography::claim_proofs::{
+use confidential_identity::{
     build_scope_claim_proof_data, CddClaimData, ProofKeyPair, ScopeClaimData,
 };
 

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,6 +1,5 @@
 use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope};
-use confidential_identity::ProofPublicKey;
-use curve25519_dalek::ristretto::CompressedRistretto;
+use confidential_identity::{CompressedRistretto, ProofPublicKey};
 
 // ZKProofs claims
 // =========================================================

--- a/primitives/src/valid_proof_of_investor.rs
+++ b/primitives/src/valid_proof_of_investor.rs
@@ -1,5 +1,5 @@
 use crate::{CddId, Claim, IdentityId, InvestorZKProofData, Scope};
-use cryptography::claim_proofs::ProofPublicKey;
+use confidential_identity::ProofPublicKey;
 use curve25519_dalek::ristretto::CompressedRistretto;
 
 // ZKProofs claims
@@ -56,7 +56,7 @@ mod tests {
     use super::*;
     use crate::proposition::{exists, Proposition};
     use crate::{Claim, Context, InvestorUid, InvestorZKProofData, Ticker};
-    use cryptography::claim_proofs::{compute_cdd_id, compute_scope_id};
+    use confidential_identity::{compute_cdd_id, compute_scope_id};
     use sp_std::convert::{From, TryFrom};
 
     #[test]


### PR DESCRIPTION
Changes to dependencies to match the restructure of cryptography repo done in https://github.com/PolymathNetwork/cryptography/pull/97

I'll fix the CI issues and then point it to the correct branch