### PR TITLE
Updated docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,10 +15,13 @@ jobs:
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2020-09-28
         target: wasm32-unknown-unknown
         override: true
         default: true
+    # This step is needed as a hack to generate wasm runtimes since cargo doc does not compile in order.
+    # That can cause weird issues around runtime wasm not being present when binary is being compiled.
+    - name: Cargo check
+      run: cargo check
     - name: Build docs
       run: cargo doc --no-deps --workspace --release --verbose --exclude node-bench --exclude node-testing
     - name: Add index file

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,12 +19,8 @@ jobs:
         target: wasm32-unknown-unknown
         override: true
         default: true
-    # This step is needed as a hack to generate wasm runtimes since cargo doc does not compile in order.
-    # That can cause weird issues around runtime wasm not being present when binary is being compiled.
-    - name: Cargo check
-      run: cargo check
     - name: Build docs
-      run: cargo doc --no-deps --workspace --release --verbose --exclude node-bench --exclude node-testing
+      run: BUILD_DUMMY_WASM_BINARY=1 cargo doc --no-deps --workspace --release --exclude node-bench --exclude node-testing
     - name: Add index file
       run: echo "<html lang='en'><head><meta http-equiv='refresh' content='0; URL=./polymesh/index.html'></head></html>" > ./target/doc/index.html
     - name: Publish to Cloudflare workers

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - docs-patch
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - docs-patch
 
 jobs:
   docs:


### PR DESCRIPTION
- The docs pipeline now fetches the rust version from rust-toolchain file
- The cargo doc now uses dummy wasm binaries rather than compiling proper ones. There was a race condition in binary building and wasm building otherwise.