### PR TITLE
Alcyone 2.3.1 Network Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             --package polymesh-runtime-tests
             --package pallet-staking
             --package pallet-group
+            --package pallet-sudo
             --package polymesh-primitives
             --package node-rpc-runtime-api
             --package pallet-transaction-payment
@@ -75,6 +76,7 @@ jobs:
             --package polymesh-runtime-tests
             --package pallet-staking
             --package pallet-group
+            --package pallet-sudo
             --package polymesh-primitives
             --package node-rpc-runtime-api
             --package pallet-transaction-payment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,12 +4717,12 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=v2.0.0#a200cdb93c6af5763b9c7bf313fa708764ac88ca"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "serde",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Anonymous"]
 build = "build.rs"
 edition = "2018"

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -337,11 +337,14 @@ decl_module! {
         /// # Errors
         /// * `FirstVoteReject`, if `call` hasn't been proposed and `approve == false`.
         /// * `BadOrigin`, if the `origin` is not a member of this committee.
-        #[weight = (
-            500_000_000 + call.get_dispatch_info().weight,
-            call.get_dispatch_info().class,
-            Pays::Yes
-        )]
+        #[weight = {
+            let dispatch_info = call.get_dispatch_info();
+            (
+                500_000_000 + dispatch_info.weight,
+                dispatch_info.class,
+                Pays::Yes
+            )
+        }]
         pub fn vote_or_propose(origin, approve: bool, call: Box<<T as Trait<I>>::Proposal>) -> DispatchResult {
             // Either create a new proposal or vote on an existing one.
             let hash = T::Hashing::hash_of(&call);

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -39,6 +39,7 @@ pallet-transaction-payment = { path = "../../transaction-payment", default-featu
 pallet-treasury = { path = "../../treasury", default-features = false }
 pallet-utility = { path = "../../utility", default-features = false }
 polymesh-contracts = { path = "../../contracts", default-features = false }
+pallet-sudo = { path = "../../sudo", default-features = false }
 
 # Others
 serde = { version = "1.0.104", default-features = false }
@@ -71,7 +72,6 @@ pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-feat
 pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 2011,
+    spec_version: 2012,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -42,6 +42,7 @@ pallet-transaction-payment = { path = "../../transaction-payment", default-featu
 pallet-treasury = { path = "../../treasury", default-features = false }
 pallet-utility = { path = "../../utility", default-features = false }
 polymesh-contracts = { path = "../../contracts", default-features = false }
+pallet-sudo = { path = "../../sudo", default-features = false }
 
 # RPC
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
@@ -80,7 +81,6 @@ pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-feat
 pallet-indices = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-offences = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-babe = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
 pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 2010,
+    spec_version: 2011,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/sudo/Cargo.toml
+++ b/pallets/sudo/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "pallet-sudo"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME pallet for sudo"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.104", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0"}
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+
+[dev-dependencies]
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, tag = "v2.0.0" }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-std/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+]

--- a/pallets/sudo/README.md
+++ b/pallets/sudo/README.md
@@ -1,0 +1,70 @@
+# Sudo Module
+
+- [`sudo::Trait`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
+
+## Overview
+
+The Sudo module allows for a single account (called the "sudo key")
+to execute dispatchable functions that require a `Root` call
+or designate a new account to replace them as the sudo key.
+Only one account can be the sudo key at a time.
+
+## Interface
+
+### Dispatchable Functions
+
+Only the sudo key can call the dispatchable functions from the Sudo module.
+
+* `sudo` - Make a `Root` call to a dispatchable function.
+* `set_key` - Assign a new account to be the sudo key.
+
+## Usage
+
+### Executing Privileged Functions
+
+The Sudo module itself is not intended to be used within other modules.
+Instead, you can build "privileged functions" (i.e. functions that require `Root` origin) in other modules.
+You can execute these privileged functions by calling `sudo` with the sudo key account.
+Privileged functions cannot be directly executed via an extrinsic.
+
+Learn more about privileged functions and `Root` origin in the [`Origin`] type documentation.
+
+### Simple Code Snippet
+
+This is an example of a module that exposes a privileged function:
+
+```rust
+use frame_support::{decl_module, dispatch};
+use frame_system::ensure_root;
+
+pub trait Config: frame_system::Config {}
+
+decl_module! {
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		#[weight = 0]
+        pub fn privileged_function(origin) -> dispatch::DispatchResult {
+            ensure_root(origin)?;
+
+            // do something...
+
+            Ok(())
+        }
+    }
+}
+```
+
+## Genesis Config
+
+The Sudo module depends on the [`GenesisConfig`](https://docs.rs/pallet-sudo/latest/pallet_sudo/struct.GenesisConfig.html).
+You need to set an initial superuser account as the sudo `key`.
+
+## Related Modules
+
+* [Democracy](https://docs.rs/pallet-democracy/latest/pallet_democracy/)
+
+[`Call`]: ./enum.Call.html
+[`Config`]: ./trait.Config.html
+[`Origin`]: https://docs.substrate.dev/docs/substrate-types
+
+License: Apache-2.0

--- a/pallets/sudo/src/lib.rs
+++ b/pallets/sudo/src/lib.rs
@@ -1,0 +1,257 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Sudo Module
+//!
+//! - [`sudo::Trait`](./trait.Trait.html)
+//! - [`Call`](./enum.Call.html)
+//!
+//! ## Overview
+//!
+//! The Sudo module allows for a single account (called the "sudo key")
+//! to execute dispatchable functions that require a `Root` call
+//! or designate a new account to replace them as the sudo key.
+//! Only one account can be the sudo key at a time.
+//!
+//! ## Interface
+//!
+//! ### Dispatchable Functions
+//!
+//! Only the sudo key can call the dispatchable functions from the Sudo module.
+//!
+//! * `sudo` - Make a `Root` call to a dispatchable function.
+//! * `set_key` - Assign a new account to be the sudo key.
+//!
+//! ## Usage
+//!
+//! ### Executing Privileged Functions
+//!
+//! The Sudo module itself is not intended to be used within other modules.
+//! Instead, you can build "privileged functions" (i.e. functions that require `Root` origin) in other modules.
+//! You can execute these privileged functions by calling `sudo` with the sudo key account.
+//! Privileged functions cannot be directly executed via an extrinsic.
+//!
+//! Learn more about privileged functions and `Root` origin in the [`Origin`] type documentation.
+//!
+//! ### Simple Code Snippet
+//!
+//! This is an example of a module that exposes a privileged function:
+//!
+//! ```
+//! use frame_support::{decl_module, dispatch};
+//! use frame_system::ensure_root;
+//!
+//! pub trait Trait: frame_system::Trait {}
+//!
+//! decl_module! {
+//!     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+//! 		#[weight = 0]
+//!         pub fn privileged_function(origin) -> dispatch::DispatchResult {
+//!             ensure_root(origin)?;
+//!
+//!             // do something...
+//!
+//!             Ok(())
+//!         }
+//!     }
+//! }
+//! # fn main() {}
+//! ```
+//!
+//! ## Genesis Config
+//!
+//! The Sudo module depends on the [`GenesisConfig`](./struct.GenesisConfig.html).
+//! You need to set an initial superuser account as the sudo `key`.
+//!
+//! ## Related Modules
+//!
+//! * [Democracy](../pallet_democracy/index.html)
+//!
+//! [`Call`]: ./enum.Call.html
+//! [`Trait`]: ./trait.Trait.html
+//! [`Origin`]: https://docs.substrate.dev/docs/substrate-types
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_runtime::{traits::StaticLookup, DispatchResult};
+use sp_std::prelude::*;
+
+use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, Parameter};
+use frame_support::{
+    dispatch::DispatchResultWithPostInfo,
+    traits::{Get, UnfilteredDispatchable},
+    weights::{GetDispatchInfo, Pays, Weight},
+};
+use frame_system::ensure_signed;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub trait Trait: frame_system::Trait {
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// A sudo-able call.
+    type Call: Parameter + UnfilteredDispatchable<Origin = Self::Origin> + GetDispatchInfo;
+}
+
+decl_module! {
+    /// Sudo module declaration.
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+
+        fn deposit_event() = default;
+
+        /// Authenticates the sudo key and dispatches a function call with `Root` origin.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - Limited storage reads.
+        /// - One DB write (event).
+        /// - Weight of derivative `call` execution + 10,000.
+        /// # </weight>
+        #[weight = {
+            let dispatch_info = call.get_dispatch_info();
+            (dispatch_info.weight.saturating_add(10_000), dispatch_info.class)
+        }]
+        fn sudo(origin, call: Box<<T as Trait>::Call>) -> DispatchResultWithPostInfo {
+            // This is a public call, so we ensure that the origin is some signed account.
+            let sender = ensure_signed(origin)?;
+            ensure!(sender == Self::key(), Error::<T>::RequireSudo);
+
+            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+            Self::deposit_event(RawEvent::Sudid(res.map(|_| ()).map_err(|e| e.error)));
+            // Sudo user does not pay a fee.
+            Ok(Pays::No.into())
+        }
+
+        /// Authenticates the sudo key and dispatches a function call with `Root` origin.
+        /// This function does not check the weight of the call, and instead allows the
+        /// Sudo user to specify the weight of the call.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - The weight of this call is defined by the caller.
+        /// # </weight>
+        #[weight = (*_weight, call.get_dispatch_info().class)]
+        fn sudo_unchecked_weight(origin, call: Box<<T as Trait>::Call>, _weight: Weight) -> DispatchResultWithPostInfo {
+            // This is a public call, so we ensure that the origin is some signed account.
+            let sender = ensure_signed(origin)?;
+            ensure!(sender == Self::key(), Error::<T>::RequireSudo);
+
+            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+            Self::deposit_event(RawEvent::Sudid(res.map(|_| ()).map_err(|e| e.error)));
+            // Sudo user does not pay a fee.
+            Ok(Pays::No.into())
+        }
+
+        /// Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo key.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - Limited storage reads.
+        /// - One DB change.
+        /// # </weight>
+        #[weight = 0]
+        fn set_key(origin, new: <T::Lookup as StaticLookup>::Source) -> DispatchResultWithPostInfo {
+            // This is a public call, so we ensure that the origin is some signed account.
+            let sender = ensure_signed(origin)?;
+            ensure!(sender == Self::key(), Error::<T>::RequireSudo);
+            let new = T::Lookup::lookup(new)?;
+
+            Self::deposit_event(RawEvent::KeyChanged(Self::key()));
+            <Key<T>>::put(new);
+            // Sudo user does not pay a fee.
+            Ok(Pays::No.into())
+        }
+
+        /// Authenticates the sudo key and dispatches a function call with `Signed` origin from
+        /// a given account.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// # <weight>
+        /// - O(1).
+        /// - Limited storage reads.
+        /// - One DB write (event).
+        /// - Weight of derivative `call` execution + 10,000.
+        /// # </weight>
+        #[weight = {
+            let dispatch_info = call.get_dispatch_info();
+            (
+                dispatch_info.weight
+                    .saturating_add(10_000)
+                    // AccountData for inner call origin accountdata.
+                    .saturating_add(T::DbWeight::get().reads_writes(1, 1)),
+                dispatch_info.class,
+            )
+        }]
+        fn sudo_as(origin,
+            who: <T::Lookup as StaticLookup>::Source,
+            call: Box<<T as Trait>::Call>
+        ) -> DispatchResultWithPostInfo {
+            // This is a public call, so we ensure that the origin is some signed account.
+            let sender = ensure_signed(origin)?;
+            ensure!(sender == Self::key(), Error::<T>::RequireSudo);
+
+            let who = T::Lookup::lookup(who)?;
+
+            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
+
+            Self::deposit_event(RawEvent::SudoAsDone(res.map(|_| ()).map_err(|e| e.error)));
+            // Sudo user does not pay a fee.
+            Ok(Pays::No.into())
+        }
+    }
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        AccountId = <T as frame_system::Trait>::AccountId,
+    {
+        /// A sudo just took place. \[result\]
+        Sudid(DispatchResult),
+        /// The \[sudoer\] just switched identity; the old key is supplied.
+        KeyChanged(AccountId),
+        /// A sudo just took place. \[result\]
+        SudoAsDone(DispatchResult),
+    }
+);
+
+decl_storage! {
+    trait Store for Module<T: Trait> as Sudo {
+        /// The `AccountId` of the sudo key.
+        Key get(fn key) config(): T::AccountId;
+    }
+}
+
+decl_error! {
+    /// Error for the Sudo module
+    pub enum Error for Module<T: Trait> {
+        /// Sender must be the Sudo account
+        RequireSudo,
+    }
+}

