### PR TITLE
Fix minor typos

### DIFF
--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -511,7 +511,7 @@ decl_module! {
         /// - `origin` which must be a signer for the CAA of `ca_id`.
         /// - `ticker` that the CA is made for.
         /// - `kind` of CA being initiated.
-        /// - `decl_date` of CA bring initialised
+        /// - `decl_date` of CA bring initialized.
         /// - `record_date`, if any, to calculate the impact of this CA.
         ///    If provided, this results in a scheduled balance snapshot ("checkpoint") at the date.
         /// - `details` of the CA in free-text form, up to a certain number of bytes in length.

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -528,7 +528,7 @@ decl_module! {
         /// - `LocalCAIdOverflow` in the unlikely event that so many CAs were created for this `ticker`,
         ///   that integer overflow would have occured if instead allowed.
         /// - `DuplicateDidTax` if a DID is included more than once in `wt`.
-        /// - `DeclDateInFuture` if the declaration date is not in the past
+        /// - `DeclDateInFuture` if the declaration date is not in the past.
         /// - When `record_date.is_some()`, other errors due to checkpoint scheduling may occur.
         #[weight = <T as Trait>::WeightInfo::initiate_corporate_action_use_defaults(1, 1)
             .max(<T as Trait>::WeightInfo::initiate_corporate_action_provided(

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -511,6 +511,7 @@ decl_module! {
         /// - `origin` which must be a signer for the CAA of `ca_id`.
         /// - `ticker` that the CA is made for.
         /// - `kind` of CA being initiated.
+        /// - `decl_date` of CA bring initialised
         /// - `record_date`, if any, to calculate the impact of this CA.
         ///    If provided, this results in a scheduled balance snapshot ("checkpoint") at the date.
         /// - `details` of the CA in free-text form, up to a certain number of bytes in length.
@@ -527,6 +528,7 @@ decl_module! {
         /// - `LocalCAIdOverflow` in the unlikely event that so many CAs were created for this `ticker`,
         ///   that integer overflow would have occured if instead allowed.
         /// - `DuplicateDidTax` if a DID is included more than once in `wt`.
+        /// - `DeclDateInFuture` if the declaration date is not in the past
         /// - When `record_date.is_some()`, other errors due to checkpoint scheduling may occur.
         #[weight = <T as Trait>::WeightInfo::initiate_corporate_action_use_defaults(1, 1)
             .max(<T as Trait>::WeightInfo::initiate_corporate_action_provided(

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -116,9 +116,7 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
             ) => handle_multisig(&Bridge::controller_key(), caller),
             // All other calls.
             //
-            // If the account has enabled charging fee to identity then the identity should be charged
-            // otherwise, the account should be charged. In any case, the external account
-            // must directly be linked to an identity with valid CDD.
+            // The external account must directly be linked to an identity with valid CDD.
             _ => match Identity::get_identity(caller) {
                 Some(did) if Identity::has_valid_cdd(did) => {
                     Context::set_current_identity::<Identity>(Some(did));

--- a/pallets/runtime/testnet/src/fee_details.rs
+++ b/pallets/runtime/testnet/src/fee_details.rs
@@ -115,10 +115,7 @@ impl CddAndFeeDetails<AccountId, Call> for CddHandler {
                 bridge::Call::propose_bridge_tx(..) | bridge::Call::batch_propose_bridge_tx(..),
             ) => handle_multisig(&Bridge::controller_key(), caller),
             // All other calls.
-            //
-            // If the account has enabled charging fee to identity then the identity should be charged
-            // otherwise, the account should be charged. In any case, the external account
-            // must directly be linked to an identity with valid CDD.
+            // The external account must directly be linked to an identity with valid CDD.
             _ => match Identity::get_identity(caller) {
                 Some(did) if Identity::has_valid_cdd(did) => {
                     Context::set_current_identity::<Identity>(Some(did));

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1085,7 +1085,7 @@
         "CAKind": {
             "_enum": [
                 "PredictableBenefit",
-                "UnpredictableBenfit",
+                "UnpredictableBenefit",
                 "IssuerNotice",
                 "Reorganization",
                 "Other"


### PR DESCRIPTION
Fixes a minor schema typo and a couple of comments.

## changelog

### modified API

- Schema for `CAKind` enum had a typo - `UnpredictableBenfit` should be `UnpredictableBenefit`