### PR TITLE
Disabled extra CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,9 +235,7 @@ workflows:
   commit:
     jobs:
       - benchmark-build
-      - lint
       - coverage
-      - migration-tests
       - benchmark:
           requires:
             - benchmark-build


### PR DESCRIPTION
- Migrations tests were for 2.5.0 release, not applicable for next release.
- Lint check is done in Concourse as well.