### PR TITLE
Fixed minor bugs in sto

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1136,8 +1136,6 @@ decl_error! {
         TotalSupplyOverflow,
         /// An invalid granularity.
         InvalidGranularity,
-        /// The account does not hold this token.
-        NotAnAssetHolder,
         /// The asset must be frozen.
         NotFrozen,
         /// No such smart extension.
@@ -1599,10 +1597,6 @@ impl<T: Trait> Module<T> {
     ) -> DispatchResult {
         Self::ensure_granular(ticker, value)?;
 
-        ensure!(
-            <BalanceOf<T>>::contains_key(ticker, &from_portfolio.did),
-            Error::<T>::NotAnAssetHolder
-        );
         ensure!(
             from_portfolio.did != to_portfolio.did,
             Error::<T>::SenderSameAsReceiver

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -440,7 +440,7 @@ fn zero_price_sto() {
         ticker,
         fundraiser_id,
         amount.into(),
-        None,
+        Some(0),
         None
     ));
 

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -178,59 +178,35 @@ fn raise_happy_path() {
         STO::fundraiser_name(offering_ticker, fundraiser_id),
         fundraiser_name
     );
-    // Investment fails if the minimum investment amount is not met
-    assert_noop!(
+    let sto_invest = |purchase_amount, max_price| {
         STO::invest(
             bob_signed.clone(),
             bob_portfolio,
             bob_portfolio,
             offering_ticker,
             fundraiser_id,
-            1,
-            Some(1_000_000u128),
-            None
-        ),
+            purchase_amount,
+            max_price,
+            None,
+        )
+    };
+    // Investment fails if the minimum investment amount is not met
+    assert_noop!(
+        sto_invest(1, Some(1_000_000u128)),
         Error::InvestmentAmountTooLow
     );
     // Investment fails if the order is not filled
     assert_noop!(
-        STO::invest(
-            bob_signed.clone(),
-            bob_portfolio,
-            bob_portfolio,
-            offering_ticker,
-            fundraiser_id,
-            1_000_001u128,
-            Some(1_000_000u128),
-            None
-        ),
+        sto_invest(1_000_001u128, Some(1_000_000u128)),
         Error::InsufficientTokensRemaining
     );
     // Investment fails if the maximum price is breached
     assert_noop!(
-        STO::invest(
-            bob_signed.clone(),
-            bob_portfolio,
-            bob_portfolio,
-            offering_ticker,
-            fundraiser_id,
-            amount.into(),
-            Some(999_999u128),
-            None
-        ),
+        sto_invest(amount.into(), Some(999_999u128)),
         Error::MaxPriceExceeded
     );
     // Bob invests in Alice's fundraiser
-    assert_ok!(STO::invest(
-        bob_signed.clone(),
-        bob_portfolio,
-        bob_portfolio,
-        offering_ticker,
-        fundraiser_id,
-        amount.into(),
-        Some(1_000_000u128),
-        None
-    ));
+    assert_ok!(sto_invest(amount.into(), Some(1_000_000u128)));
     check_fundraiser(1_000_000u128 - amount);
 
     assert_eq!(

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -182,10 +182,38 @@ fn raise_happy_path() {
             offering_ticker,
             fundraiser_id,
             1,
-            Some(2u128),
+            Some(1_000_000u128),
             None
         ),
         Error::InvestmentAmountTooLow
+    );
+    // Investment fails if the order is not filled
+    assert_noop!(
+        STO::invest(
+            bob_signed.clone(),
+            bob_portfolio,
+            bob_portfolio,
+            offering_ticker,
+            fundraiser_id,
+            1_000_001u128,
+            Some(1_000_000u128),
+            None
+        ),
+        Error::InsufficientTokensRemaining
+    );
+    // Investment fails if the maximum price is breached
+    assert_noop!(
+        STO::invest(
+            bob_signed.clone(),
+            bob_portfolio,
+            bob_portfolio,
+            offering_ticker,
+            fundraiser_id,
+            amount.into(),
+            Some(999_999u128),
+            None
+        ),
+        Error::MaxPriceExceeded
     );
     // Bob invests in Alice's fundraiser
     assert_ok!(STO::invest(
@@ -195,7 +223,7 @@ fn raise_happy_path() {
         offering_ticker,
         fundraiser_id,
         amount.into(),
-        Some(2u128),
+        Some(1_000_000u128),
         None
     ));
     check_fundraiser(1_000_000u128 - amount);

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -734,6 +734,18 @@ pub fn make_account(
     make_account_with_uid(id, uid)
 }
 
+pub fn make_account_with_portfolio(
+    id: AccountId,
+) -> (
+    <TestStorage as frame_system::Trait>::Origin,
+    IdentityId,
+    PortfolioId,
+) {
+    let (origin, did) = make_account(id).unwrap();
+    let portfolio = PortfolioId::default_portfolio(did);
+    (origin, did, portfolio)
+}
+
 pub fn make_account_with_scope(
     id: AccountId,
     ticker: Ticker,

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -230,6 +230,8 @@ decl_module! {
         /// * `venue_id` - Venue to handle settlement.
         /// * `start` - Fundraiser start time, if `None` the fundraiser will start immediately.
         /// * `end` - Fundraiser end time, if `None` the fundraiser will never expire.
+        /// * `minimum_investment` - Minimum amount of raising_asset that an investor needs to spend to invest in this raise.
+        /// * `fundraiser_name` - Fundraiser name, only used in the UIs.
         ///
         /// # Weight
         /// `800_000_000` placeholder

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -230,7 +230,7 @@ decl_module! {
         /// * `venue_id` - Venue to handle settlement.
         /// * `start` - Fundraiser start time, if `None` the fundraiser will start immediately.
         /// * `end` - Fundraiser end time, if `None` the fundraiser will never expire.
-        /// * `minimum_investment` - Minimum amount of raising_asset that an investor needs to spend to invest in this raise.
+        /// * `minimum_investment` - Minimum amount of `raising_asset` that an investor needs to spend to invest in this raise.
         /// * `fundraiser_name` - Fundraiser name, only used in the UIs.
         ///
         /// # Weight


### PR DESCRIPTION
## changelog

### Internal
- Minimum investment amount is now checked correctly against the payment tokens instead of the offering token.
- Accounted for `price_divisor` when checking for max price.
- No longer checks that the sender is an asset holder since 0 amount transfers are allowed.