### PR TITLE
MESH-1533/add minimum bond support to staking tests

### DIFF
--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -604,7 +604,7 @@ parameter_types! {
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     pub const MaxVariableInflationTotalIssuance: Balance = 1_000_000_000 * POLY;
     pub const FixedYearlyReward: Balance = 200_000_000 * POLY;
-    pub const MinimumBond: Balance = 0u128;
+    pub const MinimumBond: Balance = 10u128;
 }
 
 thread_local! {
@@ -894,7 +894,7 @@ impl ExtBuilder {
             let stake_31 = if self.validator_pool {
                 balance_factor * 1000
             } else {
-                1
+                MinimumBond::get()
             };
             let status_41 = if self.validator_pool {
                 StakerStatus::<AccountId>::Validator

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1267,7 +1267,7 @@ decl_storage! {
                     T::Lookup::unlookup(controller.clone()),
                     balance,
                     RewardDestination::Staked,
-                ).unwrap();
+                ).expect("Unable to bond");
                 let _ = match status {
                     StakerStatus::Validator => {
                         if <Module<T>>::permissioned_identity(&did).is_none() {

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1262,12 +1262,12 @@ decl_storage! {
                     "Stash does not have enough balance to bond."
                 );
                 let controller_origin = <Module<T>>::get_origin(controller.clone());
-                let _ = <Module<T>>::bond(
+                <Module<T>>::bond(
                     <Module<T>>::get_origin(stash.clone()),
                     T::Lookup::unlookup(controller.clone()),
                     balance,
                     RewardDestination::Staked,
-                );
+                ).unwrap();
                 let _ = match status {
                     StakerStatus::Validator => {
                         if <Module<T>>::permissioned_identity(&did).is_none() {


### PR DESCRIPTION
## changelog

### modified API

- passing a bond amount less than `MinimumBond` to `Staking::bond` will throw a `BondTooSmall`
