### PR TITLE
[Tooling] 2.6 Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,9 +235,7 @@ workflows:
   commit:
     jobs:
       - benchmark-build
-      - lint
       - coverage
-      - migration-tests
       - benchmark:
           requires:
             - benchmark-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Anonymous"]
 build = "build.rs"
 edition = "2018"

--- a/pallets/corporate-actions/src/benchmarking.rs
+++ b/pallets/corporate-actions/src/benchmarking.rs
@@ -154,6 +154,7 @@ fn distribute<T: Trait>(owner: &User<T>, ca_id: CAId) {
         ca_id,
         None,
         currency,
+        2u32.into(),
         1000u32.into(),
         4000,
         None,

--- a/pallets/corporate-actions/src/distribution/benchmarking.rs
+++ b/pallets/corporate-actions/src/distribution/benchmarking.rs
@@ -53,6 +53,7 @@ fn dist<T: Trait>(target_ids: u32) -> (User<T>, CAId, Ticker) {
         ca_id,
         Some(pnum),
         currency,
+        2u32.into(),
         amount,
         3000,
         Some(4000),
@@ -107,9 +108,10 @@ benchmarks! {
         let (owner, ca_id) = setup_ca::<T>(CAKind::UnpredictableBenefit);
         let currency = currency::<T>(&owner);
         let amount = 1000u32.into();
-        let pnum =1u64.into();
+        let per_share = 2u32.into();
+        let pnum = 1u64.into();
         portfolio::<T>(&owner, pnum, currency, amount);
-    }: _(owner.origin(), ca_id, Some(pnum), currency, amount, 3000, Some(4000))
+    }: _(owner.origin(), ca_id, Some(pnum), currency, per_share, amount, 3000, Some(4000))
     verify {
         ensure!(<Distributions<T>>::get(ca_id).is_some(), "distribution not created");
     }

--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -81,8 +81,11 @@ use polymesh_common_utilities::{
     protocol_fee::{ChargeProtocolFee, ProtocolOp},
     with_transaction, CommonTrait,
 };
-use polymesh_primitives::{EventDid, IdentityId, Moment, PortfolioId, PortfolioNumber, Ticker};
-use sp_runtime::traits::{CheckedDiv, CheckedMul};
+use polymesh_primitives::{
+    storage_migrate_on, storage_migration_ver, EventDid, IdentityId, Moment, PortfolioId,
+    PortfolioNumber, Ticker,
+};
+use sp_runtime::traits::CheckedMul as _;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
 use sp_std::prelude::*;
@@ -103,7 +106,10 @@ pub struct Distribution<Balance> {
     pub from: PortfolioId,
     /// The currency that payouts happen in.
     pub currency: Ticker,
-    /// Total amount to be distributed.
+    /// Amount per share to pay out, in per-million,
+    /// i.e. `1 / 10^6`th of one `currency` token.
+    pub per_share: Balance,
+    /// Total amount to be distributed at most.
     pub amount: Balance,
     /// Amount left to distribute.
     pub remaining: Balance,
@@ -140,14 +146,33 @@ decl_storage! {
         ///
         /// (CAId, DID) -> Was DID paid in the CAId?
         HolderPaid get(fn holder_paid): map hasher(blake2_128_concat) (CAId, IdentityId) => bool;
+
+        /// Storage version.
+        StorageVersion get(fn storage_version) build(|_| Version::new(1).unwrap()): Version;
     }
 }
+
+storage_migration_ver!(1);
 
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         type Error = Error<T>;
 
         fn deposit_event() = default;
+
+        fn on_runtime_upgrade() -> Weight {
+            storage_migrate_on!(StorageVersion::get(), 1, {
+                use polymesh_primitives::migrate::kill_item;
+                for item in &[
+                    b"Distributions" as &[_],
+                    b"HolderPaid" as &[_],
+                ] {
+                    kill_item(b"CapitalDistribution", item);
+                }
+            });
+
+            0
+        }
 
         /// Start and attach a capital distribution, to the CA identified by `ca_id`,
         /// with `amount` funds in `currency` withdrawn from `portfolio` belonging to `origin`'s DID.
@@ -160,7 +185,9 @@ decl_module! {
         /// - `ca_id` identifies the CA to start a capital distribution for.
         /// - `portfolio` specifies the portfolio number of the CAA to distribute `amount` from.
         /// - `currency` to withdraw and distribute from the `portfolio`.
-        /// - `amount` of `currency` to withdraw and distribute.
+        /// - `per_share` amount of `currency` to withdraw and distribute.
+        ///    Specified as a per-million, i.e. `1 / 10^6`th of one `currency` token.
+        /// - `amount` of `currency` to withdraw and distribute at most.
         /// - `payment_at` specifies when benefits may first be pushed or claimed.
         /// - `expires_at` specifies, if provided, when remaining benefits are forfeit
         ///    and may be reclaimed by `origin`.
@@ -186,6 +213,7 @@ decl_module! {
             ca_id: CAId,
             portfolio: Option<PortfolioNumber>,
             currency: Ticker,
+            per_share: T::Balance,
             amount: T::Balance,
             payment_at: Moment,
             expires_at: Option<Moment>,
@@ -238,6 +266,7 @@ decl_module! {
             let distribution = Distribution {
                 from,
                 currency,
+                per_share,
                 amount,
                 remaining: amount,
                 reclaimed: false,
@@ -409,10 +438,8 @@ decl_error! {
         CannotClaimBeforeStart,
         /// Distribution's expiry has passed. DID cannot claim anymore and has forfeited the benefits.
         CannotClaimAfterExpiry,
-        /// Multiplication of the balance with the total payout amount overflowed.
-        BalanceAmountProductOverflowed,
-        /// A failed division of the balance amount product by the total supply.
-        BalanceAmountProductSupplyDivisionFailed,
+        /// Multiplication of the balance with the per share payout amount overflowed.
+        BalancePerShareProductOverflowed,
         /// DID is not the one who created the distribution.
         NotDistributionCreator,
         /// DID who created the distribution already did reclaim.
@@ -469,11 +496,10 @@ impl<T: Trait> Module<T> {
 
         // Extract CP + total supply at the record date.
         let cp_id = <CA<T>>::record_date_cp(&ca, ca_id);
-        let supply = <CA<T>>::supply_at_cp(ca_id, cp_id);
 
         // Compute `balance * amount / supply`, i.e. DID's benefit.
         let balance = <CA<T>>::balance_at_cp(holder, ca_id, cp_id);
-        let benefit = Self::benefit_of(balance, dist.amount, supply)?;
+        let benefit = Self::benefit_of(balance, dist.per_share)?;
 
         // Compute withholding tax + gain.
         let tax = ca.tax_of(&holder);
@@ -509,17 +535,13 @@ impl<T: Trait> Module<T> {
         <Portfolio<T>>::unlock_tokens(&dist.from, &dist.currency, &amount)
     }
 
-    // Compute `balance * amount / supply`, i.e. DID's benefit.
-    fn benefit_of(
-        balance: T::Balance,
-        amount: T::Balance,
-        supply: T::Balance,
-    ) -> Result<T::Balance, DispatchError> {
+    // Compute `balance * per_share`, i.e. DID's benefit.
+    fn benefit_of(balance: T::Balance, per_share: T::Balance) -> Result<T::Balance, DispatchError> {
         balance
-            .checked_mul(&amount)
-            .ok_or(Error::<T>::BalanceAmountProductOverflowed)?
-            .checked_div(&supply)
-            .ok_or_else(|| Error::<T>::BalanceAmountProductSupplyDivisionFailed.into())
+            .checked_mul(&per_share)
+            // `per_share` was entered as a multiple of 1_000_000.
+            .map(|v| v / T::Balance::from(1_000_000u32))
+            .ok_or_else(|| Error::<T>::BalancePerShareProductOverflowed.into())
     }
 
     /// Ensure `ca_id` has some distribution and return it.

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -924,18 +924,6 @@ impl<T: Trait> Module<T> {
         }
     }
 
-    /// Returns the supply at `cp`, if any, or `did`'s current balance otherwise.
-    crate fn supply_at_cp(ca_id: CAId, cp: Option<CheckpointId>) -> T::Balance {
-        let ticker = ca_id.ticker;
-        match cp {
-            // CP exists, use it.
-            Some(cp_id) => <Checkpoint<T>>::total_supply_at(ticker, cp_id),
-            // Although record date has passed, no transfers have happened yet for `ticker`.
-            // Thus, there is no checkpoint ID, and we must use current supply instead.
-            None => <Asset<T>>::token_details(ticker).total_supply,
-        }
-    }
-
     /// Returns the balance for `did` at `cp`, if any, or `did`'s current balance otherwise.
     crate fn balance_at_cp(did: IdentityId, ca_id: CAId, cp: Option<CheckpointId>) -> T::Balance {
         let ticker = ca_id.ticker;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 2014,
+    spec_version: 2015,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 2014,
+    spec_version: 2015,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -293,7 +293,7 @@ fn only_caa_authorized() {
                 // ..., `distribute`,
                 let id = next_ca_id(ticker);
                 $assert!(mk_ca(CAKind::UnpredictableBenefit) $(, $tail)?);
-                $assert!(Dist::distribute($user.origin(), id, None, currency, 0, 3000, None) $(, $tail)?);
+                $assert!(Dist::distribute($user.origin(), id, None, currency, 0, 0, 3000, None) $(, $tail)?);
                 // ..., and `remove_distribution`.
                 $assert!(Dist::remove_distribution($user.origin(), id) $(, $tail)?);
             };
@@ -841,6 +841,7 @@ fn remove_ca_works() {
                 id,
                 None,
                 currency,
+                2,
                 0,
                 3000,
                 None,
@@ -854,6 +855,7 @@ fn remove_ca_works() {
             Some(Distribution {
                 from: PortfolioId::default_portfolio(owner.did),
                 currency,
+                per_share: 2,
                 amount: 0,
                 remaining: 0,
                 reclaimed: false,
@@ -1016,6 +1018,7 @@ fn change_record_date_works() {
             id,
             None,
             create_asset(b"BETA", owner),
+            0,
             0,
             5000,
             None,
@@ -1725,7 +1728,7 @@ fn dist_distribute_works() {
         // Test no CA at id.
         let id = next_ca_id(ticker);
         assert_noop!(
-            Dist::distribute(owner.origin(), id, None, currency, 0, 1, None),
+            Dist::distribute(owner.origin(), id, None, currency, 0, 0, 1, None),
             Error::NoSuchCA
         );
 
@@ -1733,14 +1736,14 @@ fn dist_distribute_works() {
 
         // Test same-asset logic.
         assert_noop!(
-            Dist::distribute(owner.origin(), id, None, ticker, 0, 0, None),
+            Dist::distribute(owner.origin(), id, None, ticker, 0, 0, 0, None),
             DistError::DistributingAsset
         );
 
         // Test expiry.
         for &(pay, expiry) in &[(5, 5), (6, 5)] {
             assert_noop!(
-                Dist::distribute(owner.origin(), id, None, currency, 0, pay, Some(expiry)),
+                Dist::distribute(owner.origin(), id, None, currency, 0, 0, pay, Some(expiry)),
                 DistError::ExpiryBeforePayment
             );
         }
@@ -1751,19 +1754,20 @@ fn dist_distribute_works() {
             None,
             currency,
             0,
+            0,
             5,
             Some(6)
         ));
 
         // Start before now.
         assert_noop!(
-            Dist::distribute(owner.origin(), id, None, currency, 0, 4, None),
+            Dist::distribute(owner.origin(), id, None, currency, 0, 0, 4, None),
             DistError::NowAfterPayment
         );
 
         // Distribution already exists.
         assert_noop!(
-            Dist::distribute(owner.origin(), id, None, currency, 0, 5, None),
+            Dist::distribute(owner.origin(), id, None, currency, 0, 0, 5, None),
             DistError::AlreadyExists
         );
 
@@ -1771,14 +1775,14 @@ fn dist_distribute_works() {
         let id = dist_ca(owner, ticker, Some(5)).unwrap();
         let num = PortfolioNumber(42);
         assert_noop!(
-            Dist::distribute(owner.origin(), id, Some(num), currency, 0, 5, None),
+            Dist::distribute(owner.origin(), id, Some(num), currency, 0, 0, 5, None),
             PError::PortfolioDoesNotExist
         );
 
         // No custody over portfolio.
         let custody =
             |who: User| Custodian::insert(PortfolioId::default_portfolio(owner.did), who.did);
-        let dist = |id| Dist::distribute(owner.origin(), id, None, currency, 0, 6, None);
+        let dist = |id| Dist::distribute(owner.origin(), id, None, currency, 0, 0, 6, None);
         custody(other);
         assert_noop!(dist(id), PError::UnauthorizedCustodian);
         custody(owner);
@@ -1799,7 +1803,8 @@ fn dist_distribute_works() {
         assert_noop!(dist(id), Error::NoRecordDate);
 
         // Record date after start.
-        let dist = |id, start| Dist::distribute(owner.origin(), id, None, currency, 0, start, None);
+        let dist =
+            |id, start| Dist::distribute(owner.origin(), id, None, currency, 0, 0, start, None);
         let id = dist_ca(owner, ticker, Some(5000)).unwrap();
         assert_noop!(dist(id, 4999), Error::RecordDateAfterStart);
         assert_ok!(dist(id, 5000));
@@ -1809,7 +1814,7 @@ fn dist_distribute_works() {
         transfer(&currency, owner, other);
         let id = dist_ca(other, ticker, Some(5)).unwrap();
         let dist =
-            |amount| Dist::distribute(other.origin(), id, None, currency, amount, 5, Some(13));
+            |amount| Dist::distribute(other.origin(), id, None, currency, 3, amount, 5, Some(13));
         assert_noop!(dist(501), PError::InsufficientPortfolioBalance);
         assert_ok!(dist(500));
         assert_eq!(
@@ -1817,6 +1822,7 @@ fn dist_distribute_works() {
             Some(Distribution {
                 from: PortfolioId::default_portfolio(other.did),
                 currency,
+                per_share: 3,
                 amount: 500,
                 remaining: 500,
                 reclaimed: false,
@@ -1845,6 +1851,7 @@ fn dist_remove_works() {
             id,
             None,
             create_asset(b"BETA", owner),
+            0,
             0,
             5,
             Some(6)
@@ -1881,6 +1888,7 @@ fn dist_reclaim_works() {
             id,
             None,
             currency,
+            0,
             500,
             5,
             Some(6)
@@ -1941,6 +1949,7 @@ fn dist_claim_misc_bad() {
             None,
             create_asset(b"BETA", owner),
             0,
+            0,
             5,
             Some(6)
         ));
@@ -1980,6 +1989,7 @@ fn dist_claim_not_targeted() {
                 None,
                 currency,
                 0,
+                0,
                 1,
                 None,
             ));
@@ -1994,28 +2004,32 @@ fn dist_claim_works() {
     test(|ticker, [owner, foo, bar]| {
         set_schedule_complexity();
 
+        let baz = User::new(AccountKeyring::Dave);
+
         // Add scope claims for `BETA`, allowing transfers to go through.
         let currency = create_asset(b"BETA", owner);
         provide_scope_claim_to_multiple_parties(
-            &[owner.did, foo.did, bar.did],
+            &[owner.did, foo.did, bar.did, baz.did],
             currency,
             CDDP.public(),
         );
 
-        // Transfer 500 to `foo` and 1000 to `bar`.
+        // Transfer 500 to `foo` and `baz` and 1000 to `bar`.
         transfer(&ticker, owner, foo);
         transfer(&ticker, owner, bar);
         transfer(&ticker, owner, bar);
+        transfer(&ticker, owner, baz);
 
         // Create the dist.
         let id = dist_ca(owner, ticker, Some(1)).unwrap();
         let amount = 200_000;
-        let supply = Asset::total_supply(ticker);
+        let per_share = 101_000_000;
         assert_ok!(Dist::distribute(
             owner.origin(),
             id,
             None,
             currency,
+            per_share,
             amount,
             5,
             None,
@@ -2041,8 +2055,8 @@ fn dist_claim_works() {
         // `foo` claims with 25% tax.
         assert_ok!(Dist::claim(foo.origin(), id));
         already(foo);
-        let benefit_foo = 500 * amount / supply;
-        let post_tax_foo = benefit_foo * 3 / 4;
+        let benefit_foo = 500 * per_share / 1_000_000;
+        let post_tax_foo = benefit_foo - benefit_foo * 1 / 4;
         assert_eq!(Asset::balance(&currency, foo.did), post_tax_foo);
         let assert_rem =
             |removed| assert_eq!(Dist::distributions(id).unwrap().remaining, amount - removed);
@@ -2051,7 +2065,7 @@ fn dist_claim_works() {
         // `bar` is pushed to with 1/3 tax.
         assert_ok!(Dist::push_benefit(owner.origin(), id, bar.did));
         already(bar);
-        let benefit_bar = 1_000 * amount / supply;
+        let benefit_bar = 1_000 * per_share / 1_000_000;
         let post_tax_bar = benefit_bar * 2 / 3; // Using 1/3 tax to test rounding.
         assert_eq!(Asset::balance(&currency, bar.did), post_tax_bar);
         assert_rem(benefit_foo + benefit_bar);
@@ -2059,11 +2073,17 @@ fn dist_claim_works() {
         // Owner should have some free currency balance due to withheld taxes.
         let pid = PortfolioId::default_portfolio(owner.did);
         let wht = benefit_foo - post_tax_foo + benefit_bar - post_tax_bar;
-        let rem = supply - amount + wht;
+        let rem = Asset::total_supply(ticker) - amount + wht;
         assert_ok!(Portfolio::ensure_sufficient_balance(&pid, &currency, &rem));
         assert_noop!(
             Portfolio::ensure_sufficient_balance(&pid, &currency, &(rem + 1)),
             PError::InsufficientPortfolioBalance,
+        );
+
+        // No funds left. Baz wants 101 per share but pool provided cannot satisfy that.
+        assert_noop!(
+            Dist::claim(baz.origin(), id),
+            PError::InsufficientTokensLocked
         );
     });
 }
@@ -2089,12 +2109,13 @@ fn dist_claim_cp_test(mk_ca: impl FnOnce(Ticker, User) -> CAId) {
             CDDP.public(),
         );
         let amount = 200_000;
-        let supply = Asset::total_supply(ticker);
+        let per_share = 5_000_000;
         assert_ok!(Dist::distribute(
             owner.origin(),
             id,
             None,
             currency,
+            per_share,
             amount,
             4000,
             None,
@@ -2108,7 +2129,7 @@ fn dist_claim_cp_test(mk_ca: impl FnOnce(Ticker, User) -> CAId) {
         // Check the balances; tax is 0%.
         assert_eq!(
             Asset::balance(&currency, claimant.did),
-            500 * amount / supply
+            500 * per_share / 1_000_000
         );
         assert_eq!(Asset::balance(&currency, other.did), 0);
     });

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -5745,6 +5745,10 @@ fn test_multiple_validators_from_an_entity() {
 
             assert_permissioned_identity_prefs!(entity_id, 2, 1);
 
+            // Adding the same validator again should not increment the `running_count`
+            bond_validator_with_intended_count(50, 51, 500000, Some(2));
+            assert_permissioned_identity_prefs!(entity_id, 2, 1);
+
             // Add other stash and controller to the same did.
             // 60 stash and 61 controller.
             add_secondary_key(50, 60);
@@ -5782,6 +5786,10 @@ fn test_multiple_validators_from_an_entity() {
             // Making a validator chill status.
             assert_ok!(Staking::chill(Origin::signed(61)));
 
+            assert_permissioned_identity_prefs!(entity_id, 3, 2);
+
+            // Chilling an already disabled validator should not reduce the `running_count`
+            assert_ok!(Staking::chill(Origin::signed(61)));
             assert_permissioned_identity_prefs!(entity_id, 3, 2);
         });
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1124,6 +1124,7 @@
         "Distribution": {
             "from": "PortfolioId",
             "currency": "Ticker",
+            "per_share": "Balance",
             "amount": "Balance",
             "remaining": "Balance",
             "reclaimed": "bool",


### PR DESCRIPTION
## changelog

### modified API

- Type `Distribution` has gained `per_share: Balance` field. This is used instead the total supply to compute the benefit of a claimant as `per_share * shares_at_checkpoint`. (#942) 

### modified logic

- Fixed tracking of validators being run by an Operator. Involved storage migration to retroactively fix the `running_count`. (#946) 
- Removed error `BalanceAmountProductSupplyDivisionFailed` in Capital Distributions. (#942) 
- Renamed error `BalanceAmountProductOverflowed` to `BalancePerShareProductOverflowed` in Capital Distributions. (#942) 