### PR TITLE
Mesh 1570/clean old scope_id

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1078,11 +1078,12 @@ impl<T: Trait> AssetSubTrait<T::Balance> for Module<T> {
 
     fn update_balance_of_scope_id(
         scope_id: ScopeId,
-        old_scope_ids: impl Iterator<Item = ScopeId>,
         target_did: IdentityId,
         ticker: Ticker,
     ) {
-        for old_scope_id in old_scope_ids {
+        // If `target_did` already has another ScopeId, clean up the old ScopeId data.
+        if ScopeIdOf::contains_key(&ticker, &target_did) {
+            let old_scope_id = Self::scope_id_of(&ticker, &target_did);
             // Delete the balance of target_did at old_scope_id.
             let target_balance = <BalanceOfAtScope<T>>::take(old_scope_id, target_did);
             // Reduce the aggregate balance of identities with the same ScopeId by the deleted balance.

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1097,9 +1097,9 @@ impl<T: Trait> AssetSubTrait<T::Balance> for Module<T> {
         // has the scope claim already.
         if balance_at_scope == Zero::zero() {
             let current_balance = Self::balance_of(ticker, target_did);
-            // Update the balance on the identityId under the given scopeId.
+            // Update the balance of `target_did` under `scope_id`.
             <BalanceOfAtScope<T>>::insert(scope_id, target_did, current_balance);
-            // current aggregate balance + current identity balance is always less then the total_supply of given ticker.
+            // current aggregate balance + current identity balance is always less than the total supply of `ticker`.
             <AggregateBalance<T>>::mutate(ticker, scope_id, |bal| *bal = *bal + current_balance);
         }
         // Caches the `ScopeId` for a given IdentityId and ticker.

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1076,11 +1076,7 @@ impl<T: Trait> AssetSubTrait<T::Balance> for Module<T> {
         Self::base_accept_token_ownership_transfer(to_did, auth_id)
     }
 
-    fn update_balance_of_scope_id(
-        scope_id: ScopeId,
-        target_did: IdentityId,
-        ticker: Ticker,
-    ) {
+    fn update_balance_of_scope_id(scope_id: ScopeId, target_did: IdentityId, ticker: Ticker) {
         // If `target_did` already has another ScopeId, clean up the old ScopeId data.
         if ScopeIdOf::contains_key(&ticker, &target_did) {
             let old_scope_id = Self::scope_id_of(&ticker, &target_did);

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -45,13 +45,11 @@ pub trait AssetSubTrait<Balance> {
     /// to any previous valid `old_scope_ids`.
     ///
     /// # Arguments
-    /// * `scope_id` - The `ScopeId` of the given `IdentityId`.
-    /// * `old_scope_ids` - An iterator over previous valid `ScopeId`s.
+    /// * `scope_id` - The new `ScopeId` of `target_did` and `ticker`.
     /// * `target_did` - The `IdentityId` whose balance needs to be updated.
     /// * `ticker`- Ticker of the asset whose count need to be updated for the given identity.
     fn update_balance_of_scope_id(
         scope_id: ScopeId,
-        old_scope_ids: impl Iterator<Item = ScopeId>,
         target_did: IdentityId,
         ticker: Ticker,
     );

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -48,11 +48,7 @@ pub trait AssetSubTrait<Balance> {
     /// * `scope_id` - The new `ScopeId` of `target_did` and `ticker`.
     /// * `target_did` - The `IdentityId` whose balance needs to be updated.
     /// * `ticker`- Ticker of the asset whose count need to be updated for the given identity.
-    fn update_balance_of_scope_id(
-        scope_id: ScopeId,
-        target_did: IdentityId,
-        ticker: Ticker,
-    );
+    fn update_balance_of_scope_id(scope_id: ScopeId, target_did: IdentityId, ticker: Ticker);
 
     /// Returns balance for a given scope id and target DID.
     ///

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -42,10 +42,12 @@ pub trait AssetSubTrait<Balance> {
     /// * `auth_id` Authorization id of the authorization created by current token owner
     fn accept_asset_ownership_transfer(to_did: IdentityId, auth_id: u64) -> DispatchResult;
 
-    /// Update balance of given IdentityId under the scopeId.
+    /// Update the `ticker` balance of `target_did` under `scope_id`. Clean up the balances related
+    /// to any previous valid `old_scope_ids`.
     ///
     /// # Arguments
     /// * `scope_id` - The `ScopeId` of the given `IdentityId`.
+    /// * `old_scope_ids` - An iterator over previous valid `ScopeId`s.
     /// * `target_did` - The `IdentityId` whose balance needs to be updated.
     /// * `ticker`- Ticker of the asset whose count need to be updated for the given identity.
     fn update_balance_of_scope_id(

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -45,10 +45,15 @@ pub trait AssetSubTrait<Balance> {
     /// Update balance of given IdentityId under the scopeId.
     ///
     /// # Arguments
-    /// * `of` - The `ScopeId` of the given `IdentityId`.
+    /// * `scope_id` - The `ScopeId` of the given `IdentityId`.
     /// * `target_did` - The `IdentityId` whose balance needs to be updated.
     /// * `ticker`- Ticker of the asset whose count need to be updated for the given identity.
-    fn update_balance_of_scope_id(of: ScopeId, whom: IdentityId, ticker: Ticker) -> DispatchResult;
+    fn update_balance_of_scope_id(
+        scope_id: ScopeId,
+        old_scope_ids: impl Iterator<Item = ScopeId>,
+        target_did: IdentityId,
+        ticker: Ticker,
+    );
 
     /// Returns balance for a given scope id and target DID.
     ///

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1650,7 +1650,7 @@ impl<T: Trait> Module<T> {
             if let Claim::InvestorUniqueness(scope, scope_id, cdd_id) = &claim {
                 (scope, scope_id, cdd_id)
             } else {
-                return Err(Error::<T>::ClaimVariantNotAllowed.into());
+                fail!(Error::<T>::ClaimVariantNotAllowed);
             };
         // Only owner of the identity can add that confidential claim.
         ensure!(

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1669,25 +1669,8 @@ impl<T: Trait> Module<T> {
         );
 
         if let Scope::Ticker(ticker) = &scope {
-            // If `target` already has different InvestorUniqueness claims, clean up the old ScopeId data.
-            let old_scope_ids = Self::fetch_base_claims(target, ClaimType::InvestorUniqueness)
-                .filter_map(move |id_claim| {
-                    if let Claim::InvestorUniqueness(old_scope, old_scope_id, _old_cdd_id) =
-                        &id_claim.claim
-                    {
-                        if old_scope == scope && scope_id != old_scope_id {
-                            return Some(*old_scope_id);
-                        }
-                    }
-                    None
-                });
             // Update the balance of the IdentityId under the ScopeId provided in claim data.
-            T::AssetSubTraitTarget::update_balance_of_scope_id(
-                *scope_id,
-                old_scope_ids,
-                target,
-                *ticker,
-            );
+            T::AssetSubTraitTarget::update_balance_of_scope_id(*scope_id, target, *ticker);
         }
 
         Self::base_add_claim(target, claim, issuer, expiry);

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -89,7 +89,7 @@ use core::{
 use frame_support::{
     debug, decl_error, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo},
-    ensure,
+    ensure, fail,
     traits::{ChangeMembers, Currency, EnsureOrigin, Get, GetCallMetadata, InitializeMembers},
     weights::{
         DispatchClass::{Normal, Operational},

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1670,7 +1670,7 @@ impl<T: Trait> Module<T> {
             Error::<T>::InvalidScopeClaim
         );
 
-        if let Claim::InvestorUniqueness(scope, scope_id, cdd_id) = &claim {
+        if let Claim::InvestorUniqueness(scope, scope_id, _cdd_id) = &claim {
             if let Scope::Ticker(ticker) = &scope {
                 // If `target` already has an InvestorUniqueness claim and clean up the old scope_id data.
                 let old_scope_ids = Self::fetch_base_claims(target, ClaimType::InvestorUniqueness)
@@ -1679,22 +1679,18 @@ impl<T: Trait> Module<T> {
                             &id_claim.claim
                         {
                             if old_scope == scope {
-                                return Some(old_scope_id);
+                                return Some(*old_scope_id);
                             }
                         }
                         None
                     });
-                for old_scope_id in old_scope_ids {
-                    // FIXME
-                    T::AssetSubTraitTarget::purge_balance_of_scope_id(
-                        old_scope_id,
-                        target,
-                        *ticker,
-                    )?;
-                }
-
                 // Update the balance of the IdentityId under the ScopeId provided in claim data.
-                T::AssetSubTraitTarget::update_balance_of_scope_id(*scope_id, target, *ticker)?
+                T::AssetSubTraitTarget::update_balance_of_scope_id(
+                    *scope_id,
+                    old_scope_ids,
+                    target,
+                    *ticker,
+                );
             }
         }
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -179,7 +179,7 @@ const FUNDING_ROUND: Option<FundingRoundName> = None;
 const TOTAL_SUPPLY: u128 = 1_000_000_000u128;
 
 /// Creates a simple asset, owned by `owner`.
-#[deprecated(note = "Please use a_token with basic_asset instead")]
+// FIXME: Please use a_token and basic_asset or an_asset instead.
 crate fn simple_asset(owner: Public, divisible: bool) -> (SecurityToken<u128>, Ticker) {
     let ticker = Ticker::try_from(&b"MYUSD"[..]).unwrap();
     let asset_type = AssetType::default();

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -173,7 +173,7 @@ const FUNDING_ROUND: Option<FundingRoundName> = None;
 const TOTAL_SUPPLY: u128 = 1_000_000_000u128;
 
 /// Creates a simple asset, owned by `owner`.
-pub fn simple_asset(owner: Public, divisible: bool) -> (SecurityToken<u128>, Ticker) {
+crate fn simple_asset(owner: Public, divisible: bool) -> (SecurityToken<u128>, Ticker) {
     let ticker = Ticker::try_from(&b"MYUSD"[..]).unwrap();
     let asset_type = AssetType::default();
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -173,17 +173,17 @@ const FUNDING_ROUND: Option<FundingRoundName> = None;
 const TOTAL_SUPPLY: u128 = 1_000_000_000u128;
 
 /// Creates a simple asset, owned by `owner`.
-fn simple_asset(owner: Public, is_divisible: bool) -> (SecurityToken<u128>, Ticker) {
+pub fn simple_asset(owner: Public, divisible: bool) -> (SecurityToken<u128>, Ticker) {
     let ticker = Ticker::try_from(&b"MYUSD"[..]).unwrap();
     let asset_type = AssetType::default();
 
-    let asset_name: AssetName = ticker.as_ref().into();
+    let name: AssetName = ticker.as_ref().into();
     Asset::create_asset(
         Origin::signed(owner),
-        asset_name.clone(),
+        name.clone(),
         ticker,
         TOTAL_SUPPLY,
-        is_divisible,
+        divisible,
         asset_type.clone(),
         ASSET_IDENTIFIERS,
         FUNDING_ROUND,
@@ -191,11 +191,11 @@ fn simple_asset(owner: Public, is_divisible: bool) -> (SecurityToken<u128>, Tick
     .expect("Asset cannot be created");
 
     let token = SecurityToken {
-        name: asset_name,
+        name,
         owner_did: Identity::key_to_identity_dids(owner),
         total_supply: TOTAL_SUPPLY,
-        divisible: is_divisible,
-        asset_type: asset_type,
+        divisible,
+        asset_type,
         primary_issuance_agent: None,
     };
 
@@ -1905,10 +1905,10 @@ fn check_unique_investor_count() {
             // 1c). Provide the valid scope claim.
             // Create Investor unique Id, In an ideal scenario it will be generated from the PUIS system.
             let bob_uid = generate_uid("BOB_ENTITY".to_string());
-            provide_scope_claim(bob_1.did, ticker, bob_uid, cdd_provider);
+            provide_scope_claim(bob_1.did, ticker, bob_uid, cdd_provider, None).0;
 
             let alice_uid = generate_uid("ALICE_ENTITY".to_string());
-            provide_scope_claim(alice.did, ticker, alice_uid, cdd_provider);
+            provide_scope_claim(alice.did, ticker, alice_uid, cdd_provider, None).0;
             let alice_scope_id = Asset::scope_id_of(&ticker, &alice.did);
 
             // 1d). Validate the storage changes.
@@ -1947,7 +1947,7 @@ fn check_unique_investor_count() {
             assert_eq!(Statistics::investor_count(&ticker), 2);
 
             // Provide scope claim to bob_2.did
-            provide_scope_claim(bob_2.did, ticker, bob_uid, cdd_provider);
+            provide_scope_claim(bob_2.did, ticker, bob_uid, cdd_provider, None).0;
 
             // 1f). successfully transfer funds.
             assert_ok!(transfer(ticker, alice, bob_2, 1000));

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -97,6 +97,12 @@ crate fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     token(b"A", owner_did)
 }
 
+crate fn an_asset(owner: User) -> Ticker {
+    let (ticker, token) = a_token(owner.did);
+    assert_ok!(basic_asset(owner, ticker, &token));
+    ticker
+}
+
 fn has_ticker_record(ticker: Ticker) -> bool {
     DidRecords::contains_key(Identity::get_token_did(&ticker).unwrap())
 }

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -93,7 +93,7 @@ crate fn token(name: &[u8], owner_did: IdentityId) -> (Ticker, SecurityToken<u12
     (ticker, token)
 }
 
-fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
+crate fn a_token(owner_did: IdentityId) -> (Ticker, SecurityToken<u128>) {
     token(b"A", owner_did)
 }
 
@@ -173,6 +173,7 @@ const FUNDING_ROUND: Option<FundingRoundName> = None;
 const TOTAL_SUPPLY: u128 = 1_000_000_000u128;
 
 /// Creates a simple asset, owned by `owner`.
+#[deprecated(note = "Please use a_token with basic_asset instead")]
 crate fn simple_asset(owner: Public, divisible: bool) -> (SecurityToken<u128>, Ticker) {
     let ticker = Ticker::try_from(&b"MYUSD"[..]).unwrap();
     let asset_type = AssetType::default();

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1583,16 +1583,16 @@ fn do_add_investor_uniqueness_claim() {
     let balance_at_scope = |scope_id, balance| {
         assert_eq!(
             balance,
-            <pallet_asset::BalanceOfAtScope<TestStorage>>::get(scope_id, alice.did)
+            Asset::balance_of_at_scope(scope_id, alice.did)
         );
     };
     let scope_id_of = |scope_id| {
-        assert_eq!(scope_id, <pallet_asset::ScopeIdOf>::get(ticker, alice.did));
+        assert_eq!(scope_id, Asset::scope_id_of(ticker, alice.did));
     };
     let aggregate_balance = |scope_id, balance| {
         assert_eq!(
             balance,
-            <pallet_asset::AggregateBalance<TestStorage>>::get(ticker, scope_id)
+            Asset::aggregate_balance(ticker, scope_id)
         );
     };
 

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::{a_token, basic_asset},
+    asset_test::an_asset,
     committee_test::gc_vmo,
     ext_builder::PROTOCOL_OP_BASE_FEE,
     storage::{
@@ -1570,8 +1570,7 @@ fn add_investor_uniqueness_claim() {
 fn do_add_investor_uniqueness_claim() {
     let alice = User::new(AccountKeyring::Alice);
     let cdd_provider = AccountKeyring::Charlie.public();
-    let (ticker, token) = a_token(alice.did);
-    assert_ok!(basic_asset(alice, ticker, &token));
+    let ticker = an_asset(alice);
     let initial_balance = Asset::balance_of(ticker, alice.did);
     let add_iu_claim =
         |investor_uid| provide_scope_claim(alice.did, ticker, investor_uid, cdd_provider, Some(1));

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::simple_asset,
+    asset_test::{a_token, basic_asset},
     committee_test::gc_vmo,
     ext_builder::PROTOCOL_OP_BASE_FEE,
     storage::{
@@ -1570,7 +1570,8 @@ fn add_investor_uniqueness_claim() {
 fn do_add_investor_uniqueness_claim() {
     let alice = User::new(AccountKeyring::Alice);
     let cdd_provider = AccountKeyring::Charlie.public();
-    let ticker = simple_asset(alice.acc(), true).1;
+    let (ticker, token) = a_token(alice.did);
+    assert_ok!(basic_asset(alice, ticker, &token));
     let initial_balance = Asset::balance_of(ticker, alice.did);
     let add_iu_claim =
         |investor_uid| provide_scope_claim(alice.did, ticker, investor_uid, cdd_provider, Some(1));

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1581,19 +1581,13 @@ fn do_add_investor_uniqueness_claim() {
         );
     };
     let balance_at_scope = |scope_id, balance| {
-        assert_eq!(
-            balance,
-            Asset::balance_of_at_scope(scope_id, alice.did)
-        );
+        assert_eq!(balance, Asset::balance_of_at_scope(scope_id, alice.did));
     };
     let scope_id_of = |scope_id| {
         assert_eq!(scope_id, Asset::scope_id_of(ticker, alice.did));
     };
     let aggregate_balance = |scope_id, balance| {
-        assert_eq!(
-            balance,
-            Asset::aggregate_balance(ticker, scope_id)
-        );
+        assert_eq!(balance, Asset::aggregate_balance_of(ticker, scope_id));
     };
 
     // Get some tokens for Alice in case the default initial balance changes to 0 in simple_token.

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, deprecated)]
 #![feature(crate_visibility_modifier)]
 #![feature(bindings_after_at, bool_to_option)]
 

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, deprecated)]
+#![allow(dead_code)]
 #![feature(crate_visibility_modifier)]
 #![feature(bindings_after_at, bool_to_option)]
 

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -492,12 +492,7 @@ impl AssetSubTrait<Balance> for Test {
     fn accept_asset_ownership_transfer(_: IdentityId, _: u64) -> DispatchResult {
         Ok(())
     }
-    fn update_balance_of_scope_id(
-        _: ScopeId,
-        _: IdentityId,
-        _: Ticker,
-    ) {
-    }
+    fn update_balance_of_scope_id(_: ScopeId, _: IdentityId, _: Ticker) {}
     fn balance_of_at_scope(_: &ScopeId, _: &IdentityId) -> Balance {
         0
     }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -492,8 +492,12 @@ impl AssetSubTrait<Balance> for Test {
     fn accept_asset_ownership_transfer(_: IdentityId, _: u64) -> DispatchResult {
         Ok(())
     }
-    fn update_balance_of_scope_id(_: ScopeId, _: IdentityId, _: Ticker) -> DispatchResult {
-        Ok(())
+    fn update_balance_of_scope_id(
+        _: ScopeId,
+        _: impl Iterator<Item = ScopeId>,
+        _: IdentityId,
+        _: Ticker,
+    ) {
     }
     fn balance_of_at_scope(_: &ScopeId, _: &IdentityId) -> Balance {
         0

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -494,7 +494,6 @@ impl AssetSubTrait<Balance> for Test {
     }
     fn update_balance_of_scope_id(
         _: ScopeId,
-        _: impl Iterator<Item = ScopeId>,
         _: IdentityId,
         _: Ticker,
     ) {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -751,7 +751,7 @@ pub fn make_account_with_scope(
 > {
     let uid = create_investor_uid(id);
     let (origin, did) = make_account_with_uid(id, uid.clone()).unwrap();
-    let scope_id = provide_scope_claim(did, ticker, uid, cdd_provider);
+    let scope_id = provide_scope_claim(did, ticker, uid, cdd_provider, None).0;
     Ok((origin, did, scope_id))
 }
 
@@ -924,7 +924,8 @@ pub fn provide_scope_claim(
     scope: Ticker,
     investor_uid: InvestorUid,
     cdd_provider: AccountId,
-) -> ScopeId {
+    cdd_claim_expiry: Option<u64>,
+) -> (ScopeId, CddId) {
     let (cdd_id, proof) = create_cdd_id(claim_to, scope, investor_uid);
     let scope_claim = InvestorZKProofData::make_scope_claim(&scope.as_slice(), &investor_uid);
     let scope_id = compute_scope_id(&scope_claim).compress().to_bytes().into();
@@ -936,7 +937,7 @@ pub fn provide_scope_claim(
         Origin::signed(cdd_provider),
         claim_to,
         Claim::CustomerDueDiligence(cdd_id),
-        None
+        cdd_claim_expiry,
     ));
 
     // Provide the InvestorUniqueness.
@@ -948,7 +949,7 @@ pub fn provide_scope_claim(
         None
     ));
 
-    scope_id
+    (scope_id, cdd_id)
 }
 
 pub fn provide_scope_claim_to_multiple_parties<'a>(
@@ -958,7 +959,7 @@ pub fn provide_scope_claim_to_multiple_parties<'a>(
 ) {
     parties.into_iter().enumerate().for_each(|(_, id)| {
         let uid = create_investor_uid(Identity::did_records(id).primary_key);
-        provide_scope_claim(*id, ticker, uid, cdd_provider);
+        provide_scope_claim(*id, ticker, uid, cdd_provider, None).0;
     });
 }
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -172,6 +172,10 @@ impl User {
     pub fn origin(&self) -> Origin {
         Origin::signed(self.acc())
     }
+
+    pub fn uid(&self) -> InvestorUid {
+        create_investor_uid(self.acc())
+    }
 }
 
 // For testing the module, we construct most of a mock runtime. This means

--- a/primitives/src/cdd_id.rs
+++ b/primitives/src/cdd_id.rs
@@ -45,11 +45,11 @@ impl From<[u8; 32]> for InvestorUid {
     }
 }
 
-/// It links the investor UID with an specific Identity DID in a way that no one can extract that
-/// investor UID from this CDD Id, and the investor can create a Zero Knowledge Proof to prove that
-/// an specific DID belongs to him.
-/// The main purpose of this claim is to keep the privacy of the investor using several identities
-/// to handle his portfolio.
+/// A CDD ID is a link between the investor UID and a certain Identity DID such that no one can
+/// extract the investor UID from the CDD ID while the investor can create a Zero Knowledge Proof to
+/// prove that that DID belongs to them.
+/// The main purpose of such a claim is to preserve privacy of the investor using several identities
+/// to handle their portfolio.
 #[derive(
     Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, SliceU8StrongTyped, Hash,
 )]


### PR DESCRIPTION
## changelog

### modified logic

- Calling the `add_investor_uniqueness_claim` extrinsic in the `identity` pallet with a new investor uniqueness `claim` that has a new `ScopeId` cleans up identity-ticker balances related to the `ScopeId` of the old investor uniqueness claim if there was one.
