### PR TITLE
MESH-1483: Rename valid_from to trade_date and add value_date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4786,6 +4786,7 @@ dependencies = [
 name = "pallet-treasury"
 version = "0.1.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances 0.1.0",
@@ -5412,6 +5413,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-runtime-interface",
  "sp-std",
  "sp-version",
 ]
@@ -5690,11 +5692,13 @@ dependencies = [
  "pallet-confidential",
  "pallet-corporate-actions",
  "pallet-identity",
+ "pallet-im-online",
  "pallet-pips",
  "pallet-portfolio",
  "pallet-protocol-fee",
  "pallet-settlement",
  "pallet-timestamp",
+ "pallet-treasury 0.1.0",
  "pallet-utility",
  "polymesh-contracts",
 ]

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -193,6 +193,7 @@ fn basic_settlement() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice_did),
                     to: PortfolioId::default_portfolio(bob_did),
@@ -260,6 +261,7 @@ fn create_and_affirm_instruction() {
                     alice_signed.clone(),
                     venue_counter,
                     SettlementType::SettleOnAffirmation,
+                    None,
                     None,
                     vec![Leg {
                         from: PortfolioId::default_portfolio(alice_did),
@@ -340,6 +342,7 @@ fn overdraft_failure() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice_did),
                     to: PortfolioId::default_portfolio(bob_did),
@@ -409,6 +412,7 @@ fn token_swap() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 legs.clone()
             ));
 
@@ -443,7 +447,8 @@ fn token_swap() {
                 status: InstructionStatus::Pending,
                 settlement_type: SettlementType::SettleOnAffirmation,
                 created_at: Some(Timestamp::get()),
-                valid_from: None,
+                trade_date: None,
+                value_date: None,
             };
             assert_eq!(
                 Settlement::instruction_details(instruction_counter),
@@ -724,6 +729,7 @@ fn claiming_receipt() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 legs.clone()
             ));
 
@@ -758,7 +764,8 @@ fn claiming_receipt() {
                 status: InstructionStatus::Pending,
                 settlement_type: SettlementType::SettleOnAffirmation,
                 created_at: Some(Timestamp::get()),
-                valid_from: None,
+                trade_date: None,
+                value_date: None,
             };
             assert_eq!(
                 Settlement::instruction_details(instruction_counter),
@@ -1161,6 +1168,7 @@ fn settle_on_block() {
                 venue_counter,
                 SettlementType::SettleOnBlock(block_number),
                 None,
+                None,
                 legs.clone()
             ));
             assert_eq!(1, scheduler::Agenda::<TestStorage>::get(block_number).len());
@@ -1196,7 +1204,8 @@ fn settle_on_block() {
                 status: InstructionStatus::Pending,
                 settlement_type: SettlementType::SettleOnBlock(block_number),
                 created_at: Some(Timestamp::get()),
-                valid_from: None,
+                trade_date: None,
+                value_date: None,
             };
             assert_eq!(
                 Settlement::instruction_details(instruction_counter),
@@ -1425,6 +1434,7 @@ fn failed_execution() {
                 venue_counter,
                 SettlementType::SettleOnBlock(block_number),
                 None,
+                None,
                 legs.clone()
             ));
             assert_eq!(1, scheduler::Agenda::<TestStorage>::get(block_number).len());
@@ -1460,7 +1470,8 @@ fn failed_execution() {
                 status: InstructionStatus::Pending,
                 settlement_type: SettlementType::SettleOnBlock(block_number),
                 created_at: Some(Timestamp::get()),
-                valid_from: None,
+                trade_date: None,
+                value_date: None,
             };
             assert_eq!(
                 Settlement::instruction_details(instruction_counter),
@@ -1659,6 +1670,7 @@ fn venue_filtering() {
                 venue_counter,
                 SettlementType::SettleOnBlock(block_number),
                 None,
+                None,
                 legs.clone()
             ));
             assert_ok!(Settlement::set_venue_filtering(
@@ -1671,6 +1683,7 @@ fn venue_filtering() {
                     alice_signed.clone(),
                     venue_counter,
                     SettlementType::SettleOnBlock(block_number),
+                    None,
                     None,
                     legs.clone()
                 ),
@@ -1685,6 +1698,7 @@ fn venue_filtering() {
                 alice_signed.clone(),
                 venue_counter,
                 SettlementType::SettleOnBlock(block_number + 1),
+                None,
                 None,
                 legs.clone(),
                 default_portfolio_vec(alice_did)
@@ -1863,6 +1877,7 @@ fn basic_fuzzing() {
                 venue_counter,
                 SettlementType::SettleOnBlock(block_number),
                 None,
+                None,
                 legs
             ));
 
@@ -2025,6 +2040,7 @@ fn claim_multiple_receipts_during_authorization() {
                 alice_signed.clone(),
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
+                None,
                 None,
                 legs.clone()
             ));
@@ -2234,12 +2250,14 @@ fn overload_settle_on_block() {
                     venue_counter,
                     SettlementType::SettleOnBlock(block_number),
                     None,
+                    None,
                     legs.clone()
                 ));
                 assert_ok!(Settlement::add_instruction(
                     alice_signed.clone(),
                     venue_counter,
                     SettlementType::SettleOnBlock(block_number + 1),
+                    None,
                     None,
                     legs.clone()
                 ));
