### PR TITLE
MESH-1533/Require minimum 1 POLYX bond

### DIFF
--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -352,6 +352,7 @@ parameter_types! {
     pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
     pub const MaxVariableInflationTotalIssuance: Balance = 1_000_000_000 * POLY;
     pub const FixedYearlyReward: Balance = 200_000_000 * POLY;
+    pub const MinimumBond: Balance = 1 * POLY;
 }
 
 impl pallet_staking::Trait for Runtime {
@@ -385,6 +386,7 @@ impl pallet_staking::Trait for Runtime {
     type MaxValidatorPerIdentity = MaxValidatorPerIdentity;
     type MaxVariableInflationTotalIssuance = MaxVariableInflationTotalIssuance;
     type FixedYearlyReward = FixedYearlyReward;
+    type MinimumBond = MinimumBond;
     type PalletsOrigin = OriginCaller;
 }
 

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -354,6 +354,7 @@ parameter_types! {
     pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
     pub const MaxVariableInflationTotalIssuance: Balance = 1_000_000_000 * POLY;
     pub const FixedYearlyReward: Balance = 200_000_000 * POLY;
+    pub const MinimumBond: Balance = 1 * POLY;
 }
 
 impl pallet_staking::Trait for Runtime {
@@ -387,6 +388,7 @@ impl pallet_staking::Trait for Runtime {
     type MaxValidatorPerIdentity = MaxValidatorPerIdentity;
     type MaxVariableInflationTotalIssuance = MaxVariableInflationTotalIssuance;
     type FixedYearlyReward = FixedYearlyReward;
+    type MinimumBond = MinimumBond;
     type WeightInfo = polymesh_weights::pallet_staking::WeightInfo;
 }
 

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -604,7 +604,7 @@ parameter_types! {
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     pub const MaxVariableInflationTotalIssuance: Balance = 1_000_000_000 * POLY;
     pub const FixedYearlyReward: Balance = 200_000_000 * POLY;
-    pub const MinimumBond: Balance = 1 * POLY;
+    pub const MinimumBond: Balance = 0u128;
 }
 
 thread_local! {
@@ -666,7 +666,7 @@ impl Trait for Test {
     type MaxValidatorPerIdentity = MaxValidatorPerIdentity;
     type MaxVariableInflationTotalIssuance = MaxVariableInflationTotalIssuance;
     type FixedYearlyReward = FixedYearlyReward;
-    type MinimumBond = FixedYearlyReward;
+    type MinimumBond = MinimumBond;
     type WeightInfo = polymesh_weights::pallet_staking::WeightInfo;
 }
 

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -604,6 +604,7 @@ parameter_types! {
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     pub const MaxVariableInflationTotalIssuance: Balance = 1_000_000_000 * POLY;
     pub const FixedYearlyReward: Balance = 200_000_000 * POLY;
+    pub const MinimumBond: Balance = 1 * POLY;
 }
 
 thread_local! {
@@ -665,6 +666,7 @@ impl Trait for Test {
     type MaxValidatorPerIdentity = MaxValidatorPerIdentity;
     type MaxVariableInflationTotalIssuance = MaxVariableInflationTotalIssuance;
     type FixedYearlyReward = FixedYearlyReward;
+    type MinimumBond = FixedYearlyReward;
     type WeightInfo = polymesh_weights::pallet_staking::WeightInfo;
 }
 

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1426,7 +1426,7 @@ decl_error! {
         /// When the intended number of validators to run is >= 2/3 of `validator_count`.
         IntendedCountIsExceedingConsensusLimit,
         /// When the amount to be bonded is less than `MinimumBond`
-        BondToSmall,
+        BondTooSmall,
     }
 }
 
@@ -1631,7 +1631,7 @@ decl_module! {
         ) {
             let stash = ensure_signed(origin)?;
             ensure!(!<Bonded<T>>::contains_key(&stash), Error::<T>::AlreadyBonded);
-            ensure!(value > T::MinimumBond::get() , Error::<T>::BondToSmall);
+            ensure!(value >= T::MinimumBond::get() , Error::<T>::BondTooSmall);
 
             let controller = T::Lookup::lookup(controller)?;
             ensure!(!<Ledger<T>>::contains_key(&controller), Error::<T>::AlreadyPaired);

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -992,6 +992,9 @@ pub trait Trait:
 
     /// Yearly total reward amount that gets distributed when fixed rewards kicks in.
     type FixedYearlyReward: Get<BalanceOf<Self>>;
+
+    /// Minimum bond amount.
+    type MinimumBond: Get<BalanceOf<Self>>;
 }
 
 /// Mode of era-forcing.
@@ -1421,7 +1424,9 @@ decl_error! {
         /// Running validator count hit the intended count.
         HitIntendedValidatorCount,
         /// When the intended number of validators to run is >= 2/3 of `validator_count`.
-        IntendedCountIsExceedingConsensusLimit
+        IntendedCountIsExceedingConsensusLimit,
+        /// When the amount to be bonded is less than `MinimumBond`
+        BondToSmall,
     }
 }
 
@@ -1626,6 +1631,7 @@ decl_module! {
         ) {
             let stash = ensure_signed(origin)?;
             ensure!(!<Bonded<T>>::contains_key(&stash), Error::<T>::AlreadyBonded);
+            ensure!(value > T::MinimumBond::get() , Error::<T>::BondToSmall);
 
             let controller = T::Lookup::lookup(controller)?;
             ensure!(!<Ledger<T>>::contains_key(&controller), Error::<T>::AlreadyPaired);


### PR DESCRIPTION
Test case will be added later in a different PR. Merging this so that it can be part of the next release.

## changelog

### modified logic

- A minimum of 1 POLYX must be locked when bonding for staking.
