### PR TITLE
MESH-1489 (CP schedule ref counting) + MESH-1488 (CP schedule expiry-after-ticks)

### DIFF
--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -92,6 +92,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
+#![feature(const_option)]
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
@@ -111,7 +112,7 @@ use frame_support::{
 use frame_system::ensure_root;
 use pallet_asset::{
     self as asset,
-    checkpoint::{self, ScheduleId},
+    checkpoint::{self, ScheduleId, SchedulePoints, ScheduleRefCount},
 };
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
@@ -120,9 +121,10 @@ use polymesh_common_utilities::{
     with_transaction, GC_DID,
 };
 use polymesh_primitives::{
-    calendar::CheckpointId, AuthorizationData, DocumentId, EventDid, IdentityId, Moment, Ticker,
+    calendar::CheckpointId, storage_migrate_on, storage_migration_ver, AuthorizationData,
+    DocumentId, EventDid, IdentityId, Moment, Ticker,
 };
-use polymesh_primitives_derive::VecU8StrongTyped;
+use polymesh_primitives_derive::{Migrate, VecU8StrongTyped};
 use sp_arithmetic::Permill;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
@@ -223,11 +225,15 @@ pub struct CADetails(pub Vec<u8>);
 
 /// Defines how to identify a CA's associated checkpoint, if any.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug, Migrate)]
 pub enum CACheckpoint {
     /// CA uses a record date scheduled to occur in the future.
     /// Checkpoint ID will be taken after the record date.
-    Scheduled(ScheduleId),
+    ///
+    /// Since a schedule can be recurring,
+    /// the `u64` stores the number of checkpoints before the CA was made.
+    /// This allows indexing into the list of CPs, getting exactly the right one.
+    Scheduled(ScheduleId, #[migrate_with(0)] u64),
     /// CA uses an existing checkpoint ID which was recorded in the past.
     Existing(CheckpointId),
 }
@@ -235,11 +241,12 @@ pub enum CACheckpoint {
 /// Defines the record date, at which impact should be calculated,
 /// along with checkpoint info to assess the impact at the date.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug, Migrate)]
 pub struct RecordDate {
     /// When the impact should be calculated, or already has.
     pub date: Moment,
     /// Info used to determine the `CheckpointId` once `date` has passed.
+    #[migrate]
     pub checkpoint: CACheckpoint,
 }
 
@@ -259,13 +266,14 @@ pub enum RecordDateSpec {
 /// Details of a generic CA.
 /// The `(Ticker, ID)` denoting a unique identifier for the CA is stored as a key outside.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug)]
+#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug, Migrate)]
 pub struct CorporateAction {
     /// The kind of CA that this is.
     pub kind: CAKind,
     /// When the CA was declared off-chain.
     pub decl_date: Moment,
     /// Date at which any impact, if any, should be calculated.
+    #[migrate(RecordDate)]
     pub record_date: Option<RecordDate>,
     /// Free-form text up to a limit.
     pub details: CADetails,
@@ -413,8 +421,13 @@ decl_storage! {
         /// The `CorporateActions` map stores `Ticker => LocalId => The CA`,
         /// so we can infer `Ticker => CAId`. Therefore, we don't need a double map.
         pub CADocLink get(fn ca_doc_link): map hasher(blake2_128_concat) CAId => Vec<DocumentId>;
+
+        /// Storage version.
+        StorageVersion get(fn storage_version) build(|_| Version::new(1).unwrap()): Version;
     }
 }
+
+storage_migration_ver!(1);
 
 // Public interface for this runtime module.
 decl_module! {
@@ -423,6 +436,15 @@ decl_module! {
 
         /// initialize the default event for this module
         fn deposit_event() = default;
+
+        fn on_runtime_upgrade() -> Weight {
+            storage_migrate_on!(StorageVersion::get(), 1, {
+                use polymesh_primitives::migrate::{Empty, migrate_map};
+                migrate_map::<CorporateActionOld, _>(b"CorporateActions", b"CorporateActions", |_| Empty);
+            });
+
+            0
+        }
 
         /// Set the max `length` of `details` in terms of bytes.
         /// May only be called via a PIP.
@@ -669,8 +691,12 @@ decl_module! {
         }
 
         /// Removes the CA identified by `ca_id`.
+        ///
         /// Associated data, such as document links, ballots,
         /// and capital distributions are also removed.
+        ///
+        /// Any schedule associated with the record date will see
+        /// `strong_ref_count(schedule_id)` decremented.
         ///
         /// ## Arguments
         /// - `origin` which must be a signer for the CAA of `ca_id`.
@@ -701,7 +727,8 @@ decl_module! {
                 }
             }
 
-            // Remove + emit event.
+            // Decrement, Remove, and Emit event.
+            Self::dec_strong_ref_count(ca_id, ca.record_date);
             CorporateActions::remove(ca_id.ticker, ca_id.local_id);
             CADocLink::remove(ca_id);
             Self::deposit_event(Event::CARemoved(caa, ca_id));
@@ -728,6 +755,7 @@ decl_module! {
 
             with_transaction(|| -> DispatchResult {
                 // If provided, either use the existing CP ID or schedule one to be made.
+                Self::dec_strong_ref_count(ca_id, ca.record_date);
                 ca.record_date = record_date
                     .map(|date| Self::handle_record_date(caa, ca_id.ticker, date))
                     .transpose()?;
@@ -823,8 +851,6 @@ decl_error! {
         DeclDateInFuture,
         /// CA does not target the DID.
         NotTargetedByCA,
-        /// An existing schedule was used for a new CA that was removable, and that is not allowed.
-        ExistingScheduleRemovable,
     }
 }
 
@@ -905,9 +931,13 @@ impl<T: Trait> Module<T> {
         let ticker = ca_id.ticker;
         match ca.record_date.unwrap().checkpoint {
             CACheckpoint::Existing(id) => Some(id),
-            // For CAs, there will ever be at most one CP.
-            // And assuming transfers have happened since the record date, there's exactly one CP.
-            CACheckpoint::Scheduled(id) => <Checkpoint<T>>::schedule_points((ticker, id)).pop(),
+            // For CAs, there can be more than one CP,
+            // since you may attach a pre-existing and recurring schedule to it.
+            // However, the record date stores the index for the CP,
+            // assuming a transfer has happened since the record date.
+            CACheckpoint::Scheduled(id, idx) => <Checkpoint<T>>::schedule_points((ticker, id))
+                .get(idx as usize)
+                .copied(),
         }
     }
 
@@ -915,6 +945,18 @@ impl<T: Trait> Module<T> {
     crate fn ensure_ca_targets(ca: &CorporateAction, did: &IdentityId) -> DispatchResult {
         ensure!(ca.targets.targets(did), Error::<T>::NotTargetedByCA);
         Ok(())
+    }
+
+    /// Decrement the strong reference count of any schedule used in the `record_date` of `ca_id`.
+    fn dec_strong_ref_count(ca_id: CAId, record_date: Option<RecordDate>) {
+        if let Some(RecordDate {
+            checkpoint: CACheckpoint::Scheduled(sh_id, _),
+            ..
+        }) = record_date
+        {
+            // We've proven by getting here that `c > 0`, so `c - 1` cannot underflow.
+            ScheduleRefCount::mutate((ca_id.ticker, sh_id), |c| *c -= 1);
+        }
     }
 
     /// Translate record date to a format we can store.
@@ -927,21 +969,23 @@ impl<T: Trait> Module<T> {
         let (date, checkpoint) = match date {
             RecordDateSpec::Scheduled(date) => {
                 // Create the schedule and extract the date + id.
+                // We set initial `strong_ref_count(id) <- 1`.
                 let date = date.into();
-                let schedule = <Checkpoint<T>>::create_schedule_base(caa, ticker, date, false)?;
-                (schedule.at, CACheckpoint::Scheduled(schedule.id))
+                let schedule = <Checkpoint<T>>::create_schedule_base(caa, ticker, date, 1)?;
+                // It might be the case that the CP was instantly created ^--.
+                // Or it might not have. In either case, it will end up at index 0.
+                (schedule.at, CACheckpoint::Scheduled(schedule.id, 0))
             }
             RecordDateSpec::ExistingSchedule(id) => {
-                // Schedule cannot be removable, otherwise the CP module may remove it,
-                // resulting a "dangling reference", figuratively speaking.
-                ensure!(
-                    !<Checkpoint<T>>::schedule_removable((ticker, id)),
-                    Error::<T>::ExistingScheduleRemovable,
-                );
                 // Ensure the schedule exists and extract the record date.
                 let schedules = <Checkpoint<T>>::schedules(ticker);
                 let schedule = schedules[<Checkpoint<T>>::ensure_schedule_exists(&schedules, id)?];
-                (schedule.at, CACheckpoint::Scheduled(schedule.id))
+                // Schedule cannot be removable, otherwise the CP module may remove it,
+                // so we increment the strong reference count of `id`.
+                let ticker_sh = (ticker, id);
+                ScheduleRefCount::mutate(ticker_sh, |c| *c += 1);
+                let cp_at_idx = SchedulePoints::decode_len(ticker_sh).unwrap_or(0) as u64;
+                (schedule.at, CACheckpoint::Scheduled(schedule.id, cp_at_idx))
             }
             RecordDateSpec::Existing(id) => {
                 // Ensure the CP exists.

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -5,7 +5,7 @@ use crate::{
     storage::{
         add_secondary_key, make_account_without_cdd, provide_scope_claim,
         provide_scope_claim_to_multiple_parties, register_keyring_account,
-        register_keyring_account_without_cdd, root, AccountId, Checkpoint, TestStorage,
+        register_keyring_account_without_cdd, root, AccountId, Checkpoint, TestStorage, User,
     },
 };
 use chrono::prelude::Utc;
@@ -18,9 +18,10 @@ use ink_primitives::hash as FunctionSelectorHasher;
 use pallet_asset::checkpoint::ScheduleSpec;
 use pallet_asset::ethereum;
 use pallet_asset::{
-    self as asset, AssetOwnershipRelation, ClassicTickerImport, ClassicTickerRegistration,
-    ClassicTickers, ScopeIdOf, SecurityToken, TickerRegistration, TickerRegistrationConfig,
-    Tickers,
+    self as asset,
+    checkpoint::{ScheduleId, StoredSchedule},
+    AssetOwnershipRelation, ClassicTickerImport, ClassicTickerRegistration, ClassicTickers,
+    ScopeIdOf, SecurityToken, TickerRegistration, TickerRegistrationConfig, Tickers,
 };
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;
@@ -37,9 +38,11 @@ use polymesh_common_utilities::{
 };
 use polymesh_contracts::NonceBasedAddressDeterminer;
 use polymesh_primitives::{
-    calendar::{CalendarPeriod, CalendarUnit, CheckpointId, FixedOrVariableCalendarUnit},
-    AssetIdentifier, AuthorizationData, Document, DocumentId, IdentityId, InvestorUid, PortfolioId,
-    Signatory, SmartExtension, SmartExtensionType, Ticker,
+    calendar::{
+        CalendarPeriod, CalendarUnit, CheckpointId, CheckpointSchedule, FixedOrVariableCalendarUnit,
+    },
+    AssetIdentifier, AuthorizationData, Document, DocumentId, IdentityId, InvestorUid, Moment,
+    PortfolioId, Signatory, SmartExtension, SmartExtensionType, Ticker,
 };
 use rand::Rng;
 use sp_io::hashing::keccak_256;
@@ -346,6 +349,15 @@ fn issuers_can_redeem_tokens() {
         })
 }
 
+fn default_transfer(from: IdentityId, to: IdentityId, ticker: Ticker, val: u128) {
+    assert_ok!(Asset::unsafe_transfer(
+        PortfolioId::default_portfolio(from),
+        PortfolioId::default_portfolio(to),
+        &ticker,
+        val
+    ));
+}
+
 #[test]
 fn checkpoints_fuzz_test() {
     println!("Starting");
@@ -403,12 +415,7 @@ fn checkpoints_fuzz_test() {
                     }
                     owner_balance[j] -= 1;
                     bob_balance[j] += 1;
-                    assert_ok!(Asset::unsafe_transfer(
-                        PortfolioId::default_portfolio(owner_did),
-                        PortfolioId::default_portfolio(bob_did),
-                        &ticker,
-                        1
-                    ));
+                    default_transfer(owner_did, bob_did, ticker, 1);
                 }
                 assert_ok!(Checkpoint::create_checkpoint(owner_signed.clone(), ticker));
                 let bal_at = |id, did| Asset::get_balance_at(ticker, did, CheckpointId(id));
@@ -2690,6 +2697,7 @@ fn next_checkpoint_is_updated_we() {
     let schedule = ScheduleSpec {
         start: Some(start),
         period,
+        remaining: 0,
     };
     assert_ok!(Checkpoint::set_schedules_max_complexity(
         root(),
@@ -2708,12 +2716,7 @@ fn next_checkpoint_is_updated_we() {
 
     let transfer = |at| {
         Timestamp::set_timestamp(at);
-        assert_ok!(Asset::unsafe_transfer(
-            PortfolioId::default_portfolio(alice_did),
-            PortfolioId::default_portfolio(bob_did),
-            &ticker,
-            total_supply / 2,
-        ));
+        default_transfer(alice_did, bob_did, ticker, total_supply / 2);
     };
 
     // Make a transaction before the next timestamp.
@@ -2770,6 +2773,7 @@ fn non_recurring_schedule_works_we() {
     let schedule = ScheduleSpec {
         start: Some(start),
         period,
+        remaining: 0,
     };
     assert_ok!(Checkpoint::set_schedules_max_complexity(
         root(),
@@ -2798,4 +2802,108 @@ fn next_checkpoints(ticker: Ticker, start: u64) -> Vec<Option<u64>> {
         .into_iter()
         .map(|s| s.schedule.next_checkpoint(start))
         .collect()
+}
+
+#[test]
+fn schedule_remaining_works() {
+    ExtBuilder::default().build().execute_with(|| {
+        let start = 1_000;
+        Timestamp::set_timestamp(start);
+
+        let alice = User::new(AccountKeyring::Alice);
+        let bob = User::new(AccountKeyring::Bob);
+
+        // Create the asset.
+        let token_name = b"NXT";
+        let ticker = Ticker::try_from(&token_name[..]).unwrap();
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            token_name.into(),
+            ticker,
+            1_000_000,
+            true,
+            AssetType::default(),
+            vec![],
+            None,
+        ));
+
+        let transfer = |at: Moment| {
+            Timestamp::set_timestamp(at * 1_000);
+            default_transfer(alice.did, bob.did, ticker, 1);
+        };
+        let collect_ts = |sh_id| {
+            Checkpoint::schedule_points((ticker, sh_id))
+                .into_iter()
+                .map(Checkpoint::timestamps)
+                .collect::<Vec<_>>()
+        };
+
+        // No schedules yet.
+        assert_eq!(Checkpoint::schedules(ticker), vec![]);
+
+        // For simplicity, we use 1s = 1_000ms periods.
+        let period = CalendarPeriod {
+            unit: CalendarUnit::Second,
+            amount: 1,
+        };
+
+        // Allow such a schedule to be added on-chain. Otherwise, we'll have errors.
+        assert_ok!(Checkpoint::set_schedules_max_complexity(
+            root(),
+            period.complexity()
+        ));
+
+        // Create a schedule with one remaining and where `start == now`.
+        let mut spec = ScheduleSpec {
+            start: Some(start),
+            period,
+            remaining: 1,
+        };
+        let schedule = CheckpointSchedule { start, period };
+        assert_ok!(Checkpoint::create_schedule(alice.origin(), ticker, spec));
+
+        // We had `remaining == 1` and `start == now`,
+        // so since a CP was created, hence `remaining => 0`,
+        // the schedule was immediately evicted.
+        assert_eq!(Checkpoint::schedules(ticker), vec![]);
+        assert_eq!(collect_ts(ScheduleId(1)), vec![start]);
+
+        // This time, we set `remaining == 5`, but we still have `start == now`,
+        // thus one CP is immediately created, so `remaining => 4`.
+        spec.remaining = 5;
+        let id2 = ScheduleId(2);
+        let assert_ts = |ticks| {
+            assert_eq!(
+                collect_ts(id2),
+                (1..=ticks).map(|x| x * 1_000).collect::<Vec<_>>()
+            );
+        };
+        let assert_sh = |at: Moment, remaining| {
+            assert_eq!(
+                Checkpoint::schedules(ticker),
+                vec![StoredSchedule {
+                    id: id2,
+                    schedule,
+                    at: 1_000 * at,
+                    remaining,
+                }]
+            );
+        };
+        assert_ok!(Checkpoint::create_schedule(alice.origin(), ticker, spec));
+        assert_sh(2, 4);
+        assert_ts(1);
+
+        // Transfer and move through the 2nd to 4th recurrences.
+        for i in 2..5 {
+            transfer(i);
+            assert_sh(i + 1, spec.remaining - i as u32);
+            assert_ts(i);
+        }
+
+        // Transfer and move to the 5th (last) recurrence.
+        // We've to the point where there are no ticks left.
+        transfer(5);
+        assert_eq!(Checkpoint::schedules(ticker), vec![]);
+        assert_ts(5);
+    });
 }

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -920,7 +920,12 @@ fn change_record_date_works() {
         let mk_schedule = |at, id| {
             let period = <_>::default();
             let schedule = CheckpointSchedule { start: at, period };
-            StoredSchedule { at, id, schedule }
+            StoredSchedule {
+                at,
+                id,
+                schedule,
+                remaining: 0,
+            }
         };
         let mut all_schedules = vec![];
         let mut change_ok_scheduled = || {

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -548,8 +548,8 @@ fn initiate_corporate_action_record_date() {
 
                 assert_eq!(date, rd.date);
                 match rd.checkpoint {
-                    CACheckpoint::Scheduled(id) => assert_eq!(schedule_id, id),
-                    CACheckpoint::Existing(_) => panic!(),
+                    CACheckpoint::Scheduled(id, 0) => assert_eq!(schedule_id, id),
+                    _ => panic!(),
                 }
 
                 Timestamp::set_timestamp(date);
@@ -885,6 +885,9 @@ fn change_record_date_works() {
             assert_ok!(change(id, date));
             assert_eq!(expect, get_ca(id).unwrap().record_date);
         };
+        let assert_refs =
+            |sh_id, count| assert_eq!(Checkpoint::schedule_ref_count((ticker, sh_id)), count);
+        let assert_fresh = |sh_id| assert_eq!(Checkpoint::schedule_id_sequence(ticker), sh_id);
 
         // Change for a CA that doesn't exist, and ensure failure.
         let id = next_ca_id(ticker);
@@ -898,7 +901,7 @@ fn change_record_date_works() {
             Some(RecordDate { date, checkpoint })
         };
         let rd_ts = |date, id| {
-            let checkpoint = CACheckpoint::Scheduled(id);
+            let checkpoint = CACheckpoint::Scheduled(id, 0);
             Some(RecordDate { date, checkpoint })
         };
 
@@ -913,39 +916,58 @@ fn change_record_date_works() {
         // Trigger `NoSuchSchedule`.
         assert_noop!(change(id, spec_sh(ScheduleId(42))), CPError::NoSuchSchedule);
 
-        // Successfully use a schedule which exists.
-        let sh_id = next_schedule_id(ticker);
-        change_ok(id, spec_ts(1000), rd_ts(1000, sh_id));
-        assert_eq!(Checkpoint::schedule_id_sequence(ticker), sh_id);
-        assert!(!Checkpoint::schedule_removable((ticker, sh_id)));
+        // Successfully use a schedule which exists (the same one as before).
         let mk_schedule = |at, id| {
             let period = <_>::default();
             let schedule = CheckpointSchedule { start: at, period };
             StoredSchedule { at, id, schedule }
         };
-        assert_eq!(
-            Checkpoint::schedules(ticker),
-            vec![mk_schedule(1000, sh_id)]
-        );
-        change_ok(id, spec_sh(sh_id), rd_ts(1000, sh_id));
+        let mut all_schedules = vec![];
+        let mut change_ok_scheduled = || {
+            let sh_id = next_schedule_id(ticker);
+            change_ok(id, spec_ts(1000), rd_ts(1000, sh_id));
+            assert_fresh(sh_id);
+            assert_refs(sh_id, 1);
+            all_schedules.push(mk_schedule(1000, sh_id));
+            assert_eq!(Checkpoint::schedules(ticker), all_schedules);
+            change_ok(id, spec_sh(sh_id), rd_ts(1000, sh_id));
+            sh_id
+        };
+        let sh_id1 = change_ok_scheduled();
+        assert_eq!(Checkpoint::schedule_ref_count((ticker, sh_id1)), 1);
 
-        // Use a removable schedule. Should fail.
-        let sh_id2 = next_schedule_id(ticker);
+        // Then use a distinct existing ID.
+        let sh_id2 = change_ok_scheduled();
+        assert_refs(sh_id1, 0);
+        assert_refs(sh_id2, 1);
+
+        // Use a removable schedule. Should increment strong ref count.
+        let sh_id3 = next_schedule_id(ticker);
         assert_ok!(Checkpoint::create_schedule(
             owner.origin(),
             ticker,
             2000.into()
         ));
-        assert_eq!(Checkpoint::schedule_id_sequence(ticker), sh_id2);
-        assert!(Checkpoint::schedule_removable((ticker, sh_id2)));
+        assert_fresh(sh_id3);
+        assert_refs(sh_id3, 0);
         assert_eq!(
             Checkpoint::schedules(ticker),
-            vec![mk_schedule(1000, sh_id), mk_schedule(2000, sh_id2)]
+            vec![
+                mk_schedule(1000, sh_id1),
+                mk_schedule(1000, sh_id2),
+                mk_schedule(2000, sh_id3)
+            ]
         );
-        assert_noop!(
-            change(id, spec_sh(sh_id2)),
-            Error::ExistingScheduleRemovable
-        );
+        change_ok(id, spec_sh(sh_id3), rd_ts(2000, sh_id3));
+        assert_refs(sh_id3, 1);
+
+        // While at it, let's create a bunch of CAs and use the last schedule.
+        for _ in 0..10 {
+            let id = next_ca_id(ticker);
+            ca(CAKind::IssuerNotice, Some(1000));
+            change_ok(id, spec_sh(sh_id3), rd_ts(2000, sh_id3));
+        }
+        assert_refs(sh_id3, 11);
 
         // No need to test `RecordDateSpec::Scheduled` branch beyond what we have here.
         // To do so would replicate tests in the checkpoint module.
@@ -961,11 +983,7 @@ fn change_record_date_works() {
         assert_ok!(Ballot::attach_ballot(owner.origin(), id, time, meta, true));
         let test_branch = |id, error: DispatchError| {
             let change_ok = |spec, expect| {
-                change_ok(
-                    id,
-                    dbg!(spec_ts(spec)),
-                    dbg!(rd_ts(expect, dbg!(next_schedule_id(ticker)))),
-                )
+                change_ok(id, spec_ts(spec), rd_ts(expect, next_schedule_id(ticker)))
             };
             Timestamp::set_timestamp(3000);
             change_ok(4999, 4000); // floor(4999 / 1000) * 1000 == 4000
@@ -997,6 +1015,57 @@ fn change_record_date_works() {
             None,
         ));
         test_branch(id, DistError::DistributionStarted.into());
+    });
+}
+
+#[test]
+fn existing_schedule_ref_count() {
+    test(|ticker, [owner, ..]| {
+        set_schedule_complexity();
+
+        let sh_id = next_schedule_id(ticker);
+        let spec = Some(RecordDateSpec::ExistingSchedule(sh_id));
+        let assert_refs =
+            |count| assert_eq!(Checkpoint::schedule_ref_count((ticker, sh_id)), count);
+        let remove_ca = |id| CA::remove_ca(owner.origin(), id);
+        let remove_sh = || Checkpoint::remove_schedule(owner.origin(), ticker, sh_id);
+
+        // No schedule yet, but count is 0 by default.
+        assert_refs(0);
+
+        // Schedule made, count still 0 as no CAs attached.
+        assert_ok!(Checkpoint::create_schedule(
+            owner.origin(),
+            ticker,
+            1000.into()
+        ));
+        assert_refs(0);
+
+        // Attach some CAs, bumping the count by that many.
+        let mut ids = (0..5)
+            .map(|_| {
+                let ca_id = next_ca_id(ticker);
+                assert_ok!(dated_ca(owner, ticker, CAKind::IssuerNotice, spec));
+                ca_id
+            })
+            .collect::<Vec<_>>();
+        assert_refs(5);
+
+        // Remove all of them, except for one, with the count going back to 1.
+        let stashed_id = ids.pop().unwrap();
+        for id in ids {
+            assert_ok!(remove_ca(id));
+        }
+        assert_refs(1);
+
+        // Trying to remove the checkpoint, but we're blocked from doing so.
+        assert_noop!(remove_sh(), CPError::ScheduleNotRemovable);
+
+        // Remove the last one.. Ref count -> 0.
+        assert_ok!(remove_ca(stashed_id));
+
+        // Bow we're able to remove the schedule.
+        assert_ok!(remove_sh());
     });
 }
 

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -932,11 +932,13 @@
         "StoredSchedule": {
             "schedule": "CheckpointSchedule",
             "id": "ScheduleId",
-            "at": "Moment"
+            "at": "Moment",
+            "remaining": "u32"
         },
         "ScheduleSpec": {
             "start": "Option<Moment>",
-            "period": "CalendarPeriod"
+            "period": "CalendarPeriod",
+            "remaining": "u32"
         },
         "InstructionStatus": {
             "_enum": {

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1087,7 +1087,7 @@
         "CADetails": "Text",
         "CACheckpoint": {
             "_enum": {
-                "Scheduled": "ScheduleId",
+                "Scheduled": "(ScheduleId, u64)",
                 "Existing": "CheckpointId"
             }
         },

--- a/primitives/src/migrate.rs
+++ b/primitives/src/migrate.rs
@@ -68,6 +68,18 @@ where
     }
 }
 
+impl<T: Migrate> Migrate for Option<T> {
+    type Into = Option<T::Into>;
+    type Context = T::Context;
+
+    fn migrate(self, context: Self::Context) -> Option<Self::Into> {
+        match self {
+            None => None,
+            Some(val) => Some(val.migrate(context)),
+        }
+    }
+}
+
 /// Migrate the values with old type `T` in `module::item` to `T::Into`.
 ///
 /// Migrations resulting in `old.migrate() == None` are silently dropped from storage.


### PR DESCRIPTION
## changelog

### modified API

- `ScheduleSpec` now takes `remaining` which denotes the number of CPs that can be made before the schedule expires. `remaining == 0` means the schedule will never expire. The movement from `remaining: 1 -> 0` triggers expiry. The schema is changed for this type. `StoredSchedule` receives the same change. A schema change + storage migration follows suit.

### modified logic

- Checkpoint schedules now store reference counts from CAs rather than removability.
  As a result, `CACheckpoint::Schedule` now stores the number of CPs belonging to a schedule before attachment.
  Schema changes + migration follow suit.