@@ -2483,6 +2501,7 @@ fn test_weights_for_settlement_transaction() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 legs.clone(),
             )
             .get_dispatch_info()
@@ -2492,6 +2511,7 @@ fn test_weights_for_settlement_transaction() {
                 alice_signed.clone(),
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
+                None,
                 None,
                 legs.clone()
             ));
@@ -2572,6 +2592,7 @@ fn cross_portfolio_settlement() {
                 alice_signed.clone(),
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
+                None,
                 None,
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice_did),
@@ -2705,6 +2726,7 @@ fn multiple_portfolio_settlement() {
                 alice_signed.clone(),
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
+                None,
                 None,
                 vec![
                     Leg {
@@ -2924,6 +2946,7 @@ fn multiple_custodian_settlement() {
                 venue_counter,
                 SettlementType::SettleOnAffirmation,
                 None,
+                None,
                 vec![
                     Leg {
                         from: PortfolioId::user_portfolio(alice_did, alice_num),
@@ -3130,6 +3153,7 @@ fn reject_instruction() {
                     alice_signed.clone(),
                     venue_counter,
                     SettlementType::SettleOnAffirmation,
+                    None,
                     None,
                     vec![Leg {
                         from: PortfolioId::default_portfolio(alice_did),

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -294,7 +294,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , _, _ ) = emulate_add_instruction::<T>(l, false)?;
 
-    }: _(origin, venue_id, settlement_type, Some(99999999.into()), legs)
+    }: _(origin, venue_id, settlement_type, Some(99999999.into()), Some(99999999.into()), legs)
     verify {
         verify_add_instruction::<T>(venue_id, settlement_type)?;
     }
@@ -309,7 +309,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , _,_ ) = emulate_add_instruction::<T>(l, false)?;
 
-    }: add_instruction(origin, venue_id, settlement_type, Some(99999999.into()), legs)
+    }: add_instruction(origin, venue_id, settlement_type, Some(99999999.into()), Some(99999999.into()), legs)
     verify {
         verify_add_instruction::<T>(venue_id, settlement_type)?;
     }
@@ -322,7 +322,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , portfolios, _) = emulate_add_instruction::<T>(l, true)?;
 
-    }: _(origin, venue_id, settlement_type, Some(99999999.into()), legs, portfolios.clone())
+    }: _(origin, venue_id, settlement_type, Some(99999999.into()), Some(99999999.into()), legs, portfolios.clone())
     verify {
         verify_add_and_affirm_instruction::<T>(venue_id, settlement_type, portfolios)?;
     }
@@ -336,7 +336,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , portfolios, _) = emulate_add_instruction::<T>(l, true)?;
 
-    }: add_and_affirm_instruction(origin, venue_id, settlement_type, Some(99999999.into()), legs, portfolios.clone())
+    }: add_and_affirm_instruction(origin, venue_id, settlement_type, Some(99999999.into()), Some(99999999.into()), legs, portfolios.clone())
     verify {
         verify_add_and_affirm_instruction::<T>(venue_id, settlement_type, portfolios)?;
     }

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -403,7 +403,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , portfolios, _) = emulate_add_instruction::<T>(l, true)?;
         // Add instruction
-        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, legs.clone())?;
+        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
         let instruction_id: u64 = 1;
         // Affirm an instruction
         let portfolios_set = portfolios.clone().into_iter().collect::<BTreeSet<_>>();
@@ -424,7 +424,7 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , portfolios, account_id) = emulate_add_instruction::<T>(l, true)?;
         // Add instruction
-        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, legs.clone())?;
+        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
         let instruction_id: u64 = 1;
         // Affirm an instruction
         portfolios.clone().into_iter().for_each(|p| {
@@ -462,7 +462,7 @@ benchmarks! {
         }];
 
         // Add instruction
-        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, legs.clone())?;
+        Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
         let instruction_id = 1;
         let leg_id = 0;
 
