### PR TITLE
Execute legs in order

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1600,10 +1600,6 @@ impl<T: Trait> Module<T> {
         Self::ensure_granular(ticker, value)?;
 
         ensure!(
-            <BalanceOf<T>>::contains_key(ticker, &from_portfolio.did),
-            Error::<T>::NotAnAssetHolder
-        );
-        ensure!(
             from_portfolio.did != to_portfolio.did,
             Error::<T>::SenderSameAsReceiver
         );

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -7,7 +7,9 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok, traits::OnInitialize, StorageMap};
+use frame_support::{
+    assert_noop, assert_ok, traits::OnInitialize, IterableStorageDoubleMap, StorageMap,
+};
 use pallet_asset as asset;
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;
@@ -3216,6 +3218,91 @@ fn reject_instruction() {
                 instruction_counter2,
                 AffirmationStatus::Unknown,
                 AffirmationStatus::Unknown,
+            );
+        });
+}
+
+#[test]
+fn dirty_storage_with_tx() {
+    ExtBuilder::default()
+        .cdd_providers(vec![AccountKeyring::Eve.public()])
+        .set_max_legs_allowed(500)
+        .build()
+        .execute_with(|| {
+            let (alice_signed, alice_did) = make_account(AccountKeyring::Alice.public()).unwrap();
+            let (bob_signed, bob_did) = make_account(AccountKeyring::Bob.public()).unwrap();
+            let token_name = b"ACME";
+            let ticker = Ticker::try_from(&token_name[..]).unwrap();
+            let venue_counter = init(token_name, ticker, AccountKeyring::Alice.public());
+            let instruction_counter = Settlement::instruction_counter();
+            let alice_init_balance = Asset::balance_of(&ticker, alice_did);
+            let bob_init_balance = Asset::balance_of(&ticker, bob_did);
+            let amount1 = 100u128;
+            let amount2 = 50u128;
+            let eve = AccountKeyring::Eve.public();
+
+            // Provide scope claim to sender and receiver of the transaction.
+            provide_scope_claim_to_multiple_parties(&[alice_did, bob_did], ticker, eve);
+
+            assert_ok!(Settlement::add_instruction(
+                alice_signed.clone(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                vec![
+                    Leg {
+                        from: PortfolioId::default_portfolio(alice_did),
+                        to: PortfolioId::default_portfolio(bob_did),
+                        asset: ticker,
+                        amount: amount1
+                    },
+                    Leg {
+                        from: PortfolioId::default_portfolio(bob_did),
+                        to: PortfolioId::default_portfolio(alice_did),
+                        asset: ticker,
+                        amount: 0
+                    },
+                    Leg {
+                        from: PortfolioId::default_portfolio(alice_did),
+                        to: PortfolioId::default_portfolio(bob_did),
+                        asset: ticker,
+                        amount: amount2
+                    }
+                ]
+            ));
+
+            assert_affirm_instruction!(alice_signed.clone(), instruction_counter, alice_did, 2);
+            assert_eq!(Asset::balance_of(&ticker, alice_did), alice_init_balance);
+            assert_eq!(Asset::balance_of(&ticker, bob_did), bob_init_balance);
+            set_current_block_number(5);
+            assert_affirm_instruction_with_one_leg!(
+                bob_signed.clone(),
+                instruction_counter,
+                bob_did
+            );
+
+            // Advances the block no. to execute the instruction.
+            let total_amount = amount1 + amount2;
+            assert_eq!(
+                Settlement::instruction_affirms_pending(instruction_counter),
+                0
+            );
+            next_block();
+            assert_eq!(
+                settlement::InstructionLegs::<TestStorage>::iter_prefix(instruction_counter)
+                    .count(),
+                0
+            );
+
+            // Ensure proper balance transfers
+            assert_eq!(
+                Asset::balance_of(&ticker, alice_did),
+                alice_init_balance - total_amount
+            );
+            assert_eq!(
+                Asset::balance_of(&ticker, bob_did),
+                bob_init_balance + total_amount
             );
         });
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -990,7 +990,9 @@ impl<T: Trait> Module<T> {
     }
 
     fn execute_instruction(instruction_id: u64) -> Result<u32, DispatchError> {
-        let legs = <InstructionLegs<T>>::iter_prefix(instruction_id).collect::<Vec<_>>();
+        let mut legs = <InstructionLegs<T>>::iter_prefix(instruction_id).collect::<Vec<_>>();
+        // NB: Execution order doesn't matter in most cases but might matter in some edge cases around compliance
+        legs.sort_by_key(|leg| leg.0);
         let instructions_processed: u32 = u32::try_from(legs.len()).unwrap_or_default();
         Self::unchecked_release_locks(instruction_id, &legs);
         let mut result = DispatchResult::Ok(());

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -445,7 +445,7 @@ decl_storage! {
         /// Details about an instruction. instruction_id -> instruction_details
         InstructionDetails get(fn instruction_details): map hasher(twox_64_concat) u64 => Instruction<T::Moment, T::BlockNumber>;
         /// Legs under an instruction. (instruction_id, leg_id) -> Leg
-        InstructionLegs get(fn instruction_legs): double_map hasher(twox_64_concat) u64, hasher(twox_64_concat) u64 => Leg<T::Balance>;
+        pub InstructionLegs get(fn instruction_legs): double_map hasher(twox_64_concat) u64, hasher(twox_64_concat) u64 => Leg<T::Balance>;
         /// Status of a leg under an instruction. (instruction_id, leg_id) -> LegStatus
         InstructionLegStatus get(fn instruction_leg_status): double_map hasher(twox_64_concat) u64, hasher(twox_64_concat) u64 => LegStatus<T::AccountId>;
         /// Number of affirmations pending before instruction is executed. instruction_id -> affirm_pending


### PR DESCRIPTION
Added an unrelated test case, plus:

## changelog

### modifed logic
- Legs of a settlement instruction are now executed in order.

