### PR TITLE
More minor fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,14 @@ jobs:
             - v1-bb-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
           name: Build binary with runtime-benchmarks
-          command: cargo build --features=runtime-benchmarks || cargo build -j 1 --features=runtime-benchmarks
+          command: cargo build --release --features=runtime-benchmarks || cargo build --release -j 1 --features=runtime-benchmarks
           no_output_timeout: 30m
       - save_cache:
           key: v1-bb-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "./target"
+          when: always
   test:
     docker:
       - image: polymathnet/rust:debian-nightly-2020-09-28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
           paths:
             - "~/.cargo"
             - "./target"
-          when: always
   test:
     docker:
       - image: polymathnet/rust:debian-nightly-2020-09-28

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1555,11 +1555,7 @@ impl<T: Trait> Module<T> {
             return Ok((ERC1400_TRANSFERS_HALTED, T::DbWeight::get().reads(1)));
         }
 
-        if !Identity::<T>::verify_scope_claims_for_transfer(
-            ticker,
-            from_portfolio.did,
-            to_portfolio.did,
-        ) {
+        if !Identity::<T>::verify_iu_claim(*ticker, to_portfolio.did) {
             return Ok((SCOPE_CLAIM_MISSING, T::DbWeight::get().reads(2)));
         }
 
@@ -2069,11 +2065,7 @@ impl<T: Trait> Module<T> {
             return Ok(INVALID_SENDER_DID);
         }
 
-        if !Identity::<T>::verify_scope_claims_for_transfer(
-            ticker,
-            from_portfolio.did,
-            to_portfolio.did,
-        ) {
+        if !Identity::<T>::verify_iu_claim(*ticker, to_portfolio.did) {
             return Ok(SCOPE_CLAIM_MISSING);
         }
 

--- a/pallets/compliance-manager/src/benchmarking.rs
+++ b/pallets/compliance-manager/src/benchmarking.rs
@@ -253,12 +253,13 @@ benchmarks! {
 
         // Delete the latest trusted issuer.
         let issuer = Module::<T>::trusted_claim_issuer(d.ticker).pop().unwrap();
-    }: _(d.owner.origin, d.ticker, issuer.clone())
+    }: _(d.owner.origin, d.ticker, issuer.issuer.clone())
     verify {
         let trusted_issuers = Module::<T>::trusted_claim_issuer(d.ticker);
         ensure!(
-            trusted_issuers.contains(&issuer) == false,
-            "Default trusted claim issuer was not removed");
+            !trusted_issuers.contains(&issuer),
+            "Default trusted claim issuer was not removed"
+        );
     }
 
     change_compliance_requirement {

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -445,7 +445,7 @@ decl_module! {
             let did = T::Asset::ensure_perms_owner_asset(origin, &ticker)?;
             TrustedClaimIssuer::try_mutate(ticker, |issuers| {
                 let len = issuers.len();
-                issuers.retain(|ti| ti.issuer != &issuer);
+                issuers.retain(|ti| ti.issuer != issuer);
                 ensure!(len != issuers.len(), Error::<T>::IncorrectOperationOnTrustedIssuer);
                 Ok(()) as DispatchResult
             })?;

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -441,11 +441,11 @@ decl_module! {
         /// * ticker - Symbol of the asset.
         /// * issuer - IdentityId of the trusted claim issuer.
         #[weight = <T as Trait>::WeightInfo::remove_default_trusted_claim_issuer()]
-        pub fn remove_default_trusted_claim_issuer(origin, ticker: Ticker, issuer: TrustedIssuer) {
+        pub fn remove_default_trusted_claim_issuer(origin, ticker: Ticker, issuer: IdentityId) {
             let did = T::Asset::ensure_perms_owner_asset(origin, &ticker)?;
             TrustedClaimIssuer::try_mutate(ticker, |issuers| {
                 let len = issuers.len();
-                issuers.retain(|ti| ti != &issuer);
+                issuers.retain(|ti| ti.issuer != &issuer);
                 ensure!(len != issuers.len(), Error::<T>::IncorrectOperationOnTrustedIssuer);
                 Ok(()) as DispatchResult
             })?;
@@ -508,7 +508,7 @@ decl_event!(
         TrustedDefaultClaimIssuerAdded(IdentityId, Ticker, TrustedIssuer),
         /// Emitted when default claim issuer list for a given ticker get removed.
         /// (caller DID, Ticker, Removed TrustedIssuer).
-        TrustedDefaultClaimIssuerRemoved(IdentityId, Ticker, TrustedIssuer),
+        TrustedDefaultClaimIssuerRemoved(IdentityId, Ticker, IdentityId),
     }
 );
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1859,17 +1859,25 @@ impl<T: Trait> Module<T> {
         Ok(primary_did)
     }
 
-    /// Checks whether the sender and the receiver of a transfer have valid scope claims
-    pub fn verify_scope_claims_for_transfer(
-        ticker: &Ticker,
+    /// Checks whether the sender and the receiver of a transfer have valid investor uniqueness claims for a given ticker
+    pub fn verify_iu_claims_for_transfer(
+        ticker: Ticker,
         from_did: IdentityId,
         to_did: IdentityId,
     ) -> bool {
-        let verify_scope_claim = |did| {
-            let asset_scope = Some(Scope::from(*ticker));
-            Self::fetch_claim(did, ClaimType::InvestorUniqueness, did, asset_scope).is_some()
-        };
-        verify_scope_claim(from_did) && verify_scope_claim(to_did)
+        let asset_scope = Some(Scope::from(ticker));
+        Self::base_verify_iu_claim(asset_scope.clone(), from_did)
+            && Self::base_verify_iu_claim(asset_scope, to_did)
+    }
+
+    /// Checks whether the identity has a valid investor uniqueness claim for a given ticker
+    pub fn verify_iu_claim(ticker: Ticker, did: IdentityId) -> bool {
+        let asset_scope = Some(Scope::from(ticker));
+        Self::base_verify_iu_claim(asset_scope, did)
+    }
+
+    fn base_verify_iu_claim(scope: Option<Scope>, did: IdentityId) -> bool {
+        Self::fetch_claim(did, ClaimType::InvestorUniqueness, did, scope).is_some()
     }
 }
 

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -809,7 +809,7 @@ fn should_modify_vector_of_trusted_issuer_we() {
     assert_ok!(ComplianceManager::remove_default_trusted_claim_issuer(
         token_owner_signed.clone(),
         ticker,
-        trusted_issuer_did_1.into()
+        trusted_issuer_did_1
     ));
 
     assert_eq!(ComplianceManager::trusted_claim_issuer(ticker).len(), 1);


### PR DESCRIPTION
- `remove_default_trusted_claim_issuer` now takes only the issuer Identity instead of the full `TrustedIssuer` object. (API breaking but suggested by the SDK team)
- Investor uniqueness claim is no longer checked for the sender.
- Fixed benchmark build.