### PR TITLE
Asset::{create_asset, update_identifiers} now rejects bad `AssetIdentifiers`

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1369,9 +1369,10 @@ impl<T: Trait> AssetSubTrait<T::Balance> for Module<T> {
 impl<T: Trait> Module<T> {
     /// Ensure that all `idents` are valid.
     fn ensure_asset_idents_valid(idents: &[AssetIdentifier]) -> DispatchResult {
-        for ai in idents {
-            ensure!(ai.is_valid(), Error::<T>::InvalidAssetIdentifier);
-        }
+        ensure!(
+            idents.iter().all(|i| i.is_valid()),
+            Error::<T>::InvalidAssetIdentifier
+        );
         Ok(())
     }
 

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -492,7 +492,8 @@ decl_module! {
         #[weight = <T as Trait>::WeightInfo::create_asset(
             name.len() as u32,
             identifiers.len() as u32,
-            funding_round.as_ref().map_or(0, |name| name.len()) as u32)]
+            funding_round.as_ref().map_or(0, |name| name.len()) as u32
+        )]
         pub fn create_asset(
             origin,
             name: AssetName,
@@ -505,6 +506,8 @@ decl_module! {
         ) {
             ensure!(name.len() <= T::AssetNameMaxLength::get(), Error::<T>::MaxLengthOfAssetNameExceeded);
             ensure!(funding_round.as_ref().map_or(0, |name| name.len()) <= T::FundingRoundNameMaxLength::get(), Error::<T>::FundingRoundNameMaxLengthExceeded);
+
+            Self::ensure_asset_idents_valid(&identifiers)?;
 
             let PermissionedCallOriginData {
                 sender,
@@ -579,7 +582,7 @@ decl_module! {
             // `InvestorUniqueness` claim. So we are skipping the scope claim based stats update as
             // those data points will get added in to the system whenever asset issuer/ primary issuance agent
             // have InvestorUniqueness claim. This also applies when issuing assets.
-            <AssetOwnershipRelations>::insert(did, ticker, AssetOwnershipRelation::AssetOwned);
+            AssetOwnershipRelations::insert(did, ticker, AssetOwnershipRelation::AssetOwned);
             Self::deposit_event(RawEvent::AssetCreated(
                 did,
                 ticker,
@@ -589,17 +592,10 @@ decl_module! {
                 did,
             ));
 
-            let identifiers: Vec<AssetIdentifier> = identifiers
-                .into_iter()
-                .filter_map(|identifier| identifier.validate())
-                .collect();
-
-            Identifiers::insert(ticker, identifiers.clone());
-
             // Add funding round name.
             FundingRound::insert(ticker, funding_round.unwrap_or_default());
 
-            Self::deposit_event(RawEvent::IdentifiersUpdated(did, ticker, identifiers));
+            Self::unverified_update_idents(did, ticker, identifiers);
 
             // Mint total supply to PIA
             if total_supply > Zero::zero() {
@@ -846,14 +842,9 @@ decl_module! {
             ticker: Ticker,
             identifiers: Vec<AssetIdentifier>
         ) {
+            Self::ensure_asset_idents_valid(&identifiers)?;
             let did = Self::ensure_perms_owner_asset(origin, &ticker)?;
-            let identifiers: Vec<AssetIdentifier> = identifiers
-                .into_iter()
-                .filter_map(|identifier| identifier.validate())
-                .collect();
-
-            Identifiers::insert(ticker, identifiers.clone());
-            Self::deposit_event(RawEvent::IdentifiersUpdated(did, ticker, identifiers));
+            Self::unverified_update_idents(did, ticker, identifiers);
         }
 
         /// Permissioning the Smart-Extension address for a given ticker.
@@ -1232,6 +1223,8 @@ decl_error! {
         MaxLengthOfAssetNameExceeded,
         /// Maximum length of the funding round name has been exceeded.
         FundingRoundNameMaxLengthExceeded,
+        /// Some `AssetIdentifier` was invalid.
+        InvalidAssetIdentifier,
     }
 }
 
@@ -1374,6 +1367,22 @@ impl<T: Trait> AssetSubTrait<T::Balance> for Module<T> {
 /// Public functions can be called from other modules e.g.: lock and unlock (being called from the tcr module)
 /// All functions in the impl module section are not part of public interface because they are not part of the Call enum.
 impl<T: Trait> Module<T> {
+    /// Ensure that all `idents` are valid.
+    fn ensure_asset_idents_valid(idents: &[AssetIdentifier]) -> DispatchResult {
+        for ai in idents {
+            ensure!(ai.is_valid(), Error::<T>::InvalidAssetIdentifier);
+        }
+        Ok(())
+    }
+
+    /// Update identitifiers of `ticker` as `did`.
+    ///
+    /// Does not verify that actor `did` is permissioned for this call or that `idents` are valid.
+    fn unverified_update_idents(did: IdentityId, ticker: Ticker, idents: Vec<AssetIdentifier>) {
+        Identifiers::insert(ticker, idents.clone());
+        Self::deposit_event(RawEvent::IdentifiersUpdated(did, ticker, idents));
+    }
+
     /// Returns the max number of extensions that can be attached to an asset
     pub fn max_number_of_tm_extension() -> u32 {
         T::MaxNumberOfTMExtensionForAsset::get()

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -78,6 +78,15 @@ fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     (ticker, token)
 }
 
+fn allow_all_transfers(ticker: Ticker, owner: User) {
+    assert_ok!(ComplianceManager::add_compliance_requirement(
+        owner.origin(),
+        ticker,
+        vec![],
+        vec![]
+    ));
+}
+
 fn setup_se_template(
     creator: AccountId,
     creator_did: IdentityId,
@@ -218,13 +227,7 @@ fn valid_transfers_pass() {
                 token.total_supply
             );
 
-            // Allow all transfers
-            assert_ok!(ComplianceManager::add_compliance_requirement(
-                owner.origin(),
-                ticker,
-                vec![],
-                vec![]
-            ));
+            allow_all_transfers(ticker, owner);
 
             // Should fail as sender matches receiver
             let transfer = |from, to| {
@@ -344,13 +347,8 @@ fn checkpoints_fuzz_test() {
                 None,
             ));
 
-            // Allow all transfers
-            assert_ok!(ComplianceManager::add_compliance_requirement(
-                owner.origin(),
-                ticker,
-                vec![],
-                vec![]
-            ));
+            allow_all_transfers(ticker, owner);
+
             let mut owner_balance: [u128; 100] = [1_000_000; 100];
             let mut bob_balance: [u128; 100] = [0; 100];
             let mut rng = rand::thread_rng();
@@ -612,13 +610,7 @@ fn controller_transfer() {
                 token.total_supply
             );
 
-            // Allow all transfers
-            assert_ok!(ComplianceManager::add_compliance_requirement(
-                owner.origin(),
-                ticker,
-                vec![],
-                vec![]
-            ));
+            allow_all_transfers(ticker, owner);
 
             // Should fail as sender matches receiver
             assert_noop!(
@@ -1451,13 +1443,8 @@ fn freeze_unfreeze_asset() {
             None,
         ));
 
-        // Allow all transfers.
-        assert_ok!(ComplianceManager::add_compliance_requirement(
-            owner.origin(),
-            ticker,
-            vec![],
-            vec![]
-        ));
+        allow_all_transfers(ticker, owner);
+
         assert_err!(
             Asset::freeze(bob.origin(), ticker),
             AssetError::Unauthorized
@@ -1649,14 +1636,7 @@ fn test_can_transfer_rpc() {
             assert_ok!(Asset::unfreeze(owner.origin(), ticker));
 
             // Case 7: when transaction get success by the compliance_manager
-            // Allow all transfers.
-            assert_ok!(ComplianceManager::add_compliance_requirement(
-                owner.origin(),
-                ticker,
-                vec![],
-                vec![]
-            ));
-
+            allow_all_transfers(ticker, owner);
             assert_eq!(
                 unsafe_can_transfer_result(owner.did, bob.did, 20 * currency::ONE_UNIT),
                 ERC1400_TRANSFER_SUCCESS
@@ -2357,12 +2337,7 @@ fn check_unique_investor_count() {
             // 1. Transfer some funds to bob_1.did.
 
             // 1a). Add empty compliance requirement.
-            assert_ok!(ComplianceManager::add_compliance_requirement(
-                alice.origin(),
-                ticker,
-                vec![],
-                vec![]
-            ));
+            allow_all_transfers(ticker, alice);
 
             // 1b). Should fail when transferring funds to bob_1.did because it doesn't posses scope_claim.
             // portfolio Id -

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -157,6 +157,10 @@ fn transfer(ticker: Ticker, from: User, to: User, amount: u128) -> DispatchResul
     )
 }
 
+fn cusip() -> AssetIdentifier {
+    AssetIdentifier::cusip(*b"037833100").unwrap()
+}
+
 #[test]
 fn check_the_test_hex() {
     ExtBuilder::default().build().execute_with(|| {
@@ -777,32 +781,25 @@ fn update_identifiers() {
         // Expected token entry
         let (ticker, token) = a_token(owner.did);
         assert!(!has_ticker_record(ticker));
-        let ident_bad = AssetIdentifier::CUSIP(*b"aaaa_aaaa");
-        let mut identifiers = vec![
-            AssetIdentifier::cusip(*b"037833100").unwrap(),
-            ident_bad,
-        ];
 
         let create = |idents| asset_with_ids(owner, ticker, &token, idents);
         let update = |idents| Asset::update_identifiers(owner.origin(), ticker, idents);
 
         // Create: A bad entry was rejected.
         assert_noop!(
-            update(identifiers.clone()),
+            update(vec![cusip(), AssetIdentifier::CUSIP(*b"aaaa_aaaa")]),
             AssetError::InvalidAssetIdentifier
         );
-        identifiers.pop().unwrap();
 
         // Create: A correct entry was added.
-        assert_ok!(create(identifiers.clone()));
+        assert_ok!(create(vec![cusip()]));
         assert_eq!(Asset::token_details(ticker), token);
-        assert_eq!(Asset::identifiers(ticker), identifiers);
+        assert_eq!(Asset::identifiers(ticker), vec![cusip()]);
 
         // Update: A bad entry was rejected.
-        let identifier_value2 = b"US0378331005";
         let mut updated_identifiers = vec![
             AssetIdentifier::cusip(*b"17275R102").unwrap(),
-            AssetIdentifier::isin(*identifier_value2).unwrap(),
+            AssetIdentifier::isin(*b"US0378331005").unwrap(),
             AssetIdentifier::CUSIP(*b"aaaa_aaaa"),
         ];
         assert_noop!(
@@ -876,8 +873,7 @@ fn add_extension_successfully() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers.clone()));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);
@@ -921,8 +917,7 @@ fn add_same_extension_should_fail() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);
@@ -972,8 +967,7 @@ fn should_successfully_archive_extension() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);
@@ -1028,8 +1022,7 @@ fn should_fail_to_archive_an_already_archived_extension() {
             // Expected token entry.
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);
@@ -1088,8 +1081,7 @@ fn should_fail_to_archive_a_non_existent_extension() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = AccountKeyring::Bob.public();
@@ -1112,8 +1104,7 @@ fn should_successfuly_unarchive_an_extension() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);
@@ -1178,8 +1169,7 @@ fn should_fail_to_unarchive_an_already_unarchived_extension() {
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
             assert!(!has_ticker_record(ticker));
-            let identifiers = vec![AssetIdentifier::cusip(*b"037833100").unwrap()];
-            assert_ok!(asset_with_ids(owner, ticker, &token, identifiers));
+            assert_ok!(asset_with_ids(owner, ticker, &token, vec![cusip()]));
 
             // Add smart extension.
             let extension_id = setup_se_template(owner.acc(), owner.did, true);

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -123,31 +123,27 @@ fn issuers_can_create_and_rename_tokens() {
         assert!(!<DidRecords>::contains_key(
             Identity::get_token_did(&ticker).unwrap()
         ));
-        assert_noop!(
+
+        let create = |supply| {
             Asset::create_asset(
                 owner_signed.clone(),
                 token.name.clone(),
                 ticker,
-                1_000_000_000_000_000_000_000_000, // Total supply over the limit
+                supply,
                 true,
                 token.asset_type.clone(),
                 Vec::new(),
                 Some(funding_round_name.clone()),
-            ),
+            )
+        };
+
+        assert_noop!(
+            create(1_000_000_000_000_000_000_000_000), // Total supply over the limit.
             AssetError::TotalSupplyAboveLimit
         );
 
-        // Issuance is successful
-        assert_ok!(Asset::create_asset(
-            owner_signed.clone(),
-            token.name.clone(),
-            ticker,
-            token.total_supply,
-            true,
-            token.asset_type.clone(),
-            Vec::new(),
-            Some(funding_round_name.clone()),
-        ));
+        // Issuance is successful.
+        assert_ok!(create(token.total_supply));
 
         // Check the update investor count for the newly created asset
         assert_eq!(Statistics::investor_count(ticker), 1);

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -72,7 +72,7 @@ fn set_time_to_now() {
     Timestamp::set_timestamp(now());
 }
 
-fn token(name: &[u8], owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
+crate fn token(name: &[u8], owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     let ticker = Ticker::try_from(name).unwrap();
     let token = SecurityToken {
         name: name.into(),
@@ -114,11 +114,11 @@ fn asset_with_ids(
     r
 }
 
-fn basic_asset(owner: User, ticker: Ticker, token: &SecurityToken<u128>) -> DispatchResult {
+crate fn basic_asset(owner: User, ticker: Ticker, token: &SecurityToken<u128>) -> DispatchResult {
     asset_with_ids(owner, ticker, token, vec![])
 }
 
-fn allow_all_transfers(ticker: Ticker, owner: User) {
+crate fn allow_all_transfers(ticker: Ticker, owner: User) {
     assert_ok!(ComplianceManager::add_compliance_requirement(
         owner.origin(),
         ticker,

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -63,6 +63,14 @@ type System = frame_system::Module<TestStorage>;
 type FeeError = pallet_protocol_fee::Error<TestStorage>;
 type PortfolioError = pallet_portfolio::Error<TestStorage>;
 
+fn now() -> u64 {
+    Utc::now().timestamp() as _
+}
+
+fn set_time_to_now() {
+    Timestamp::set_timestamp(now());
+}
+
 fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     let name = b"A" as &[_];
     let ticker = Ticker::try_from(name).unwrap();
@@ -198,8 +206,7 @@ fn valid_transfers_pass() {
         .cdd_providers(vec![eve])
         .build()
         .execute_with(|| {
-            let now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_time_to_now();
 
             let owner = User::new(AccountKeyring::Dave);
             let alice = User::new(AccountKeyring::Alice);
@@ -255,8 +262,7 @@ fn issuers_can_redeem_tokens() {
         .cdd_providers(vec![alice])
         .build()
         .execute_with(|| {
-            let now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_time_to_now();
 
             let owner = User::new(AccountKeyring::Dave);
             let bob = User::new(AccountKeyring::Bob);
@@ -318,8 +324,7 @@ fn checkpoints_fuzz_test() {
     for _ in 0..10 {
         // When fuzzing in local, feel free to bump this number to add more fuzz runs.
         ExtBuilder::default().build().execute_with(|| {
-            let now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_time_to_now();
 
             let owner = User::new(AccountKeyring::Dave);
             let bob = User::new(AccountKeyring::Bob);
@@ -379,8 +384,7 @@ fn checkpoints_fuzz_test() {
 #[test]
 fn register_ticker() {
     ExtBuilder::default().build().execute_with(|| {
-        let now = Utc::now();
-        Timestamp::set_timestamp(now.timestamp() as u64);
+        set_time_to_now();
 
         let owner = User::new(AccountKeyring::Dave);
         let alice = User::new(AccountKeyring::Alice);
@@ -438,7 +442,7 @@ fn register_ticker() {
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner.did), true);
         assert_eq!(Asset::is_ticker_available(&ticker), false);
 
-        Timestamp::set_timestamp(now.timestamp() as u64 + 10001);
+        Timestamp::set_timestamp(now() + 10001);
 
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner.did), false);
         assert_eq!(Asset::is_ticker_available(&ticker), true);
@@ -461,8 +465,7 @@ fn register_ticker() {
 #[test]
 fn transfer_ticker() {
     ExtBuilder::default().build().execute_with(|| {
-        let now = Utc::now();
-        Timestamp::set_timestamp(now.timestamp() as u64);
+        set_time_to_now();
 
         let owner = User::new(AccountKeyring::Dave);
         let alice = User::new(AccountKeyring::Alice);
@@ -526,7 +529,7 @@ fn transfer_ticker() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::TransferTicker(ticker),
-            Some(now.timestamp() as u64 - 100),
+            Some(now() - 100),
         );
 
         assert_err!(
@@ -538,7 +541,7 @@ fn transfer_ticker() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::Custom(ticker),
-            Some(now.timestamp() as u64 + 100),
+            Some(now() + 100),
         );
 
         assert_err!(
@@ -550,7 +553,7 @@ fn transfer_ticker() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::TransferTicker(ticker),
-            Some(now.timestamp() as u64 + 100),
+            Some(now() + 100),
         );
 
         assert_ok!(Asset::accept_ticker_transfer(bob.origin(), auth_id));
@@ -569,8 +572,7 @@ fn controller_transfer() {
         .cdd_providers(vec![eve])
         .build()
         .execute_with(|| {
-            let now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_time_to_now();
 
             let owner = User::new(AccountKeyring::Dave);
             let alice = User::new(AccountKeyring::Alice);
@@ -641,8 +643,7 @@ fn controller_transfer() {
 #[test]
 fn transfer_primary_issuance_agent() {
     ExtBuilder::default().build().execute_with(|| {
-        let now = Utc::now();
-        Timestamp::set_timestamp(now.timestamp() as u64);
+        set_time_to_now();
 
         let owner = User::new(AccountKeyring::Alice);
         let pia = User::new(AccountKeyring::Bob);
@@ -667,7 +668,7 @@ fn transfer_primary_issuance_agent() {
             owner.did,
             Signatory::from(pia.did),
             AuthorizationData::TransferPrimaryIssuanceAgent(ticker),
-            Some(now.timestamp() as u64 - 100),
+            Some(now() - 100),
         );
 
         assert_err!(
@@ -722,8 +723,7 @@ fn transfer_primary_issuance_agent() {
 #[test]
 fn transfer_token_ownership() {
     ExtBuilder::default().build().execute_with(|| {
-        let now = Utc::now();
-        Timestamp::set_timestamp(now.timestamp() as u64);
+        set_time_to_now();
 
         let owner = User::new(AccountKeyring::Dave);
         let alice = User::new(AccountKeyring::Alice);
@@ -791,7 +791,7 @@ fn transfer_token_ownership() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::TransferAssetOwnership(ticker),
-            Some(now.timestamp() as u64 - 100),
+            Some(now() - 100),
         );
 
         assert_err!(
@@ -803,7 +803,7 @@ fn transfer_token_ownership() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::Custom(ticker),
-            Some(now.timestamp() as u64 + 100),
+            Some(now() + 100),
         );
 
         assert_err!(
@@ -815,7 +815,7 @@ fn transfer_token_ownership() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::TransferAssetOwnership(Ticker::try_from(&[0x50][..]).unwrap()),
-            Some(now.timestamp() as u64 + 100),
+            Some(now() + 100),
         );
 
         assert_err!(
@@ -827,7 +827,7 @@ fn transfer_token_ownership() {
             alice.did,
             Signatory::from(bob.did),
             AuthorizationData::TransferAssetOwnership(ticker),
-            Some(now.timestamp() as u64 + 100),
+            Some(now() + 100),
         );
 
         assert_ok!(Asset::accept_asset_ownership_transfer(
@@ -1389,8 +1389,7 @@ fn should_fail_to_unarchive_an_already_unarchived_extension() {
 #[test]
 fn freeze_unfreeze_asset() {
     ExtBuilder::default().build().execute_with(|| {
-        let now = Utc::now();
-        Timestamp::set_timestamp(now.timestamp() as u64);
+        set_time_to_now();
 
         let owner = User::new(AccountKeyring::Alice);
         let bob = User::new(AccountKeyring::Bob);

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 use chrono::prelude::Utc;
 use frame_support::{
-    assert_err, assert_noop, assert_ok, dispatch::DispatchError, IterableStorageMap,
-    StorageDoubleMap, StorageMap,
+    assert_noop, assert_ok, dispatch::DispatchError, IterableStorageMap, StorageDoubleMap,
+    StorageMap,
 };
 use hex_literal::hex;
 use ink_primitives::hash as FunctionSelectorHasher;
@@ -178,7 +178,7 @@ fn issuers_can_create_and_rename_tokens() {
 
         // Unauthorized identities cannot rename the token.
         let eve = User::new(AccountKeyring::Eve);
-        assert_err!(
+        assert_noop!(
             Asset::rename_asset(eve.origin(), ticker, vec![0xde, 0xad, 0xbe, 0xef].into()),
             AssetError::Unauthorized
         );
@@ -410,12 +410,12 @@ fn register_ticker() {
         let stored_token = Asset::token_details(&ticker);
         assert_eq!(stored_token.asset_type, token.asset_type);
         assert_eq!(Asset::identifiers(ticker), identifiers);
-        assert_err!(
+        assert_noop!(
             register(Ticker::try_from(&[b'A'][..]).unwrap()),
             AssetError::AssetAlreadyCreated
         );
 
-        assert_err!(
+        assert_noop!(
             register(
                 Ticker::try_from(&[b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A'][..])
                     .unwrap()
@@ -434,7 +434,7 @@ fn register_ticker() {
             AssetOwnershipRelation::TickerOwned
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::register_ticker(alice.origin(), ticker),
             AssetError::TickerAlreadyRegistered
         );
@@ -494,7 +494,7 @@ fn transfer_ticker() {
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, alice.did), false);
         assert_eq!(Asset::is_ticker_available(&ticker), false);
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_ticker_transfer(alice.origin(), auth_id_alice + 1),
             "Authorization does not exist"
         );
@@ -520,7 +520,7 @@ fn transfer_ticker() {
             AssetOwnershipRelation::TickerOwned
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_ticker_transfer(bob.origin(), auth_id_bob),
             "Illegal use of Authorization"
         );
@@ -532,7 +532,7 @@ fn transfer_ticker() {
             Some(now() - 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_ticker_transfer(bob.origin(), auth_id),
             "Authorization expired"
         );
@@ -544,7 +544,7 @@ fn transfer_ticker() {
             Some(now() + 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_ticker_transfer(bob.origin(), auth_id),
             AssetError::NoTickerTransferAuth
         );
@@ -671,7 +671,7 @@ fn transfer_primary_issuance_agent() {
             Some(now() - 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_primary_issuance_agent_transfer(pia.origin(), auth_id),
             "Authorization expired"
         );
@@ -684,7 +684,7 @@ fn transfer_primary_issuance_agent() {
             None,
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_primary_issuance_agent_transfer(pia.origin(), auth_id),
             "Authorization does not exist"
         );
@@ -697,7 +697,7 @@ fn transfer_primary_issuance_agent() {
             None,
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_primary_issuance_agent_transfer(pia.origin(), auth_id),
             "Illegal use of Authorization"
         );
@@ -758,7 +758,7 @@ fn transfer_token_ownership() {
 
         assert_eq!(Asset::token_details(&ticker).owner_did, owner.did);
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_asset_ownership_transfer(alice.origin(), auth_id_alice + 1),
             "Authorization does not exist"
         );
@@ -782,7 +782,7 @@ fn transfer_token_ownership() {
             AssetOwnershipRelation::AssetOwned
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id_bob),
             "Illegal use of Authorization"
         );
@@ -794,7 +794,7 @@ fn transfer_token_ownership() {
             Some(now() - 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id),
             "Authorization expired"
         );
@@ -806,7 +806,7 @@ fn transfer_token_ownership() {
             Some(now() + 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id),
             AssetError::NotTickerOwnershipTransferAuth
         );
@@ -818,7 +818,7 @@ fn transfer_token_ownership() {
             Some(now() + 100),
         );
 
-        assert_err!(
+        assert_noop!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id),
             AssetError::NoSuchAsset
         );
@@ -1062,7 +1062,7 @@ fn add_same_extension_should_fail() {
                 extension_id
             );
 
-            assert_err!(
+            assert_noop!(
                 Asset::add_extension(owner.origin(), ticker, extension_details),
                 AssetError::ExtensionAlreadyPresent
             );
@@ -1195,7 +1195,7 @@ fn should_fail_to_archive_an_already_archived_extension() {
                 true
             );
 
-            assert_err!(
+            assert_noop!(
                 Asset::archive_extension(owner.origin(), ticker, extension_id),
                 AssetError::AlreadyArchived
             );
@@ -1226,7 +1226,7 @@ fn should_fail_to_archive_a_non_existent_extension() {
 
             // Add smart extension.
             let extension_id = AccountKeyring::Bob.public();
-            assert_err!(
+            assert_noop!(
                 Asset::archive_extension(owner.origin(), ticker, extension_id),
                 AssetError::NoSuchSmartExtension
             );
@@ -1379,7 +1379,7 @@ fn should_fail_to_unarchive_an_already_unarchived_extension() {
                 false
             );
 
-            assert_err!(
+            assert_noop!(
                 Asset::unarchive_extension(owner.origin(), ticker, extension_id),
                 AssetError::AlreadyUnArchived
             );
@@ -1408,16 +1408,16 @@ fn freeze_unfreeze_asset() {
 
         allow_all_transfers(ticker, owner);
 
-        assert_err!(
+        assert_noop!(
             Asset::freeze(bob.origin(), ticker),
             AssetError::Unauthorized
         );
-        assert_err!(
+        assert_noop!(
             Asset::unfreeze(owner.origin(), ticker),
             AssetError::NotFrozen
         );
         assert_ok!(Asset::freeze(owner.origin(), ticker));
-        assert_err!(
+        assert_noop!(
             Asset::freeze(owner.origin(), ticker),
             AssetError::AlreadyFrozen
         );
@@ -1436,7 +1436,7 @@ fn freeze_unfreeze_asset() {
         ));
 
         assert_ok!(Asset::unfreeze(bob.origin(), ticker));
-        assert_err!(Asset::unfreeze(bob.origin(), ticker), AssetError::NotFrozen);
+        assert_noop!(Asset::unfreeze(bob.origin(), ticker), AssetError::NotFrozen);
     });
 }
 #[test]
@@ -1493,7 +1493,7 @@ fn frozen_secondary_keys_create_asset_we() {
     //     vec![],
     //     None,
     // );
-    // assert_err!(
+    // assert_noop!(
     //     create_token_result,
     //     DispatchError::Other("Current identity is none and key is not linked to any identity")
     // );
@@ -1701,7 +1701,7 @@ fn check_functionality_of_remove_extension() {
             );
 
             // Removing the same extension gives the error.
-            assert_err!(
+            assert_noop!(
                 Asset::remove_smart_extension(owner.origin(), ticker, extension_id),
                 AssetError::NoSuchSmartExtension
             );
@@ -2305,7 +2305,7 @@ fn check_unique_investor_count() {
             // portfolio Id -
             let sender_portfolio = PortfolioId::default_portfolio(alice.did);
             let receiver_portfolio = PortfolioId::default_portfolio(bob_1.did);
-            assert_err!(
+            assert_noop!(
                 Asset::base_transfer(sender_portfolio, receiver_portfolio, &ticker, 1000),
                 AssetError::InvalidTransfer
             );

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -78,6 +78,10 @@ fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     (ticker, token)
 }
 
+fn has_ticker_record(ticker: Ticker) -> bool {
+    DidRecords::contains_key(Identity::get_token_did(&ticker).unwrap())
+}
+
 fn allow_all_transfers(ticker: Ticker, owner: User) {
     assert_ok!(ComplianceManager::add_compliance_requirement(
         owner.origin(),
@@ -126,13 +130,11 @@ fn issuers_can_create_and_rename_tokens() {
     ExtBuilder::default().build().execute_with(|| {
         let owner = User::new(AccountKeyring::Dave);
 
-        let funding_round_name: FundingRoundName = b"round1".into();
         // Expected token entry
         let (ticker, token) = a_token(owner.did);
-        assert!(!<DidRecords>::contains_key(
-            Identity::get_token_did(&ticker).unwrap()
-        ));
+        assert!(!has_ticker_record(ticker));
 
+        let funding_round_name: FundingRoundName = b"round1".into();
         let create = |supply| {
             Asset::create_asset(
                 owner.origin(),
@@ -163,9 +165,7 @@ fn issuers_can_create_and_rename_tokens() {
             Asset::asset_ownership_relation(token.owner_did, ticker),
             AssetOwnershipRelation::AssetOwned
         );
-        assert!(<DidRecords>::contains_key(
-            Identity::get_token_did(&ticker).unwrap()
-        ));
+        assert!(has_ticker_record(ticker));
         assert_eq!(Asset::funding_round(ticker), funding_round_name.clone());
 
         // Unauthorized identities cannot rename the token.
@@ -845,9 +845,7 @@ fn update_identifiers() {
 
         // Expected token entry
         let (ticker, token) = a_token(owner.did);
-        assert!(!DidRecords::contains_key(
-            Identity::get_token_did(&ticker).unwrap()
-        ));
+        assert!(!has_ticker_record(ticker));
         let ident_bad = AssetIdentifier::CUSIP(*b"aaaa_aaaa");
         let identifier_value1 = b"037833100";
         let mut identifiers = vec![
@@ -906,12 +904,7 @@ fn adding_removing_documents() {
         let owner = User::new(AccountKeyring::Dave);
 
         let (ticker, token) = a_token(owner.did);
-
-        assert!(!<DidRecords>::contains_key(
-            Identity::get_token_did(&ticker).unwrap()
-        ));
-
-        Identity::get_token_did(&ticker).unwrap();
+        assert!(!has_ticker_record(ticker));
 
         // Issuance is successful
         assert_ok!(Asset::create_asset(
@@ -973,9 +966,7 @@ fn add_extension_successfully() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             let identifier_value1 = b"037833100";
             let identifiers = vec![AssetIdentifier::cusip(*identifier_value1).unwrap()];
             assert_ok!(Asset::create_asset(
@@ -1030,9 +1021,7 @@ fn add_same_extension_should_fail() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),
@@ -1091,9 +1080,7 @@ fn should_successfully_archive_extension() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),
@@ -1157,9 +1144,7 @@ fn should_fail_to_archive_an_already_archived_extension() {
 
             // Expected token entry.
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),
@@ -1227,9 +1212,7 @@ fn should_fail_to_archive_a_non_existent_extension() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),
@@ -1261,9 +1244,7 @@ fn should_successfuly_unarchive_an_extension() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),
@@ -1337,9 +1318,7 @@ fn should_fail_to_unarchive_an_already_unarchived_extension() {
 
             // Expected token entry
             let (ticker, token) = a_token(owner.did);
-            assert!(!DidRecords::contains_key(
-                Identity::get_token_did(&ticker).unwrap()
-            ));
+            assert!(!has_ticker_record(ticker));
             assert_ok!(Asset::create_asset(
                 owner.origin(),
                 token.name.clone(),

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -96,12 +96,7 @@ fn currency_test(logic: impl FnOnce(Ticker, Ticker, [User; 3])) {
 fn transfer(ticker: &Ticker, from: User, to: User) {
     // Provide scope claim to sender and receiver of the transaction.
     provide_scope_claim_to_multiple_parties(&[from.did, to.did], *ticker, CDDP.public());
-    assert_ok!(Asset::base_transfer(
-        PortfolioId::default_portfolio(from.did),
-        PortfolioId::default_portfolio(to.did),
-        ticker,
-        500
-    ));
+    assert_ok!(crate::asset_test::transfer(*ticker, from, to, 500));
 }
 
 fn create_asset(ticker: &[u8], owner: User) -> Ticker {

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 #![feature(crate_visibility_modifier)]
+#![feature(bindings_after_at)]
 
 pub mod storage;
 pub use storage::{

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -947,12 +947,12 @@ pub fn provide_scope_claim(
     scope_id
 }
 
-pub fn provide_scope_claim_to_multiple_parties(
-    parties: &[IdentityId],
+pub fn provide_scope_claim_to_multiple_parties<'a>(
+    parties: impl IntoIterator<Item = &'a IdentityId>,
     ticker: Ticker,
     cdd_provider: AccountId,
 ) {
-    parties.iter().enumerate().for_each(|(_, id)| {
+    parties.into_iter().enumerate().for_each(|(_, id)| {
         let uid = create_investor_uid(Identity::did_records(id).primary_key);
         provide_scope_claim(*id, ticker, uid, cdd_provider);
     });

--- a/primitives/src/smart_extension.rs
+++ b/primitives/src/smart_extension.rs
@@ -95,10 +95,7 @@ pub struct TemplateDetails<Balance> {
     pub frozen: bool,
 }
 
-impl<Balance> TemplateDetails<Balance>
-where
-    Balance: Clone + Copy,
-{
+impl<Balance: Copy> TemplateDetails<Balance> {
     /// Return the instantiation fee
     pub fn get_instantiation_fee(&self) -> Balance {
         self.instantiation_fee


### PR DESCRIPTION
Best reviewed with whitespace changes hidden.
Also refactors asset tests as a drive-by.

## changelog

### modified logic

- `Asset::{create_asset, update_identifiers}` now reject bad `AssetIdentifier` with the error `InvalidAssetIdentifier`.
