### PR TITLE
Update address prefix

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -71,7 +71,7 @@ pub fn get_authority_keys_from_seed(seed: &str, uniq: bool) -> InitialAuth {
 }
 
 fn polymath_props() -> Properties {
-    json!({"tokenDecimals": 6, "tokenSymbol": "POLYX" })
+    json!({ "ss58Format": 12, "tokenDecimals": 6, "tokenSymbol": "POLYX" })
         .as_object()
         .unwrap()
         .clone()


### PR DESCRIPTION
## changelog

### modified API

- [Only applies to new networks] Address prefix changed from `5xxx` to `2xxx`. i.e. We are not using 12 as the ss58 prefix.