--- a/pallets/sudo/src/mock.rs
+++ b/pallets/sudo/src/mock.rs
@@ -1,0 +1,181 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test utilities
+
+use super::*;
+use crate as sudo;
+use frame_support::traits::Filter;
+use frame_support::{
+    impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, weights::Weight,
+};
+use sp_core::H256;
+use sp_io;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
+
+// Logger module to track execution.
+pub mod logger {
+    use super::*;
+    use frame_system::ensure_root;
+
+    pub trait Trait: frame_system::Trait {
+        type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    }
+
+    decl_storage! {
+        trait Store for Module<T: Trait> as Logger {
+            AccountLog get(fn account_log): Vec<T::AccountId>;
+            I32Log get(fn i32_log): Vec<i32>;
+        }
+    }
+
+    decl_event! {
+        pub enum Event<T> where AccountId = <T as frame_system::Trait>::AccountId {
+            AppendI32(i32, Weight),
+            AppendI32AndAccount(AccountId, i32, Weight),
+        }
+    }
+
+    decl_module! {
+        pub struct Module<T: Trait> for enum Call where origin: <T as frame_system::Trait>::Origin {
+            fn deposit_event() = default;
+
+            #[weight = *weight]
+            fn privileged_i32_log(origin, i: i32, weight: Weight){
+                // Ensure that the `origin` is `Root`.
+                ensure_root(origin)?;
+                <I32Log>::append(i);
+                Self::deposit_event(RawEvent::AppendI32(i, weight));
+            }
+
+            #[weight = *weight]
+            fn non_privileged_log(origin, i: i32, weight: Weight){
+                // Ensure that the `origin` is some signed account.
+                let sender = ensure_signed(origin)?;
+                <I32Log>::append(i);
+                <AccountLog<T>>::append(sender.clone());
+                Self::deposit_event(RawEvent::AppendI32AndAccount(sender, i, weight));
+            }
+        }
+    }
+}
+
+impl_outer_origin! {
+    pub enum Origin for Test where system = frame_system {}
+}
+
+mod test_events {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for Test {
+        frame_system<T>,
+        sudo<T>,
+        logger<T>,
+    }
+}
+
+impl_outer_dispatch! {
+    pub enum Call for Test where origin: Origin {
+        sudo::Sudo,
+        logger::Logger,
+    }
+}
+
+// For testing the pallet, we construct most of a mock runtime. This means
+// first constructing a configuration type (`Test`) which `impl`s each of the
+// configuration traits of pallets we want to use.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Test;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+pub struct BlockEverything;
+impl Filter<Call> for BlockEverything {
+    fn filter(_: &Call) -> bool {
+        false
+    }
+}
+
+impl frame_system::Trait for Test {
+    type BaseCallFilter = BlockEverything;
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type PalletInfo = ();
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+}
+
+// Implement the logger module's `Trait` on the Test runtime.
+impl logger::Trait for Test {
+    type Event = TestEvent;
+}
+
+// Implement the sudo module's `Trait` on the Test runtime.
+impl Trait for Test {
+    type Event = TestEvent;
+    type Call = Call;
+}
+
+// Assign back to type variables in order to make dispatched calls of these modules later.
+pub type Sudo = Module<Test>;
+pub type Logger = logger::Module<Test>;
+pub type System = frame_system::Module<Test>;
+
+// New types for dispatchable functions.
+pub type SudoCall = sudo::Call<Test>;
+pub type LoggerCall = logger::Call<Test>;
+
+// Build test environment by setting the root `key` for the Genesis.
+pub fn new_test_ext(root_key: u64) -> sp_io::TestExternalities {
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    GenesisConfig::<Test> { key: root_key }
+        .assimilate_storage(&mut t)
+        .unwrap();
+    t.into()
+}

