### PR TITLE
[WIP] SingedExtension optimization proposal

### DIFF
--- a/pallets/permissions/Cargo.toml
+++ b/pallets/permissions/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # Common
-polymesh-common-utilities = { package = "polymesh-common-utilities", path = "../common", default-features = false }
+polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
 # Other
@@ -16,8 +16,10 @@ serde = { version = "1.0.104", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-sp-std = { package = "sp-std", git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+
+# Only for benchmarking
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0", optional = true }
 
 [features]
@@ -36,5 +38,5 @@ std = [
 ]
 runtime-benchmarks = [
     "frame-benchmarking",
-    "sp-runtime/runtime-benchmarks",
+    "polymesh-common-utilities/runtime-benchmarks",
 ]

--- a/pallets/permissions/src/benchmarking.rs
+++ b/pallets/permissions/src/benchmarking.rs
@@ -28,8 +28,8 @@ benchmarks! {
         StoreCallMetadata::<T>::set_call_metadata(pallet_name, dispatchable_name);
     }
     verify {
-        assert_eq!( CurrentPalletName::get(), pallet_name_exp);
-        assert_eq!( CurrentDispatchableName::get(), dispatchable_name_exp);
+        assert_eq!( StoreCallMetadata::<T>::current_pallet_name(), pallet_name_exp);
+        assert_eq!( StoreCallMetadata::<T>::current_dispatchable_name(), dispatchable_name_exp);
     }
 
     clear_call_metadata {
@@ -40,6 +40,7 @@ benchmarks! {
         StoreCallMetadata::<T>::clear_call_metadata();
     }
     verify {
-        assert_eq!(CurrentPalletName::exists(), false);
-    }
+        assert_eq!( StoreCallMetadata::<T>::current_pallet_name(), PalletName::default());
+        assert_eq!( StoreCallMetadata::<T>::current_dispatchable_name(), DispatchableName::default());
+     }
 }

--- a/pallets/permissions/src/benchmarking.rs
+++ b/pallets/permissions/src/benchmarking.rs
@@ -1,0 +1,45 @@
+use crate::*;
+
+use polymesh_primitives::{DispatchableName, PalletName};
+
+use frame_benchmarking::benchmarks;
+use sp_std::{iter, prelude::*};
+
+const MAX_PALLET_NAME: u32 = 512;
+const MAX_DISPATCHABLE_NAME: u32 = 1024;
+
+fn make_name(m: u32) -> Vec<u8> {
+    iter::repeat(b'x').take(m as usize).collect::<Vec<_>>()
+}
+
+benchmarks! {
+    _ {}
+
+    set_call_metadata {
+        let p in 1..MAX_PALLET_NAME;
+        let d in 1..MAX_DISPATCHABLE_NAME;
+
+        let pallet_name :PalletName = make_name(p).into();
+        let pallet_name_exp = pallet_name.clone();
+        let dispatchable_name :DispatchableName = make_name(p).into();
+        let dispatchable_name_exp = dispatchable_name.clone();
+
+    }: {
+        StoreCallMetadata::<T>::set_call_metadata(pallet_name, dispatchable_name);
+    }
+    verify {
+        assert_eq!( CurrentPalletName::get(), pallet_name_exp);
+        assert_eq!( CurrentDispatchableName::get(), dispatchable_name_exp);
+    }
+
+    clear_call_metadata {
+        let pallet_name :PalletName = make_name(MAX_PALLET_NAME).into();
+        let dispatchable_name :DispatchableName = make_name(MAX_DISPATCHABLE_NAME).into();
+        StoreCallMetadata::<T>::set_call_metadata(pallet_name, dispatchable_name);
+    }: {
+        StoreCallMetadata::<T>::clear_call_metadata();
+    }
+    verify {
+        assert_eq!(CurrentPalletName::exists(), false);
+    }
+}

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -20,6 +20,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "runtime-benchmarks")]
+pub mod benchmarking;
+
 use codec::{Decode, Encode};
 use frame_support::{
     decl_error, decl_module, decl_storage,

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -202,5 +202,6 @@ runtime-benchmarks = [
     "pallet-utility/runtime-benchmarks",
     "pallet-treasury/runtime-benchmarks",
     "pallet-group/runtime-benchmarks",
+    "pallet-permissions/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
 ]

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -1310,6 +1310,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, pallet_treasury, Treasury);
             add_benchmark!(params, batches, pallet_im_online, ImOnline);
             add_benchmark!(params, batches, pallet_group, CddServiceProviders);
+            add_benchmark!(params, batches, pallet_permissions, Permissions);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)


### PR DESCRIPTION
This optimization basically consists of removing the usage of the DB storage as temporal  storage during the execution of the extrinsic. 
Instead of that, it uses thread local storage (in std).

The weights & DB operations (write/read) obtained by benchmarks are the following:

| Version |  Native | Wasm | **Optimized Native** | Improvement |
|------------|----------:|---------:|-----------------------:|-------------------:|
| set_call_metadata (Weight)  | 1_307_000 |  6_909_000 + p *  2_000 |  **128_000** |  10.21x |
| set_call_metadata (DB op) | 2 | 2 | **0** | ∞  |
| clear_call_metadata (Weight) | 1_380_0000 | 4_794_000 | **104_000** | 13.26x |
| clear_call_metadata (DB op) | 2 | 2 | **0** | ∞  |

## TODO
- It seems that `SignedExtension`s are used only in native, I need to double-check that. 
- Double-check thread usage on substrate & `SE`, to be sure that no `AccessError` is risen up and constructor cannot panic.