### PR TITLE
[WIP] Minor benchmark refactoring

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1172,15 +1172,6 @@ decl_error! {
 }
 
 impl<T: Trait> AssetFnTrait<T::Balance, T::AccountId, T::Origin> for Module<T> {
-    fn _mint_from_sto(
-        ticker: &Ticker,
-        caller: T::AccountId,
-        sender: IdentityId,
-        assets_purchased: T::Balance,
-    ) -> DispatchResult {
-        Self::_mint(ticker, caller, sender, assets_purchased, None)
-    }
-
     fn is_owner(ticker: &Ticker, did: IdentityId) -> bool {
         Self::_is_owner(ticker, did)
     }
@@ -1249,6 +1240,26 @@ impl<T: Trait> AssetFnTrait<T::Balance, T::AccountId, T::Origin> for Module<T> {
     #[inline]
     fn register_ticker(origin: T::Origin, ticker: Ticker) -> DispatchResult {
         Self::register_ticker(origin, ticker)
+    }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    /// Adds an artificial IU claim for benchmarks
+    fn add_investor_uniqueness_claim(did: IdentityId, ticker: Ticker) {
+        use polymesh_primitives::{CddId, Claim, InvestorUid, Scope};
+        Identity::<T>::base_add_claim(
+            did,
+            Claim::InvestorUniqueness(
+                Scope::Ticker(ticker),
+                did,
+                CddId::new(did, InvestorUid::from(did.to_bytes())),
+            ),
+            did,
+            None,
+        );
+        let current_balance = Self::balance_of(ticker, did);
+        <AggregateBalance<T>>::insert(ticker, &did, current_balance);
+        <BalanceOfAtScope<T>>::insert(did, did, current_balance);
+        <ScopeIdOf>::insert(ticker, did, did);
     }
 }
 

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -105,12 +105,6 @@ impl Default for FundingRoundName {
 pub trait AssetFnTrait<Balance, Account, Origin> {
     fn total_supply(ticker: &Ticker) -> Balance;
     fn balance(ticker: &Ticker, did: IdentityId) -> Balance;
-    fn _mint_from_sto(
-        ticker: &Ticker,
-        caller: Account,
-        sender_did: IdentityId,
-        assets_purchased: Balance,
-    ) -> DispatchResult;
     /// Check if an Identity is the owner of a ticker.
     fn is_owner(ticker: &Ticker, did: IdentityId) -> bool;
     /// Get an Identity's balance of a token at a particular checkpoint.
@@ -142,4 +136,7 @@ pub trait AssetFnTrait<Balance, Account, Origin> {
     ) -> DispatchResult;
 
     fn register_ticker(origin: Origin, ticker: Ticker) -> DispatchResult;
+    #[cfg(feature = "runtime-benchmarks")]
+    /// Adds an artificial IU claim for benchmarks
+    fn add_investor_uniqueness_claim(did: IdentityId, ticker: Ticker);
 }

--- a/pallets/corporate-actions/src/ballot/benchmarking.rs
+++ b/pallets/corporate-actions/src/ballot/benchmarking.rs
@@ -53,9 +53,9 @@ benchmarks! {
     _ {}
 
     attach_ballot {
-        let j in 0..MAX_CHOICES;
+        let c in 0..MAX_CHOICES;
 
-        let meta = meta(1, j);
+        let meta = meta(1, c);
         let (owner, ca_id) = setup_ca::<T>(CAKind::IssuerNotice);
     }: _(owner.origin(), ca_id, RANGE, meta, true)
     verify {
@@ -63,21 +63,21 @@ benchmarks! {
     }
 
     vote {
-        let j in 0..MAX_CHOICES;
-        let k in 0..MAX_TARGETS;
+        let c in 0..MAX_CHOICES;
+        let t in 0..MAX_TARGETS;
 
         // Attach and prepare to vote.
-        let (owner, ca_id) = attach::<T>(1, j);
+        let (owner, ca_id) = attach::<T>(1, c);
         <pallet_timestamp::Now<T>>::set(3000.into());
 
         // Change targets, as they are read in voting.
-        set_ca_targets::<T>(ca_id, k);
+        set_ca_targets::<T>(ca_id, t);
 
         // Construct the voting list.
-        let votes = (0..j)
-            .map(|j| BallotVote {
+        let votes = (0..c)
+            .map(|c| BallotVote {
                 power: 0.into(),
-                fallback: (j as u16).checked_sub(1),
+                fallback: (c as u16).checked_sub(1),
             })
             .collect::<Vec<_>>();
 
@@ -97,10 +97,10 @@ benchmarks! {
     }
 
     change_meta {
-        let j in 0..MAX_CHOICES;
+        let c in 0..MAX_CHOICES;
 
         let (owner, ca_id) = attach::<T>(0, 0);
-        let meta = meta(1, j);
+        let meta = meta(1, c);
         let meta2 = meta.clone();
     }: _(owner.origin(), ca_id, meta)
     verify {

--- a/pallets/corporate-actions/src/benchmarking.rs
+++ b/pallets/corporate-actions/src/benchmarking.rs
@@ -214,10 +214,10 @@ benchmarks! {
     }
 
     set_default_targets {
-        let i in 0..MAX_TARGET_IDENTITIES;
+        let t in 0..MAX_TARGET_IDENTITIES;
 
         let (owner, ticker) = setup::<T>();
-        let targets = target_ids::<T>(i, TargetTreatment::Exclude);
+        let targets = target_ids::<T>(t, TargetTreatment::Exclude);
         let targets2 = targets.clone();
     }: _(owner.origin(), ticker, targets)
     verify {
@@ -232,11 +232,11 @@ benchmarks! {
     }
 
     set_did_withholding_tax {
-        let i in 0..(MAX_DID_WHT_IDS - 1);
+        let w in 0..(MAX_DID_WHT_IDS - 1);
 
         let (owner, ticker) = setup::<T>();
-        let mut whts = init_did_whts::<T>(ticker, i);
-        let last = target::<T>(i + 1);
+        let mut whts = init_did_whts::<T>(ticker, w);
+        let last = target::<T>(w + 1);
     }: _(owner.origin(), ticker, last, Some(TAX))
     verify {
         whts.push((last, TAX));
@@ -245,13 +245,13 @@ benchmarks! {
     }
 
     initiate_corporate_action_use_defaults {
-        let j in 0..MAX_DID_WHT_IDS;
-        let k in 0..MAX_TARGET_IDENTITIES;
+        let w in 0..MAX_DID_WHT_IDS;
+        let t in 0..MAX_TARGET_IDENTITIES;
 
         let (owner, ticker) = setup::<T>();
         let details = details(DETAILS_LEN);
-        let whts = init_did_whts::<T>(ticker, j);
-        let targets = target_ids::<T>(k, TargetTreatment::Exclude).dedup();
+        let whts = init_did_whts::<T>(ticker, w);
+        let targets = target_ids::<T>(t, TargetTreatment::Exclude).dedup();
         DefaultTargetIdentities::insert(ticker, targets);
     }: initiate_corporate_action(
         owner.origin(), ticker, CAKind::Other, 1000, RD_SPEC, details, None, None, None
@@ -261,13 +261,13 @@ benchmarks! {
     }
 
     initiate_corporate_action_provided {
-        let j in 0..MAX_DID_WHT_IDS;
-        let k in 0..MAX_TARGET_IDENTITIES;
+        let w in 0..MAX_DID_WHT_IDS;
+        let t in 0..MAX_TARGET_IDENTITIES;
 
         let (owner, ticker) = setup::<T>();
         let details = details(DETAILS_LEN);
-        let whts = Some(did_whts::<T>(j));
-        let targets = Some(target_ids::<T>(k, TargetTreatment::Exclude));
+        let whts = Some(did_whts::<T>(w));
+        let targets = Some(target_ids::<T>(t, TargetTreatment::Exclude));
     }: initiate_corporate_action(
         owner.origin(), ticker, CAKind::Other, 1000, RD_SPEC, details, targets, Some(TAX), whts
     )
@@ -276,11 +276,11 @@ benchmarks! {
     }
 
     link_ca_doc {
-        let i in 0..MAX_DOCS;
+        let d in 0..MAX_DOCS;
 
         let (owner, ticker) = setup::<T>();
         let origin: T::Origin = owner.origin().into();
-        let ids = add_docs::<T>(&origin, ticker, i);
+        let ids = add_docs::<T>(&origin, ticker, d);
         let ids2 = ids.clone();
         <Module<T>>::initiate_corporate_action(
             origin, ticker, CAKind::Other, 1000, None, "".into(), None, None, None

--- a/pallets/corporate-actions/src/distribution/benchmarking.rs
+++ b/pallets/corporate-actions/src/distribution/benchmarking.rs
@@ -134,10 +134,10 @@ benchmarks! {
 
     // TODO(Centril): make this work with WASM execution.
     claim {
-        let i in 0..MAX_TARGETS;
-        let j in 0..MAX_DID_WHT_IDS;
+        let t in 0..MAX_TARGETS;
+        let w in 0..MAX_DID_WHT_IDS;
 
-        let (_, holder, ca_id) = prepare_transfer::<T>(i, j);
+        let (_, holder, ca_id) = prepare_transfer::<T>(t, w);
     }: _(holder.origin(), ca_id)
     verify {
         ensure!(HolderPaid::get((ca_id, holder.did())), "not paid");
@@ -145,10 +145,10 @@ benchmarks! {
 
     // TODO(Centril): make this work with WASM execution.
     push_benefit {
-        let i in 0..MAX_TARGETS;
-        let j in 0..MAX_DID_WHT_IDS;
+        let t in 0..MAX_TARGETS;
+        let w in 0..MAX_DID_WHT_IDS;
 
-        let (owner, holder, ca_id) = prepare_transfer::<T>(i, j);
+        let (owner, holder, ca_id) = prepare_transfer::<T>(t, w);
     }: _(owner.origin(), ca_id, holder.did())
     verify {
         ensure!(HolderPaid::get((ca_id, holder.did())), "not paid");

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -52,8 +52,8 @@ benchmarks! {
 
     move_portfolio_funds {
         // Number of assets being moved
-        let i in 1 .. 500;
-        let mut items = Vec::with_capacity(i as usize);
+        let a in 1 .. 500;
+        let mut items = Vec::with_capacity(a as usize);
         let target = UserBuilder::<T>::default().generate_did().build("target");
         let first_ticker = Ticker::try_from(generate_ticker(0u64).as_slice()).unwrap();
         let amount = T::Balance::from(10);
@@ -62,7 +62,7 @@ benchmarks! {
         let default_portfolio = PortfolioId::default_portfolio(target.did());
         let user_portfolio = PortfolioId::user_portfolio(target.did(), next_portfolio_num.clone());
 
-        for x in 0..i as u64 {
+        for x in 0..a as u64 {
             let ticker = Ticker::try_from(generate_ticker(x).as_slice()).unwrap();
             items.push(MovePortfolioItem {
                 ticker,

--- a/pallets/sto/src/benchmarking.rs
+++ b/pallets/sto/src/benchmarking.rs
@@ -157,10 +157,7 @@ benchmarks! {
     }
 
     invest {
-        let c in 1 .. T::MaxConditionComplexity::get() as u32;
-        let s in 1 .. T::MaxTransferManagersPerAsset::get() as u32;
-
-        let (alice, bob) = setup_fundraiser::<T>(c, MAX_TIERS as u32, s)?;
+        let (alice, bob) = setup_fundraiser::<T>(T::MaxConditionComplexity::get() as u32, MAX_TIERS as u32, T::MaxTransferManagersPerAsset::get() as u32)?;
     }: _(
             bob.user.origin(),
             bob.portfolio,

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -30,7 +30,6 @@ use codec::{Decode, Encode};
 use core::mem;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
-    traits::Get,
 };
 use pallet_asset as asset;
 use pallet_identity::{self as identity, PermissionedCallOriginData};
@@ -149,7 +148,7 @@ pub struct FundraiserName(Vec<u8>);
 
 pub trait WeightInfo {
     fn create_fundraiser(i: u32) -> Weight;
-    fn invest(c: u32) -> Weight;
+    fn invest() -> Weight;
     fn freeze_fundraiser() -> Weight;
     fn unfreeze_fundraiser() -> Weight;
     fn modify_fundraiser_window() -> Weight;
@@ -322,7 +321,7 @@ decl_module! {
         ///
         /// # Weight
         /// `2_000_000_000` placeholder
-        #[weight = <T as Trait>::WeightInfo::invest(T::MaxConditionComplexity::get())]
+        #[weight = <T as Trait>::WeightInfo::invest()]
         pub fn invest(
             origin,
             investment_portfolio: PortfolioId,

--- a/pallets/weights/src/pallet_sto.rs
+++ b/pallets/weights/src/pallet_sto.rs
@@ -13,11 +13,9 @@ impl pallet_sto::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(11 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
-    fn invest(c: u32) -> Weight {
-        (373_222_000 as Weight)
-            .saturating_add((15_652_000 as Weight).saturating_mul(c as Weight))
-            .saturating_add(DbWeight::get().reads(49 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+    fn invest() -> Weight {
+        (1_100_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(100 as Weight))
             .saturating_add(DbWeight::get().writes(30 as Weight))
     }
     fn freeze_fundraiser() -> Weight {


### PR DESCRIPTION
- Fixed corporate action benchmarks in WASM execution.
- Renamed a few variables so that we are consistent with what a variable means in one pallet's benchmarks. This was needed because I wanted to easily map variables to what they mean for visualization of benchmarks. It has no functional effect.
- STO.invest benchmark made to assume worst case always.