--- a/pallets/sudo/src/tests.rs
+++ b/pallets/sudo/src/tests.rs
@@ -1,0 +1,178 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the module.
+
+use super::*;
+use frame_support::{assert_noop, assert_ok};
+use mock::{
+    new_test_ext, Call, Logger, LoggerCall, Origin, Sudo, SudoCall, System, Test, TestEvent,
+};
+
+#[test]
+fn test_setup_works() {
+    // Environment setup, logger storage, and sudo `key` retrieval should work as expected.
+    new_test_ext(1).execute_with(|| {
+        assert_eq!(Sudo::key(), 1u64);
+        assert!(Logger::i32_log().is_empty());
+        assert!(Logger::account_log().is_empty());
+    });
+}
+
+#[test]
+fn sudo_basics() {
+    // Configure a default test environment and set the root `key` to 1.
+    new_test_ext(1).execute_with(|| {
+        // A privileged function should work when `sudo` is passed the root `key` as `origin`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Sudo::sudo(Origin::signed(1), call));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
+
+        // A privileged function should not work when `sudo` is passed a non-root `key` as `origin`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_noop!(
+            Sudo::sudo(Origin::signed(2), call),
+            Error::<Test>::RequireSudo
+        );
+    });
+}
+
+#[test]
+fn sudo_emits_events_correctly() {
+    new_test_ext(1).execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
+
+        // Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        assert_ok!(Sudo::sudo(Origin::signed(1), call));
+        let expected_event = TestEvent::sudo(RawEvent::Sudid(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    })
+}
+
+#[test]
+fn sudo_unchecked_weight_basics() {
+    new_test_ext(1).execute_with(|| {
+        // A privileged function should work when `sudo` is passed the root `key` as origin.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Sudo::sudo_unchecked_weight(Origin::signed(1), call, 1_000));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
+
+        // A privileged function should not work when called with a non-root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_noop!(
+            Sudo::sudo_unchecked_weight(Origin::signed(2), call, 1_000),
+            Error::<Test>::RequireSudo,
+        );
+        // `I32Log` is unchanged after unsuccessful call.
+        assert_eq!(Logger::i32_log(), vec![42i32]);
+
+        // Controls the dispatched weight.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        let sudo_unchecked_weight_call = SudoCall::sudo_unchecked_weight(call, 1_000);
+        let info = sudo_unchecked_weight_call.get_dispatch_info();
+        assert_eq!(info.weight, 1_000);
+    });
+}
+
+#[test]
+fn sudo_unchecked_weight_emits_events_correctly() {
+    new_test_ext(1).execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
+
+        // Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
+        assert_ok!(Sudo::sudo_unchecked_weight(Origin::signed(1), call, 1_000));
+        let expected_event = TestEvent::sudo(RawEvent::Sudid(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    })
+}
+
+#[test]
+fn set_key_basics() {
+    new_test_ext(1).execute_with(|| {
+        // A root `key` can change the root `key`
+        assert_ok!(Sudo::set_key(Origin::signed(1), 2));
+        assert_eq!(Sudo::key(), 2u64);
+    });
+
+    new_test_ext(1).execute_with(|| {
+        // A non-root `key` will trigger a `RequireSudo` error and a non-root `key` cannot change the root `key`.
+        assert_noop!(
+            Sudo::set_key(Origin::signed(2), 3),
+            Error::<Test>::RequireSudo
+        );
+    });
+}
+
+#[test]
+fn set_key_emits_events_correctly() {
+    new_test_ext(1).execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
+
+        // A root `key` can change the root `key`.
+        assert_ok!(Sudo::set_key(Origin::signed(1), 2));
+        let expected_event = TestEvent::sudo(RawEvent::KeyChanged(1));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+        // Double check.
+        assert_ok!(Sudo::set_key(Origin::signed(2), 4));
+        let expected_event = TestEvent::sudo(RawEvent::KeyChanged(2));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    });
+}
+
+#[test]
+fn sudo_as_basics() {
+    new_test_ext(1).execute_with(|| {
+        // A privileged function will not work when passed to `sudo_as`.
+        let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1_000)));
+        assert_ok!(Sudo::sudo_as(Origin::signed(1), 2, call));
+        assert!(Logger::i32_log().is_empty());
+        assert!(Logger::account_log().is_empty());
+
+        // A non-privileged function should not work when called with a non-root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_noop!(
+            Sudo::sudo_as(Origin::signed(3), 2, call),
+            Error::<Test>::RequireSudo
+        );
+
+        // A non-privileged function will work when passed to `sudo_as` with the root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_ok!(Sudo::sudo_as(Origin::signed(1), 2, call));
+        assert_eq!(Logger::i32_log(), vec![42i32]);
+        // The correct user makes the call within `sudo_as`.
+        assert_eq!(Logger::account_log(), vec![2]);
+    });
+}
+
+#[test]
+fn sudo_as_emits_events_correctly() {
+    new_test_ext(1).execute_with(|| {
+        // Set block number to 1 because events are not emitted on block 0.
+        System::set_block_number(1);
+
+        // A non-privileged function will work when passed to `sudo_as` with the root `key`.
+        let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
+        assert_ok!(Sudo::sudo_as(Origin::signed(1), 2, call));
+        let expected_event = TestEvent::sudo(RawEvent::SudoAsDone(Ok(())));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    });
+}


### PR DESCRIPTION
Release notes -
- Using a fork version of the `Sudo` pallet instead of a reference from the substrate repo.
- Fixes some weight calculation.