@@ -494,7 +494,7 @@ benchmarks! {
     //     }];
 
     //     // Add instruction
-    //     Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, legs.clone())?;
+    //     Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
     //     let instruction_id = 1;
 
     //     let msg = Receipt {

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -1086,10 +1086,6 @@ impl<T: Trait> Module<T> {
             Error::<T>::InstructionNotPending
         );
         if let Some(trade_date) = instruction_details.trade_date {
-            ensure!(
-                <pallet_timestamp::Module<T>>::get() >= trade_date,
-                Error::<T>::InstructionDatesInvalid
-            );
             if let Some(value_date) = instruction_details.value_date {
                 ensure!(
                     value_date >= trade_date,

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -215,7 +215,9 @@ pub struct Instruction<Moment, BlockNumber> {
     /// Date at which this instruction was created
     pub created_at: Option<Moment>,
     /// Date from which this instruction is valid
-    pub valid_from: Option<Moment>,
+    pub trade_date: Option<Moment>,
+    /// Date after which the instruction should be settled (not enforced)
+    pub value_date: Option<Moment>,
 }
 
 /// Details of a leg including the leg id in the instruction
@@ -450,12 +452,13 @@ decl_event!(
         /// An existing venue has been updated (did, venue_id, details, type)
         VenueUpdated(IdentityId, u64, VenueDetails, VenueType),
         /// A new instruction has been created
-        /// (did, venue_id, instruction_id, settlement_type, valid_from, legs)
+        /// (did, venue_id, instruction_id, settlement_type, trade_date, value_date, legs)
         InstructionCreated(
             IdentityId,
             u64,
             u64,
             SettlementType<BlockNumber>,
+            Option<Moment>,
             Option<Moment>,
             Vec<Leg<Balance>>,
         ),
@@ -515,8 +518,8 @@ decl_error! {
         FailedToLockTokens,
         /// Instruction failed to execute.
         InstructionFailed,
-        /// Instruction validity has not started yet.
-        InstructionWaitingValidity,
+        /// Instruction has invalid dates
+        InstructionDatesInvalid,
         /// Instruction's target settle block reached.
         InstructionSettleBlockPassed,
         /// Offchain signature is invalid.
@@ -659,7 +662,8 @@ decl_module! {
         /// * `venue_id` - ID of the venue this instruction belongs to.
         /// * `settlement_type` - Defines if the instruction should be settled
         ///    in the next block after receiving all affirmations or waiting till a specific block.
-        /// * `valid_from` - Optional date from which people can interact with this instruction.
+        /// * `trade_date` - Optional date from which people can interact with this instruction.
+        /// * `value_date` - Optional date after which the instruction should be settled (not enforced)
         /// * `legs` - Legs included in this instruction.
         ///
         /// # Weight
@@ -669,11 +673,12 @@ decl_module! {
             origin,
             venue_id: u64,
             settlement_type: SettlementType<T::BlockNumber>,
-            valid_from: Option<T::Moment>,
+            trade_date: Option<T::Moment>,
+            value_date: Option<T::Moment>,
             legs: Vec<Leg<T::Balance>>
         ) -> DispatchResult {
             let did = Identity::<T>::ensure_origin_call_permissions(origin)?.primary_did;
-            Self::base_add_instruction(did, venue_id, settlement_type, valid_from, legs)?;
+            Self::base_add_instruction(did, venue_id, settlement_type, trade_date, value_date, legs)?;
             Ok(())
         }
 
@@ -683,7 +688,8 @@ decl_module! {
         /// * `venue_id` - ID of the venue this instruction belongs to.
         /// * `settlement_type` - Defines if the instruction should be settled
         ///    in the next block after receiving all affirmations or waiting till a specific block.
-        /// * `valid_from` - Optional date from which people can interact with this instruction.
+        /// * `trade_date` - Optional date from which people can interact with this instruction.
+        /// * `value_date` - Optional date after which the instruction should be settled (not enforced)
         /// * `legs` - Legs included in this instruction.
         /// * `portfolios` - Portfolios that the sender controls and wants to use in this affirmations.
         #[weight = weight_for::weight_for_instruction_creation::<T>(legs.len())
@@ -694,14 +700,15 @@ decl_module! {
             origin,
             venue_id: u64,
             settlement_type: SettlementType<T::BlockNumber>,
-            valid_from: Option<T::Moment>,
+            trade_date: Option<T::Moment>,
+            value_date: Option<T::Moment>,
             legs: Vec<Leg<T::Balance>>,
             portfolios: Vec<PortfolioId>
         ) -> DispatchResult {
             let did = Identity::<T>::ensure_origin_call_permissions(origin.clone())?.primary_did;
             let portfolios_set = portfolios.into_iter().collect::<BTreeSet<_>>();
             with_transaction(|| {
-                let instruction_id = Self::base_add_instruction(did, venue_id, settlement_type, valid_from, legs)?;
+                let instruction_id = Self::base_add_instruction(did, venue_id, settlement_type, trade_date, value_date, legs)?;
                 Self::affirm_instruction(origin, instruction_id, portfolios_set.into_iter().collect::<Vec<_>>())
             })
         }
@@ -911,7 +918,8 @@ impl<T: Trait> Module<T> {
         did: IdentityId,
         venue_id: u64,
         settlement_type: SettlementType<T::BlockNumber>,
-        valid_from: Option<T::Moment>,
+        trade_date: Option<T::Moment>,
+        value_date: Option<T::Moment>,
         legs: Vec<Leg<T::Balance>>,
     ) -> Result<u64, DispatchError> {
         // Check whether the no. of legs within the limit or not.
@@ -962,7 +970,8 @@ impl<T: Trait> Module<T> {
             status: InstructionStatus::Pending,
             settlement_type,
             created_at: Some(<pallet_timestamp::Module<T>>::get()),
-            valid_from,
+            trade_date,
+            value_date,
         };
 
         // write data to storage
@@ -999,7 +1008,8 @@ impl<T: Trait> Module<T> {
             venue_id,
             instruction_counter,
             settlement_type,
-            valid_from,
+            trade_date,
+            value_date,
             legs,
         ));
         Ok(instruction_counter)
@@ -1075,11 +1085,17 @@ impl<T: Trait> Module<T> {
             instruction_details.status == InstructionStatus::Pending,
             Error::<T>::InstructionNotPending
         );
-        if let Some(valid_from) = instruction_details.valid_from {
+        if let Some(trade_date) = instruction_details.trade_date {
             ensure!(
-                <pallet_timestamp::Module<T>>::get() >= valid_from,
-                Error::<T>::InstructionWaitingValidity
+                <pallet_timestamp::Module<T>>::get() >= trade_date,
+                Error::<T>::InstructionDatesInvalid
             );
+            if let Some(value_date) = instruction_details.value_date {
+                ensure!(
+                    value_date >= trade_date,
+                    Error::<T>::InstructionDatesInvalid
+                );
+            }
         }
         if let SettlementType::SettleOnBlock(block_number) = instruction_details.settlement_type {
             ensure!(

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -363,6 +363,7 @@ decl_module! {
                     fundraiser.venue_id,
                     SettlementType::SettleOnAffirmation,
                     None,
+                    None,
                     legs
                 )?;
 

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -987,7 +987,8 @@
             "status": "InstructionStatus",
             "settlement_type": "SettlementType",
             "created_at": "Option<Moment>",
-            "valid_from": "Option<Moment>"
+            "trade_date": "Option<Moment>",
+            "value_date": "Option<Moment>"
         },
         "Leg": {
             "from": "PortfolioId",

--- a/scripts/cli/tests/12_A_settlement.js
+++ b/scripts/cli/tests/12_A_settlement.js
@@ -132,6 +132,7 @@ async function addInstruction(
       venueCounter,
       0,
       null,
+      null,
       [leg]
     );
 

--- a/scripts/cli/tests/12_B_settlement.js
+++ b/scripts/cli/tests/12_B_settlement.js
@@ -185,7 +185,7 @@ async function addGroupInstruction(
     amount: amount,
   };
 
-  transaction = await api.tx.settlement.addInstruction(venueCounter, 0, null, [
+  transaction = await api.tx.settlement.addInstruction(venueCounter, 0, null, null, [
     leg,
     leg2,
     leg3,

--- a/scripts/cli/util/init.js
+++ b/scripts/cli/util/init.js
@@ -570,12 +570,14 @@ async function addInstruction(
       venueCounter,
       0,
       null,
+      null,
       [leg]
     );
   } else {
     transaction = await api.tx.settlement.addInstruction(
       venueCounter,
       0,
+      null,
       null,
       [leg, leg2]
     );


### PR DESCRIPTION
I haven't added runtime migration as I think it is fine for the `value_date` of previous instructions to be `None`.

## changelog

### new features

- Capture `value_date` of an instruction.

### modified API

- Modified `add_instruction` and `add_and_affirm_instruction` by renaming `valid_from` to `trade_date` and adding new `value_date` parameter.
- Modified `Instruction` schema.
- Modified `InstructionCreated` event.

### modified logic

- `value_date` of an instruction must be after `trade_date`.
