### PR TITLE
MESH-1413: ASCII-only tickers

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -529,6 +529,11 @@ decl_module! {
                 TickerRegistrationStatus::Available => true,
             };
 
+            // If `ticker` isn't registered, it will be, so ensure it is fully ascii.
+            if available {
+                Self::ensure_ticker_ascii(&ticker)?;
+            }
+
             let token_did = Identity::<T>::get_token_did(&ticker)?;
             // Ensure there's no pre-existing entry for the DID.
             // This should never happen, but let's be defensive here.
@@ -1157,6 +1162,8 @@ decl_error! {
         AssetAlreadyCreated,
         /// The ticker length is over the limit.
         TickerTooLong,
+        /// The ticker has non-ascii-encoded parts.
+        TickerNotAscii,
         /// The ticker is already registered to someone else.
         TickerAlreadyRegistered,
         /// An invalid total supply.
@@ -1470,6 +1477,12 @@ impl<T: Trait> Module<T> {
         }
     }
 
+    /// Ensure `ticker` is fully ASCII.
+    fn ensure_ticker_ascii(ticker: &Ticker) -> DispatchResult {
+        ensure!(ticker.as_slice().is_ascii(), Error::<T>::TickerNotAscii);
+        Ok(())
+    }
+
     /// Before registering a ticker, do some checks, and return the expiry moment.
     fn ticker_registration_checks(
         ticker: &Ticker,
@@ -1477,6 +1490,8 @@ impl<T: Trait> Module<T> {
         no_re_register: bool,
         config: impl FnOnce() -> TickerRegistrationConfig<T::Moment>,
     ) -> Result<Option<T::Moment>, DispatchError> {
+        Self::ensure_ticker_ascii(&ticker)?;
+
         ensure!(
             !<Tokens<T>>::contains_key(&ticker),
             Error::<T>::AssetAlreadyCreated

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1477,9 +1477,16 @@ impl<T: Trait> Module<T> {
         }
     }
 
-    /// Ensure `ticker` is fully ASCII.
+    /// Ensure `ticker` is fully printable ASCII (SPACE to '~').
     fn ensure_ticker_ascii(ticker: &Ticker) -> DispatchResult {
-        ensure!(ticker.as_slice().is_ascii(), Error::<T>::TickerNotAscii);
+        let bytes = ticker.as_slice();
+        // Find first byte not printable ASCII.
+        let good = bytes
+            .iter()
+            .position(|b| !matches!(b, 32..=126))
+            // Everything after must be a NULL byte.
+            .map_or(true, |nm_pos| bytes[nm_pos..].iter().all(|b| *b == 0));
+        ensure!(good, Error::<T>::TickerNotAscii);
         Ok(())
     }
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -126,7 +126,7 @@ fn issuers_can_create_and_rename_tokens() {
         let funding_round_name: FundingRoundName = b"round1".into();
         // Expected token entry
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -223,7 +223,7 @@ fn valid_transfers_pass() {
 
             // Expected token entry
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did,
                 total_supply: 1_000_000,
                 divisible: true,
@@ -303,7 +303,7 @@ fn issuers_can_redeem_tokens() {
 
             // Expected token entry
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did,
                 total_supply: 1_000_000,
                 divisible: true,
@@ -373,7 +373,7 @@ fn checkpoints_fuzz_test() {
 
             // Expected token entry
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did,
                 total_supply: 1_000_000,
                 divisible: true,
@@ -452,7 +452,7 @@ fn register_ticker() {
         let owner_did = register_keyring_account(AccountKeyring::Dave).unwrap();
 
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -479,20 +479,20 @@ fn register_ticker() {
         assert_eq!(stored_token.asset_type, token.asset_type);
         assert_eq!(Asset::identifiers(ticker), identifiers);
         assert_err!(
-            Asset::register_ticker(owner_signed.clone(), Ticker::try_from(&[0x01][..]).unwrap()),
+            Asset::register_ticker(owner_signed.clone(), Ticker::try_from(&[b'A'][..]).unwrap()),
             AssetError::AssetAlreadyCreated
         );
 
         assert_err!(
             Asset::register_ticker(
                 owner_signed.clone(),
-                Ticker::try_from(&[0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01][..])
+                Ticker::try_from(&[b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A'][..])
                     .unwrap()
             ),
             AssetError::TickerTooLong
         );
 
-        let ticker = Ticker::try_from(&[0x01, 0x01][..]).unwrap();
+        let ticker = Ticker::try_from(&[b'A', b'A'][..]).unwrap();
 
         assert_eq!(Asset::is_ticker_available(&ticker), true);
 
@@ -534,7 +534,7 @@ fn transfer_ticker() {
         let bob_signed = Origin::signed(AccountKeyring::Bob.public());
         let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
 
-        let ticker = Ticker::try_from(&[0x01, 0x01][..]).unwrap();
+        let ticker = Ticker::try_from(&[b'A', b'A'][..]).unwrap();
 
         assert_eq!(Asset::is_ticker_available(&ticker), true);
         assert_ok!(Asset::register_ticker(owner_signed.clone(), ticker));
@@ -645,7 +645,7 @@ fn controller_transfer() {
 
             // Expected token entry
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did,
                 total_supply: 1_000_000,
                 divisible: true,
@@ -733,7 +733,7 @@ fn transfer_primary_issuance_agent() {
         let primary_issuance_signed = Origin::signed(AccountKeyring::Bob.public());
         let primary_issuance_agent = register_keyring_account(AccountKeyring::Bob).unwrap();
 
-        let ticker = Ticker::try_from(&[0x01, 0x01][..]).unwrap();
+        let ticker = Ticker::try_from(&[b'A', b'A'][..]).unwrap();
         let token = SecurityToken {
             name: ticker.as_slice().into(),
             total_supply: 1_000_000,
@@ -826,7 +826,7 @@ fn transfer_token_ownership() {
         let bob_signed = Origin::signed(AccountKeyring::Bob.public());
         let bob_did = register_keyring_account(AccountKeyring::Bob).unwrap();
 
-        let token_name = vec![0x01, 0x01];
+        let token_name = vec![b'A', b'A'];
         let ticker = Ticker::try_from(token_name.as_slice()).unwrap();
         assert_ok!(Asset::create_asset(
             owner_signed.clone(),
@@ -992,7 +992,7 @@ fn adding_removing_documents() {
         let owner_did = register_keyring_account(AccountKeyring::Dave).unwrap();
 
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -1682,7 +1682,7 @@ fn frozen_secondary_keys_create_asset_we() {
 
     // 2. Bob can create token
     let token_1 = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: alice_id,
         total_supply: 1_000_000,
         divisible: true,
@@ -1708,7 +1708,7 @@ fn frozen_secondary_keys_create_asset_we() {
 
     // 4. Bob cannot create a token.
     let token_2 = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: alice_id,
         total_supply: 1_000_000,
         divisible: true,
@@ -1883,7 +1883,7 @@ fn can_set_primary_issuance_agent_we() {
         Some(Memo::from("Bob funding"))
     ));
     let mut token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: alice_id,
         total_supply: 1_000_000,
         divisible: true,
@@ -1941,7 +1941,7 @@ fn test_weights_for_is_valid_transfer() {
             let dave = AccountKeyring::Dave.public();
 
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did: alice_did,
                 total_supply: 1_000_000_000,
                 divisible: true,
@@ -2124,7 +2124,7 @@ fn check_functionality_of_remove_extension() {
             let (alice_signed, alice_did) = make_account_without_cdd(alice).unwrap();
 
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did: alice_did,
                 total_supply: 1_000_000_000,
                 divisible: true,
@@ -2735,7 +2735,7 @@ fn check_unique_investor_count() {
             let total_supply = 1_000_000_000;
 
             let token = SecurityToken {
-                name: vec![0x01].into(),
+                name: vec![b'A'].into(),
                 owner_did: alice_did,
                 total_supply: total_supply,
                 divisible: true,

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -518,6 +518,22 @@ fn register_ticker() {
 
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner_did), false);
         assert_eq!(Asset::is_ticker_available(&ticker), true);
+
+        for bs in &[
+            [b'A', 31, b'B'].as_ref(),
+            [127, b'A'].as_ref(),
+            [b'A', 0, 0, 0, b'A'].as_ref(),
+        ] {
+            assert_noop!(
+                Asset::register_ticker(owner_signed.clone(), Ticker::try_from(&bs[..]).unwrap()),
+                AssetError::TickerNotAscii
+            );
+        }
+
+        assert_ok!(Asset::register_ticker(
+            owner_signed,
+            Ticker::try_from(&[b' ', b'A', b'~'][..]).unwrap()
+        ));
     })
 }
 

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -122,7 +122,7 @@ fn should_add_and_verify_compliance_requirement_we() {
     assert_ok!(CDDGroup::reset_members(root, vec![cdd_id]));
     // A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did.clone(),
         total_supply: 1_000_000,
         divisible: true,
@@ -337,7 +337,7 @@ fn should_replace_asset_compliance_we() {
 
     // A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did,
         total_supply: 1_000_000,
         divisible: true,
@@ -405,7 +405,7 @@ fn should_reset_asset_compliance_we() {
 
     // A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did,
         total_supply: 1_000_000,
         divisible: true,
@@ -464,7 +464,7 @@ fn pause_resume_asset_compliance_we() {
 
     // 1. A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did.clone(),
         total_supply: 1_000_000,
         divisible: true,
@@ -563,7 +563,7 @@ fn should_successfully_add_and_use_default_issuers_we() {
 
     // 1. A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did,
         total_supply: 1_000_000,
         divisible: true,
@@ -705,7 +705,7 @@ fn should_modify_vector_of_trusted_issuer_we() {
 
     // 1. A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did.clone(),
         total_supply: 1_000_000,
         divisible: true,
@@ -895,7 +895,7 @@ fn jurisdiction_asset_compliance_we() {
     let user_id = register_keyring_account(AccountKeyring::Charlie).unwrap();
     // 1. Create a token.
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_id.clone(),
         total_supply: 1_000_000,
         divisible: true,
@@ -977,7 +977,7 @@ fn scope_asset_compliance_we() {
     let cdd_id = register_keyring_account(AccountKeyring::Bob).unwrap();
     let user_id = register_keyring_account(AccountKeyring::Charlie).unwrap();
     // 1. Create a token.
-    let (ticker, owner_did) = make_ticker_env(owner, vec![0x01].into());
+    let (ticker, owner_did) = make_ticker_env(owner, vec![b'A'].into());
 
     // Provide scope claim for sender and receiver.
     provide_scope_claim_to_multiple_parties(
@@ -1026,7 +1026,7 @@ fn cm_test_case_9_we() {
     let issuer_id = register_keyring_account(AccountKeyring::Bob).unwrap();
 
     // 1. Create a token.
-    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![0x01].into());
+    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![b'A'].into());
     // 2. Set up compliance requirements for Asset transfer.
     let scope = Scope::Identity(Identity::get_token_did(&ticker).unwrap());
     let receiver_conditions = vec![Condition::from_dids(
@@ -1124,7 +1124,7 @@ fn cm_test_case_11_we() {
     let ferdie = AccountKeyring::Ferdie.public();
 
     // 1. Create a token.
-    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![0x01].into());
+    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![b'A'].into());
     // 2. Set up compliance requirements for Asset transfer.
     let scope = Scope::Identity(Identity::get_token_did(&ticker).unwrap());
     let receiver_conditions = vec![
@@ -1236,7 +1236,7 @@ fn cm_test_case_13_we() {
     let issuer_id = register_keyring_account(AccountKeyring::Bob).unwrap();
 
     // 1. Create a token.
-    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![0x01].into());
+    let (ticker, owner_did) = make_ticker_env(AccountKeyring::Alice, vec![b'A'].into());
     // 2. Set up compliance requirements for Asset transfer.
     let scope = Scope::Identity(Identity::get_token_did(&ticker).unwrap());
     let receiver_conditions = vec![
@@ -1360,7 +1360,7 @@ fn can_verify_restriction_with_primary_issuance_agent_we() {
     let issuer = AccountKeyring::Bob.public();
     let issuer_id = register_keyring_account(AccountKeyring::Bob).unwrap();
     let random_guy_id = register_keyring_account(AccountKeyring::Charlie).unwrap();
-    let token_name: AssetName = vec![0x01].into();
+    let token_name: AssetName = vec![b'A'].into();
     let ticker = Ticker::try_from(token_name.0.as_slice()).unwrap();
     assert_ok!(Asset::create_asset(
         owner_origin.clone(),
@@ -1472,7 +1472,7 @@ fn should_limit_compliance_requirements_complexity_we() {
 
     // A token representing 1M shares
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did: token_owner_did,
         total_supply: 1_000_000,
         divisible: true,
@@ -1552,7 +1552,7 @@ fn check_new_return_type_of_rpc() {
 
         // 1. A token representing 1M shares
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did: token_owner_did.clone(),
             total_supply: 1_000_000,
             divisible: true,

--- a/pallets/runtime/tests/src/dividend_test.rs
+++ b/pallets/runtime/tests/src/dividend_test.rs
@@ -56,7 +56,7 @@ fn correct_dividend_must_work() {
 
         // A token representing 1M shares
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did: token_owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -64,7 +64,7 @@ fn correct_dividend_must_work() {
             ..Default::default()
         };
         let payout_token = SecurityToken {
-            name: vec![0x02].into(),
+            name: vec![b'B'].into(),
             owner_did: payout_owner_did,
             total_supply: 200_000_000,
             divisible: true,

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -24,7 +24,7 @@ fn create_token() -> (SecurityToken<u128>, Ticker) {
     let owner_did = Identity::get_identity(&AccountKeyring::Alice.public()).unwrap();
     let total_supply = 1_000_000u128;
     let token = SecurityToken {
-        name: vec![0x01].into(),
+        name: vec![b'A'].into(),
         owner_did,
         total_supply,
         divisible: true,

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -1765,37 +1765,15 @@ fn basic_fuzzing() {
             ];
 
             for i in 0..10 {
-                let mut token_name = [123u8 + u8::try_from(i * 4 + 0).unwrap()];
-                tickers.push(Ticker::try_from(&token_name[..]).unwrap());
-                create_token(
-                    &token_name[..],
-                    tickers[i * 4 + 0],
-                    AccountKeyring::Alice.public(),
-                );
-
-                token_name = [123u8 + u8::try_from(i * 4 + 1).unwrap()];
-                tickers.push(Ticker::try_from(&token_name[..]).unwrap());
-                create_token(
-                    &token_name[..],
-                    tickers[i * 4 + 1],
-                    AccountKeyring::Bob.public(),
-                );
-
-                token_name = [123u8 + u8::try_from(i * 4 + 2).unwrap()];
-                tickers.push(Ticker::try_from(&token_name[..]).unwrap());
-                create_token(
-                    &token_name[..],
-                    tickers[i * 4 + 2],
-                    AccountKeyring::Charlie.public(),
-                );
-
-                token_name = [123u8 + u8::try_from(i * 4 + 3).unwrap()];
-                tickers.push(Ticker::try_from(&token_name[..]).unwrap());
-                create_token(
-                    &token_name[..],
-                    tickers[i * 4 + 3],
-                    AccountKeyring::Dave.public(),
-                );
+                let mut create = |x: usize, key: AccountKeyring| {
+                    let tn = [b'!' + u8::try_from(i * 4 + x).unwrap()];
+                    tickers.push(Ticker::try_from(&tn[..]).unwrap());
+                    create_token(&tn, tickers[i * 4 + x], key.public());
+                };
+                create(0, AccountKeyring::Alice);
+                create(1, AccountKeyring::Bob);
+                create(2, AccountKeyring::Charlie);
+                create(3, AccountKeyring::Dave);
             }
 
             let block_number = System::block_number() + 1;

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -44,7 +44,7 @@ fn raise_unhappy_path_ext() {
 fn create_asset(origin: Origin, ticker: Ticker, supply: u128) {
     assert_ok!(Asset::create_asset(
         origin,
-        vec![0x01].into(),
+        vec![b'A'].into(),
         ticker,
         supply,
         true,
@@ -74,8 +74,8 @@ fn raise_happy_path() {
     let bob_portfolio = PortfolioId::default_portfolio(bob_did);
 
     // Register tokens
-    let offering_ticker = Ticker::try_from(&[0x01][..]).unwrap();
-    let raise_ticker = Ticker::try_from(&[0x02][..]).unwrap();
+    let offering_ticker = Ticker::try_from(&[b'A'][..]).unwrap();
+    let raise_ticker = Ticker::try_from(&[b'B'][..]).unwrap();
     create_asset(alice_signed.clone(), offering_ticker, 1_000_000);
     create_asset(alice_signed.clone(), raise_ticker, 1_000_000);
 
@@ -204,8 +204,8 @@ fn raise_unhappy_path() {
     let _bob = AccountKeyring::Bob.public();
     let bob_portfolio = PortfolioId::default_portfolio(bob_did);
 
-    let offering_ticker = Ticker::try_from(&[0x03][..]).unwrap();
-    let raise_ticker = Ticker::try_from(&[0x04][..]).unwrap();
+    let offering_ticker = Ticker::try_from(&[b'C'][..]).unwrap();
+    let raise_ticker = Ticker::try_from(&[b'D'][..]).unwrap();
 
     // Provide scope claim to both the parties of the transaction.
     let eve = AccountKeyring::Eve.public();

--- a/pallets/runtime/tests/src/voting_test.rs
+++ b/pallets/runtime/tests/src/voting_test.rs
@@ -33,7 +33,7 @@ fn add_ballot() {
 
         // A token representing 1M shares
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did: token_owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -197,7 +197,7 @@ fn cancel_ballot() {
 
         // A token representing 1M shares
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did: token_owner_did,
             total_supply: 1_000_000,
             divisible: true,
@@ -287,7 +287,7 @@ fn vote() {
 
         // A token representing 1M shares
         let token = SecurityToken {
-            name: vec![0x01].into(),
+            name: vec![b'A'].into(),
             owner_did: token_owner_did,
             total_supply: 1000,
             divisible: true,


### PR DESCRIPTION
## changelog

### modified logic

- A `Ticker` must now consist of ASCII characters or error `TickerNotAscii` occurs at registration or asset creation time. Not applied retroactively to existing tickers.
