### PR TITLE
Added identity to staking `Reward` event

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1302,8 +1302,8 @@ decl_event!(
         /// the remainder from the maximum amount of reward.
         /// [era_index, validator_payout, remainder]
         EraPayout(EraIndex, Balance, Balance),
-        /// The staker has been rewarded by this amount. [stash, amount]
-        Reward(AccountId, Balance),
+        /// The staker has been rewarded by this amount. [stash_identity, stash, amount]
+        Reward(IdentityId, AccountId, Balance),
         /// One validator (and its nominators) has been slashed by the given amount.
         /// [validator, amount]
         Slash(AccountId, Balance),
@@ -2735,7 +2735,11 @@ impl<T: Trait> Module<T> {
             &ledger.stash,
             validator_staking_payout + validator_commission_payout,
         ) {
-            Self::deposit_event(RawEvent::Reward(ledger.stash, imbalance.peek()));
+            Self::deposit_event(RawEvent::Reward(
+                <Identity<T>>::get_identity(&ledger.stash).unwrap_or_default(),
+                ledger.stash,
+                imbalance.peek(),
+            ));
         }
 
         // Lets now calculate how this is split to the nominators.
@@ -2748,7 +2752,11 @@ impl<T: Trait> Module<T> {
                 nominator_exposure_part * validator_leftover_payout;
             // We can now make nominator payout:
             if let Some(imbalance) = Self::make_payout(&nominator.who, nominator_reward) {
-                Self::deposit_event(RawEvent::Reward(nominator.who.clone(), imbalance.peek()));
+                Self::deposit_event(RawEvent::Reward(
+                    <Identity<T>>::get_identity(&nominator.who).unwrap_or_default(),
+                    nominator.who.clone(),
+                    imbalance.peek(),
+                ));
             }
         }
 


### PR DESCRIPTION
## changelog

### modified API

- The Staking `Reward` event now also contains the Identity of the key being rewarded.
