### PR TITLE
MESH-1416: Require IU claims for payer and receiver of transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4786,6 +4786,7 @@ dependencies = [
 name = "pallet-treasury"
 version = "0.1.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances 0.1.0",
@@ -5412,6 +5413,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-runtime-interface",
  "sp-std",
  "sp-version",
 ]
@@ -5690,11 +5692,13 @@ dependencies = [
  "pallet-confidential",
  "pallet-corporate-actions",
  "pallet-identity",
+ "pallet-im-online",
  "pallet-pips",
  "pallet-portfolio",
  "pallet-protocol-fee",
  "pallet-settlement",
  "pallet-timestamp",
+ "pallet-treasury 0.1.0",
  "pallet-utility",
  "polymesh-contracts",
 ]

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -511,11 +511,16 @@ decl_module! {
             ensure!( funding_round.as_ref().map_or(0, |name| name.len()) <= T::FundingRoundNameMaxLength::get(), Error::<T>::FundingRoundNameMaxLengthExceeded);
 
             let PermissionedCallOriginData {
+                sender,
                 primary_did: did,
-                secondary_key,
-                ..
+                secondary_key
             } = Identity::<T>::ensure_origin_call_permissions(origin)?;
+
+            // Check total supply here to avoid any later failure
             Self::ensure_create_asset_parameters(&ticker, total_supply)?;
+            if !divisible {
+                ensure!(total_supply % ONE_UNIT.into() == 0.into(), Error::<T>::InvalidTotalSupply);
+            }
 
             // Ensure its registered by DID or at least expired, thus available.
             let available = match Self::is_ticker_available_or_registered_to(&ticker, did) {
@@ -523,10 +528,6 @@ decl_module! {
                 TickerRegistrationStatus::RegisteredByDid => false,
                 TickerRegistrationStatus::Available => true,
             };
-
-            if !divisible {
-                ensure!(total_supply % ONE_UNIT.into() == 0.into(), Error::<T>::InvalidTotalSupply);
-            }
 
             let token_did = Identity::<T>::get_token_did(&ticker)?;
             // Ensure there's no pre-existing entry for the DID.
@@ -568,7 +569,7 @@ decl_module! {
 
             let token = SecurityToken {
                 name,
-                total_supply,
+                total_supply: Zero::zero(),
                 owner_did: did,
                 divisible,
                 asset_type: asset_type.clone(),
@@ -578,9 +579,7 @@ decl_module! {
             // NB - At the time of asset creation it is obvious that asset issuer/ primary issuance agent will not have
             // `InvestorUniqueness` claim. So we are skipping the scope claim based stats update as
             // those data points will get added in to the system whenever asset issuer/ primary issuance agent
-            // have InvestorUniqueness claim.
-            <BalanceOf<T>>::insert(ticker, did, total_supply);
-            Portfolio::<T>::set_default_portfolio_balance(did, &ticker, total_supply);
+            // have InvestorUniqueness claim. This also applies when issuing assets.
             <AssetOwnershipRelations>::insert(did, ticker, AssetOwnershipRelation::AssetOwned);
             Self::deposit_event(RawEvent::AssetCreated(
                 did,
@@ -601,27 +600,12 @@ decl_module! {
             // Add funding round name.
             <FundingRound>::insert(ticker, funding_round.unwrap_or_default());
 
-            // Update the investor count of an asset.
-            <statistics::Module<T>>::update_transfer_stats(&ticker, None, Some(total_supply), total_supply);
-
             Self::deposit_event(RawEvent::IdentifiersUpdated(did, ticker, identifiers));
-            <IssuedInFundingRound<T>>::insert((ticker, Self::funding_round(ticker)), total_supply);
-            Self::deposit_event(RawEvent::Transfer(
-                did,
-                ticker,
-                PortfolioId::default(),
-                user_default_portfolio,
-                total_supply
-            ));
-            Self::deposit_event(RawEvent::Issued(
-                did,
-                ticker,
-                did,
-                total_supply,
-                Self::funding_round(ticker),
-                total_supply,
-                Some(did),
-            ));
+
+            // Mint total supply to PIA
+            if total_supply > Zero::zero() {
+                Self::_mint(&ticker, sender, did, total_supply, None)?;
+            }
             Ok(())
         }
 
@@ -1556,7 +1540,11 @@ impl<T: Trait> Module<T> {
             return Ok((ERC1400_TRANSFERS_HALTED, T::DbWeight::get().reads(1)));
         }
 
-        if !Identity::<T>::verify_iu_claim(*ticker, to_portfolio.did) {
+        if !Identity::<T>::verify_iu_claims_for_transfer(
+            *ticker,
+            to_portfolio.did,
+            from_portfolio.did,
+        ) {
             return Ok((SCOPE_CLAIM_MISSING, T::DbWeight::get().reads(2)));
         }
 
@@ -2066,7 +2054,11 @@ impl<T: Trait> Module<T> {
             return Ok(INVALID_SENDER_DID);
         }
 
-        if !Identity::<T>::verify_iu_claim(*ticker, to_portfolio.did) {
+        if !Identity::<T>::verify_iu_claims_for_transfer(
+            *ticker,
+            to_portfolio.did,
+            from_portfolio.did,
+        ) {
             return Ok(SCOPE_CLAIM_MISSING);
         }
 


### PR DESCRIPTION
Adds back the IU claim check for sender & receiver of assets.

Uses `_mint` for issuance and allocation of total supply on asset creation (slightly more expensive, but less duplicated logic)

Still allows initial issuance (`create_asset` and `issue`) without IU claim.

## changelog

### modified logic

- Both the sender and receiver of an asset settlement must have an `InvestorUniqueness` claim (previously just receiver)
- `Transfer` and `Issued` events are only emitted for `create_asset` if `total_supply > 0`
