### PR TITLE
MESH-1589: Limit lengths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,6 +5421,7 @@ dependencies = [
  "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-committee 0.1.0",
  "pallet-group 0.1.0",
  "pallet-identity 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5476,6 +5476,7 @@ dependencies = [
  "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-identity 0.1.0",
  "pallet-permissions 0.1.0",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5914,6 +5914,7 @@ dependencies = [
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-asset 0.1.0",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-compliance-manager 0.1.0",
  "pallet-identity 0.1.0",
  "pallet-permissions 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,6 +4420,7 @@ dependencies = [
  "hex-literal 0.2.1",
  "libsecp256k1",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-contracts 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-identity 0.1.0",
  "pallet-permissions 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,6 +5199,7 @@ dependencies = [
  "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-permissions 0.1.0",
  "pallet-timestamp 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5694,6 +5694,7 @@ dependencies = [
  "hex-literal 0.2.1",
  "pallet-asset 0.1.0",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-compliance-manager 0.1.0",
  "pallet-contracts 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-identity 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6823,6 +6823,7 @@ dependencies = [
  "frame-benchmarking 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "pallet-base",
  "pallet-contracts 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-identity 0.1.0",
  "pallet-protocol-fee 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,6 +4671,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-base"
+version = "0.1.0"
+dependencies = [
+ "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "parity-scale-codec",
+ "polymesh-common-utilities 0.1.0",
+ "serde",
+ "serde_derive",
+ "sp-api 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "sp-core 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "sp-io 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "sp-runtime 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "sp-std 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+ "sp-version 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
+]
+
+[[package]]
 name = "pallet-bridge"
 version = "1.0.0"
 dependencies = [
@@ -4678,6 +4696,7 @@ dependencies = [
  "frame-support 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-identity 0.1.0",
  "pallet-multisig 0.1.0",
  "pallet-scheduler 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
@@ -7027,6 +7046,7 @@ dependencies = [
  "pallet-authorship 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-babe 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-bridge 1.0.0",
  "pallet-committee 0.1.0",
  "pallet-compliance-manager 0.1.0",
@@ -7105,6 +7125,7 @@ dependencies = [
  "pallet-authorship 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-babe 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-bridge 1.0.0",
  "pallet-committee 0.1.0",
  "pallet-compliance-manager 0.1.0",
@@ -7184,6 +7205,7 @@ dependencies = [
  "pallet-authorship 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-babe 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-bridge 1.0.0",
  "pallet-committee 0.1.0",
  "pallet-compliance-manager 0.1.0",
@@ -7345,6 +7367,7 @@ dependencies = [
  "pallet-authorship 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-babe 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-bridge 1.0.0",
  "pallet-committee 0.1.0",
  "pallet-compliance-manager 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4973,6 +4973,7 @@ dependencies = [
  "libsecp256k1",
  "pallet-asset 0.1.0",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-compliance-manager 0.1.0",
  "pallet-identity 0.1.0",
  "pallet-portfolio 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,6 +4789,7 @@ dependencies = [
  "frame-system 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",
  "pallet-asset 0.1.0",
  "pallet-balances 0.1.0",
+ "pallet-base",
  "pallet-identity 0.1.0",
  "pallet-permissions 0.1.0",
  "pallet-timestamp 2.0.1 (git+https://github.com/PolymathNetwork/substrate?tag=v2.0.1-2)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "node-rpc",
     "pallets/asset",
     "pallets/balances",
+    "pallets/base",
     "pallets/bridge",
     "pallets/committee",
     "pallets/common",

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -12,6 +12,7 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 
 # Our Pallets
 pallet-balances = { path = "../balances", default-features = false  }
+pallet-base = { path = "../base", default-features = false  }
 pallet-contracts = { git = "https://github.com/PolymathNetwork/substrate", tag = "v2.0.1-2", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-permissions = { path = "../permissions", default-features = false }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2078,8 +2078,6 @@ impl<T: Trait> Module<T> {
         ticker: Ticker,
     ) -> DispatchResult {
         let did = Self::ensure_perms_owner_asset(origin, &ticker)?;
-        let len = docs.len();
-        T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocument, len)?;
 
         // Ensure strings are limited.
         for doc in &docs {
@@ -2090,6 +2088,11 @@ impl<T: Trait> Module<T> {
             }
         }
 
+        // Charge fee.
+        let len = docs.len();
+        T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocument, len)?;
+
+        // Add the documents & emit events.
         AssetDocumentsIdSequence::mutate(ticker, |DocumentId(ref mut id)| {
             for (id, doc) in (*id..).map(DocumentId).zip(docs) {
                 AssetDocuments::insert(ticker, id, doc.clone());

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -96,7 +96,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::ensure_root;
-use pallet_base::ensure_string_limited;
+use pallet_base::{ensure_opt_string_limited, ensure_string_limited};
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
     asset::{AssetFnTrait, AssetSubTrait},
@@ -2083,9 +2083,7 @@ impl<T: Trait> Module<T> {
         for doc in &docs {
             ensure_string_limited::<T>(&doc.uri)?;
             ensure_string_limited::<T>(&doc.name)?;
-            if let Some(ty) = &doc.doc_type {
-                ensure_string_limited::<T>(ty)?;
-            }
+            ensure_opt_string_limited::<T>(doc.doc_type.as_deref())?;
         }
 
         // Charge fee.

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -96,6 +96,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::ensure_root;
+use pallet_base::ensure_string_limited;
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
     asset::{AssetFnTrait, AssetSubTrait},
@@ -114,7 +115,6 @@ use polymesh_primitives::{
     DocumentId, IdentityId, MetaVersion as ExtVersion, PortfolioId, ScopeId, SecondaryKey,
     Signatory, SmartExtension, SmartExtensionName, SmartExtensionType, Ticker,
 };
-use pallet_base::ensure_string_limited;
 use sp_runtime::traits::{CheckedAdd, Saturating, Zero};
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1859,6 +1859,9 @@ impl<T: Trait> Module<T> {
             name.len() <= T::AssetNameMaxLength::get(),
             Error::<T>::MaxLengthOfAssetNameExceeded
         );
+        if let AssetType::Custom(ty) = &asset_type {
+            pallet_base::ensure_string_limited::<T>(ty);
+        }
         ensure!(
             funding_round.as_ref().map_or(0, |name| name.len())
                 <= T::FundingRoundNameMaxLength::get(),

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1860,7 +1860,7 @@ impl<T: Trait> Module<T> {
             Error::<T>::MaxLengthOfAssetNameExceeded
         );
         if let AssetType::Custom(ty) = &asset_type {
-            pallet_base::ensure_string_limited::<T>(ty);
+            pallet_base::ensure_string_limited::<T>(ty)?;
         }
         ensure!(
             funding_round.as_ref().map_or(0, |name| name.len())
@@ -2138,6 +2138,10 @@ impl<T: Trait> Module<T> {
         extension_details: SmartExtension<T::AccountId>,
     ) -> DispatchResult {
         let my_did = Self::ensure_perms_owner_asset(origin, &ticker)?;
+
+        if let SmartExtensionType::Custom(ty) = &extension_details.extension_type {
+            pallet_base::ensure_string_limited::<T>(ty)?;
+        }
 
         // Verify the details of smart extension & store it
         ensure!(

--- a/pallets/base/Cargo.toml
+++ b/pallets/base/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pallet-base"
+version = "0.1.0"
+authors = ["Polymath"]
+edition = "2018"
+
+[dependencies]
+polymesh-common-utilities = { path = "../common", default-features = false }
+
+# Others
+serde = { version = "1.0.104", default-features = false }
+serde_derive = { version = "1.0.104", optional = true, default-features = false  }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "1.1.0", default-features = false, features = ["derive"] }
+sp-core = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+sp-std = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+sp-io = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+sp-runtime = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+sp-version = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+sp-api = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+
+frame-system = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+frame-support = { git = "https://github.com/PolymathNetwork/substrate", default-features = false, tag = "v2.0.1-2" }
+
+[features]

--- a/pallets/base/src/lib.rs
+++ b/pallets/base/src/lib.rs
@@ -27,14 +27,14 @@ decl_error! {
 }
 
 /// Ensure that the `len` provided is within the generic length limit.
-pub fn ensure_length_ok<T: Trait>(len: u32) -> DispatchResult {
-    ensure!(len <= T::MaxLen::get(), Error::<T>::TooLong);
+pub fn ensure_length_ok<T: Trait>(len: usize) -> DispatchResult {
+    ensure!(len <= T::MaxLen::get() as usize, Error::<T>::TooLong);
     Ok(())
 }
 
 /// Ensure that `s.len()` is within the generic length limit.
 pub fn ensure_string_limited<T: Trait>(s: &[u8]) -> DispatchResult {
-    ensure_length_ok::<T>(s.len() as u32)
+    ensure_length_ok::<T>(s.len())
 }
 
 /// Ensure that given `Some(s)`, `s.len()` is within the generic length limit.

--- a/pallets/base/src/lib.rs
+++ b/pallets/base/src/lib.rs
@@ -1,3 +1,28 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymathNetwork/Polymesh).
+// Copyright (c) 2021 Polymath
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Base Module
+//!
+//! The Base module provides utility and framework-like functionality atop of substrate.
+//!
+//! Currently, the module contains:
+//! - `Error::TooLong` and `ensure_*` functions to conveniently check data types for length.
+//! - `Event::UnexpectedError` and `emit_unexpected_error` to embed an error for manual inspection.
+//!
+//! There are currently no extrinsics or storage items in the base module.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::dispatch::{DispatchError, DispatchResult};

--- a/pallets/base/src/lib.rs
+++ b/pallets/base/src/lib.rs
@@ -32,7 +32,15 @@ pub fn ensure_length_ok<T: Trait>(len: u32) -> DispatchResult {
     Ok(())
 }
 
-/// Ensure that string's `.len()` is within the generic length limit.
+/// Ensure that `s.len()` is within the generic length limit.
 pub fn ensure_string_limited<T: Trait>(s: &[u8]) -> DispatchResult {
     ensure_length_ok::<T>(s.len() as u32)
+}
+
+/// Ensure that given `Some(s)`, `s.len()` is within the generic length limit.
+pub fn ensure_opt_string_limited<T: Trait>(s: Option<&[u8]>) -> DispatchResult {
+    match s {
+        None => Ok(()),
+        Some(s) => ensure_string_limited::<T>(s),
+    }
 }

--- a/pallets/base/src/lib.rs
+++ b/pallets/base/src/lib.rs
@@ -1,0 +1,54 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::traits::Get;
+use frame_support::{decl_error, decl_event, decl_module, ensure};
+
+pub trait Trait: frame_system::Trait {
+    /// The overarching event type.
+    type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// The maximum length governing `TooLong`.
+    ///
+    /// How lengths are computed to compare against this value is situation based.
+    /// For example, you could halve it, double it, compute a sum for some tree of strings, etc.
+    type MaxLen: Get<u32>;
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+        fn deposit_event() = default;
+    }
+}
+
+decl_event! {
+    pub enum Event {
+        /// An unexpected error happened that should be investigated.
+        UnexpectedError(Option<DispatchError>),
+    }
+}
+
+/// Emit an unexpected error event that should be investigated manually
+pub fn emit_unexpected_error<T: Trait>(error: Option<DispatchError>) {
+    Module::<T>::deposit_event(Event::UnexpectedError(error));
+}
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        /// Exceeded a generic length limit.
+        /// The limit could be for any sort of lists of things, including a string.
+        TooLong,
+    }
+}
+
+/// Ensure that the `len` provided is within the generic length limit.
+pub fn ensure_length_ok<T: Trait>(len: u32) -> DispatchResult {
+    ensure!(len <= T::MaxLen::get(), Error::<T>::TooLong);
+    Ok(())
+}
+
+/// Ensure that string's `.len()` is within the generic length limit.
+pub fn ensure_string_limited<T: Trait>(s: &[u8]) -> DispatchResult {
+    ensure_length_ok::<T>(s.len() as u32)
+}

--- a/pallets/base/src/lib.rs
+++ b/pallets/base/src/lib.rs
@@ -2,30 +2,14 @@
 
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::traits::Get;
-use frame_support::{decl_error, decl_event, decl_module, ensure};
+use frame_support::{decl_error, decl_module, ensure};
 
-pub trait Trait: frame_system::Trait {
-    /// The overarching event type.
-    type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
-
-    /// The maximum length governing `TooLong`.
-    ///
-    /// How lengths are computed to compare against this value is situation based.
-    /// For example, you could halve it, double it, compute a sum for some tree of strings, etc.
-    type MaxLen: Get<u32>;
-}
+pub use polymesh_common_utilities::traits::base::{Event, Trait};
 
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         type Error = Error<T>;
         fn deposit_event() = default;
-    }
-}
-
-decl_event! {
-    pub enum Event {
-        /// An unexpected error happened that should be investigated.
-        UnexpectedError(Option<DispatchError>),
     }
 }
 

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -9,6 +9,7 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
 pallet-balances = { path = "../balances", default-features = false }
+pallet-base = { path = "../base", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-multisig = { path = "../multisig", default-features = false }
 

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -133,7 +133,7 @@ use sp_std::{convert::TryFrom, prelude::*};
 
 type Identity<T> = identity::Module<T>;
 
-pub trait Trait: multisig::Trait + scheduler::Trait + BalancesTrait {
+pub trait Trait: multisig::Trait + scheduler::Trait + BalancesTrait + pallet_base::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     type Proposal: From<Call<Self>> + Into<<Self as IdentityTrait>::Proposal>;
     /// Scheduler of timelocked bridge transactions.
@@ -893,7 +893,7 @@ impl<T: Trait> Module<T> {
             RawOrigin::Root.into(),
             call,
         ) {
-            <Identity<T>>::emit_unexpected_error(Some(e));
+            pallet_base::emit_unexpected_error::<T>(Some(e));
         } else {
             let current_did = Context::current_identity::<Identity<T>>().unwrap_or_else(|| GC_DID);
             Self::deposit_event(RawEvent::BridgeTxScheduled(

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -20,7 +20,7 @@ pub mod constants;
 
 pub mod traits;
 pub use traits::{
-    asset, balances, compliance_manager, governance_group, group, identity, multisig, pip,
+    asset, balances, base, compliance_manager, governance_group, group, identity, multisig, pip,
     portfolio, transaction_payment, CommonTrait, TestUtilsFn,
 };
 pub mod context;

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -28,7 +28,7 @@ use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
     dispatch::{DispatchError, DispatchResult, PostDispatchInfo},
-    traits::{Currency, EnsureOrigin, Get, GetCallMetadata},
+    traits::{Currency, EnsureOrigin, GetCallMetadata},
     weights::{GetDispatchInfo, Weight},
     Parameter,
 };
@@ -220,9 +220,6 @@ decl_event!(
 
         /// All Secondary keys of the identity ID are unfrozen.
         SecondaryKeysUnfrozen(IdentityId),
-
-        /// An unexpected error happened that should be investigated.
-        UnexpectedError(Option<DispatchError>),
 
         /// Mocked InvestorUid created.
         MockInvestorUIDCreated(IdentityId, InvestorUid),

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -27,8 +27,8 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
-    dispatch::{DispatchError, DispatchResult, PostDispatchInfo},
-    traits::{Currency, EnsureOrigin, GetCallMetadata},
+    dispatch::{DispatchResult, PostDispatchInfo},
+    traits::{Currency, EnsureOrigin, Get, GetCallMetadata},
     weights::{GetDispatchInfo, Weight},
     Parameter,
 };

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -104,7 +104,7 @@ pub trait IdentityToCorporateAction {
 }
 
 /// The module's configuration trait.
-pub trait Trait: CommonTrait + pallet_timestamp::Trait {
+pub trait Trait: CommonTrait + pallet_timestamp::Trait + crate::traits::base::Trait {
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     /// An extrinsic call.

--- a/pallets/common/src/traits/mod.rs
+++ b/pallets/common/src/traits/mod.rs
@@ -81,3 +81,27 @@ pub trait TestUtilsFn<AccountId> {
         secondary_keys: sp_std::vec::Vec<SecondaryKey<AccountId>>,
     ) -> DispatchResult;
 }
+
+pub mod base {
+    use frame_support::decl_event;
+    use frame_support::dispatch::DispatchError;
+    use frame_support::traits::Get;
+
+    decl_event! {
+        pub enum Event {
+            /// An unexpected error happened that should be investigated.
+            UnexpectedError(Option<DispatchError>),
+        }
+    }
+
+    pub trait Trait: frame_system::Trait {
+        /// The overarching event type.
+        type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
+
+        /// The maximum length governing `TooLong`.
+        ///
+        /// How lengths are computed to compare against this value is situation based.
+        /// For example, you could halve it, double it, compute a sum for some tree of strings, etc.
+        type MaxLen: Get<u32>;
+    }
+}

--- a/pallets/compliance-manager/Cargo.toml
+++ b/pallets/compliance-manager/Cargo.toml
@@ -10,6 +10,7 @@ polymesh-primitives = { path = "../../primitives", default-features = false }
 polymesh-common-utilities = { path = "../common", default-features = false }
 
 # Our pallets
+pallet-base = { path = "../base", default-features = false }
 pallet-identity = { path = "../identity", default-features = false  }
 pallet-permissions = { path = "../permissions", default-features = false }
 ## Only for benchmarks

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -85,8 +85,8 @@ use frame_support::{
     traits::Get,
     weights::Weight,
 };
-use pallet_identity as identity;
 use pallet_base::ensure_length_ok;
+use pallet_identity as identity;
 pub use polymesh_common_utilities::traits::compliance_manager::WeightInfo;
 use polymesh_common_utilities::{
     asset::AssetFnTrait,
@@ -347,7 +347,7 @@ decl_module! {
             TrustedClaimIssuer::try_mutate(ticker, |issuers| {
                 // Ensure we don't have too many issuers now in total.
                 let new_count = issuers.len().saturating_add(1);
-                ensure_length_ok::<T>(new_count as u32)?;
+                ensure_length_ok::<T>(new_count)?;
 
                 // Ensure the new issuer is new.
                 ensure!(!issuers.contains(&issuer), Error::<T>::IncorrectOperationOnTrustedIssuer);
@@ -621,7 +621,7 @@ impl<T: Trait> Module<T> {
 
     fn ensure_issuers_in_req_limited(req: &ComplianceRequirement) -> DispatchResult {
         req.conditions().try_for_each(|cond| {
-            ensure_length_ok::<T>(cond.issuers.len() as u32)?;
+            ensure_length_ok::<T>(cond.issuers.len())?;
             cond.issuers
                 .iter()
                 .try_for_each(Self::ensure_issuer_limited)
@@ -631,7 +631,7 @@ impl<T: Trait> Module<T> {
     fn ensure_issuer_limited(issuer: &TrustedIssuer) -> DispatchResult {
         match &issuer.trusted_for {
             TrustedFor::Any => Ok(()),
-            TrustedFor::Specific(cts) => ensure_length_ok::<T>(cts.len() as u32),
+            TrustedFor::Specific(cts) => ensure_length_ok::<T>(cts.len()),
         }
     }
 }

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -581,7 +581,6 @@ impl<T: Trait> Module<T> {
         asset_compliance: &[ComplianceRequirement],
         default_issuer_complexity: usize,
     ) -> DispatchResult {
-        dbg!(default_issuer_complexity);
         let complexity = asset_compliance
             .iter()
             .flat_map(|requirement| {

--- a/pallets/contracts/Cargo.toml
+++ b/pallets/contracts/Cargo.toml
@@ -20,6 +20,7 @@ wat = { version = "1.0", optional = true, default-features = false }
 parity-wasm = { version = "0.41.0", default-features = false }
 
 # Polymesh specific
+pallet-base = { path = "../base", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 polymesh-common-utilities = { path = "../common", default-features = false }

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -427,9 +427,7 @@ decl_module! {
             // Ensure whether the extrinsic is signed & validate the `code_hash`.
             let (did, _) = Self::ensure_signed_and_template_exists(origin, code_hash)?;
             // Ensure URL is limited in length.
-            if let Some(url) = &new_url {
-                ensure_string_limited::<T>(url)?;
-            }
+            ensure_opt_string_limited::<T>(new_url.as_deref())?;
             // Update the usage fee for a given code hash.
             let old_url = <MetadataOfTemplate<T>>::mutate(&code_hash, |metadata| mem::replace(&mut metadata.url, new_url.clone()));
             // Emit event with old and new url.

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::{
     weights::{DispatchClass::Operational, Weight},
 };
 use frame_system::ensure_root;
-use pallet_base::ensure_string_limited;
+use pallet_base::{ensure_opt_string_limited, ensure_string_limited};
 use pallet_contracts::{BalanceOf, CodeHash, ContractAddressFor, Gas, Schedule};
 use pallet_identity as identity;
 use polymesh_common_utilities::{
@@ -237,9 +237,7 @@ decl_module! {
 
             // Ensure strings are limited in length.
             ensure_string_limited::<T>(&meta_info.description)?;
-            if let Some(url) = &meta_info.url {
-                ensure_string_limited::<T>(url)?;
-            }
+            ensure_opt_string_limited::<T>(meta_info.url.as_deref())?;
             if let SmartExtensionType::Custom(ty) = &meta_info.se_type {
                 ensure_string_limited::<T>(ty)?;
             }

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -29,6 +29,7 @@ use frame_support::{
     weights::{DispatchClass::Operational, Weight},
 };
 use frame_system::ensure_root;
+use pallet_base::ensure_string_limited;
 use pallet_contracts::{BalanceOf, CodeHash, ContractAddressFor, Gas, Schedule};
 use pallet_identity as identity;
 use polymesh_common_utilities::{
@@ -235,12 +236,12 @@ decl_module! {
             let did = Identity::<T>::ensure_perms(origin.clone())?;
 
             // Ensure strings are limited in length.
-            pallet_base::ensure_string_limited::<T>(&meta_info.description)?;
+            ensure_string_limited::<T>(&meta_info.description)?;
             if let Some(url) = &meta_info.url {
-                pallet_base::ensure_string_limited::<T>(url)?;
+                ensure_string_limited::<T>(url)?;
             }
             if let SmartExtensionType::Custom(ty) = &meta_info.se_type {
-                pallet_base::ensure_string_limited::<T>(ty)?;
+                ensure_string_limited::<T>(ty)?;
             }
 
             // Save metadata related to the SE template
@@ -389,7 +390,6 @@ decl_module! {
             Ok(())
         }
 
-
         /// Change the usage fee & the instantiation fee of the smart extension template
         ///
         /// # Arguments
@@ -418,7 +418,6 @@ decl_module! {
             Ok(())
         }
 
-
         /// Change the template meta url.
         ///
         /// # Arguments
@@ -431,7 +430,7 @@ decl_module! {
             let (did, _) = Self::ensure_signed_and_template_exists(origin, code_hash)?;
             // Ensure URL is limited in length.
             if let Some(url) = &new_url {
-                pallet_base::ensure_string_limited::<T>(url)?;
+                ensure_string_limited::<T>(url)?;
             }
             // Update the usage fee for a given code hash.
             let old_url = <MetadataOfTemplate<T>>::mutate(&code_hash, |metadata| mem::replace(&mut metadata.url, new_url.clone()));

--- a/pallets/corporate-actions/Cargo.toml
+++ b/pallets/corporate-actions/Cargo.toml
@@ -12,6 +12,7 @@ polymesh-common-utilities = { path = "../common", default-features = false }
 
 # Our Pallets
 pallet-balances = { path = "../balances", default-features = false }
+pallet-base = { path = "../base", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-asset = { path = "../asset", default-features = false }
 pallet-portfolio = { path = "../portfolio", default-features = false }

--- a/pallets/corporate-actions/src/ballot/mod.rs
+++ b/pallets/corporate-actions/src/ballot/mod.rs
@@ -90,6 +90,7 @@ use frame_support::{
     weights::Weight,
 };
 use pallet_asset::checkpoint;
+use pallet_base::ensure_string_limited;
 use pallet_identity as identity;
 use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee, ProtocolOp};
 use polymesh_common_utilities::CommonTrait;
@@ -647,12 +648,12 @@ impl<T: Trait> Module<T> {
 
     /// Ensure that no string embedded within `meta` is too long.
     fn ensure_meta_lengths_limited(meta: &BallotMeta) -> DispatchResult {
-        pallet_base::ensure_string_limited::<T>(&meta.title)?;
+        ensure_string_limited::<T>(&meta.title)?;
         for motion in &meta.motions {
-            pallet_base::ensure_string_limited::<T>(&motion.title)?;
-            pallet_base::ensure_string_limited::<T>(&motion.info_link)?;
+            ensure_string_limited::<T>(&motion.title)?;
+            ensure_string_limited::<T>(&motion.info_link)?;
             for choice in &motion.choices {
-                pallet_base::ensure_string_limited::<T>(choice)?;
+                ensure_string_limited::<T>(choice)?;
             }
         }
         Ok(())

--- a/pallets/corporate-actions/src/ballot/mod.rs
+++ b/pallets/corporate-actions/src/ballot/mod.rs
@@ -320,6 +320,7 @@ decl_module! {
         /// - `RecordDateAfterStart` if `date > range.start` where `date` is the CA's record date.
         /// - `AlreadyExists` if there's a ballot already.
         /// - `NumberOfChoicesOverflow` if the total choice in `meta` overflows `usize`.
+        /// - `TooLong` if any of the embedded strings in `meta` are too long.
         /// - `InsufficientBalance` if the protocol fee couldn't be charged.
         #[weight = <T as Trait>::BallotWeightInfo::attach_ballot(meta.saturating_num_choices())]
         pub fn attach_ballot(origin, ca_id: CAId, range: BallotTimeRange, meta: BallotMeta, rcv: bool) {
@@ -334,6 +335,7 @@ decl_module! {
 
             // Compute number-of-choices-in-motion cache.
             let choices = Self::derive_motion_num_choices(&meta.motions)?;
+            Self::ensure_meta_lengths_limited(&meta)?;
 
             // Charge protocol fee.
             T::ProtocolFee::charge_fee(ProtocolOp::BallotAttachBallot)?;
@@ -495,6 +497,7 @@ decl_module! {
         /// - `NoSuchBallot` if `ca_id` does not identify a ballot.
         /// - `VotingAlreadyStarted` if `start >= now`, where `now` is the current time.
         /// - `NumberOfChoicesOverflow` if the total choice in `meta` overflows `usize`.
+        /// - `TooLong` if any of the embedded strings in `meta` are too long.
         #[weight = <T as Trait>::BallotWeightInfo::change_meta(meta.saturating_num_choices())]
         pub fn change_meta(origin, ca_id: CAId, meta: BallotMeta) {
             // Ensure origin is CAA, a ballot exists, start is in the future.
@@ -503,6 +506,7 @@ decl_module! {
 
             // Compute number-of-choices-in-motion cache.
             let choices = Self::derive_motion_num_choices(&meta.motions)?;
+            Self::ensure_meta_lengths_limited(&meta)?;
 
             // Commit metadata to storage + emit event.
             MotionNumChoices::insert(ca_id, choices);
@@ -638,6 +642,19 @@ impl<T: Trait> Module<T> {
 
         // Emit event.
         Self::deposit_event(Event::<T>::Removed(caa, ca_id));
+        Ok(())
+    }
+
+    /// Ensure that no string embedded within `meta` is too long.
+    fn ensure_meta_lengths_limited(meta: &BallotMeta) -> DispatchResult {
+        pallet_base::ensure_string_limited::<T>(&meta.title)?;
+        for motion in &meta.motions {
+            pallet_base::ensure_string_limited::<T>(&motion.title)?;
+            pallet_base::ensure_string_limited::<T>(&motion.info_link)?;
+            for choice in &motion.choices {
+                pallet_base::ensure_string_limited::<T>(choice)?;
+            }
+        }
         Ok(())
     }
 

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 pallet-balances = { path = "../balances", default-features = false }
+pallet-base = { path = "../base", default-features = false }
 pallet-permissions = { path = "../permissions", default-features = false }
 polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -98,6 +98,7 @@ use frame_support::{
     StorageDoubleMap,
 };
 use frame_system::{self as system, ensure_root, ensure_signed, RawOrigin};
+use pallet_base::{ensure_length_ok, ensure_string_limited};
 use pallet_permissions::with_call_metadata;
 pub use polymesh_common_utilities::traits::identity::WeightInfo;
 use polymesh_common_utilities::{
@@ -123,7 +124,7 @@ use polymesh_primitives::{
     storage_migrate_on, storage_migration_ver, Authorization, AuthorizationData,
     AuthorizationError, AuthorizationType, CddId, Claim, ClaimType, DispatchableName,
     Identity as DidRecord, IdentityClaim, IdentityId, InvestorUid, InvestorZKProofData, PalletName,
-    Permissions, Scope, SecondaryKey, Signatory, Ticker, ValidProofOfInvestor,
+    Permissions, Scope, SecondaryKey, Signatory, SubsetRestriction, Ticker, ValidProofOfInvestor,
 };
 use sp_core::sr25519::Signature;
 use sp_io::hashing::blake2_256;
@@ -559,6 +560,9 @@ decl_module! {
             expiry: Option<T::Moment>
         ) {
             let from_did = Self::ensure_perms(origin)?;
+            if let AuthorizationData::JoinIdentity(perms) = &authorization_data {
+                Self::ensure_perms_limited(perms)?;
+            }
             Self::add_auth(from_did, target, authorization_data, expiry);
         }
 
@@ -684,9 +688,16 @@ decl_module! {
             };
             let auth_encoded = authorization.encode();
 
+            let mut record = <DidRecords<T>>::get(did);
+
+            // Ensure we won't have too many keys.
+            ensure_length_ok::<T>(record.secondary_keys.len().saturating_add(additional_keys.len()) as u32)?;
+
             // 1. Verify signatures.
             for si_with_auth in additional_keys.iter() {
                 let si: SecondaryKey<T::AccountId> = si_with_auth.secondary_key.clone().into();
+
+                Self::ensure_perms_limited(&si.permissions)?;
 
                 // Get account_id from signer
                 let account_id = match si.signer {
@@ -735,9 +746,8 @@ decl_module! {
                 }
             });
             // 2.2. Update that identity information and its offchain authorization nonce.
-            <DidRecords<T>>::mutate(did, |record| {
-                (*record).add_secondary_keys(additional_keys_si.iter().map(|sk| sk.clone().into()));
-            });
+            record.add_secondary_keys(additional_keys_si.iter().map(|sk| sk.clone().into()));
+            <DidRecords<T>>::insert(did, record);
             OffChainAuthorizationNonce::mutate(did, |offchain_nonce| {
                 *offchain_nonce = authorization.nonce + 1;
             });
@@ -1182,6 +1192,8 @@ impl<T: Trait> Module<T> {
         signer: &Signatory<T::AccountId>,
         mut permissions: Permissions,
     ) -> DispatchResult {
+        Self::ensure_perms_limited(&permissions)?;
+
         let mut new_s_item: Option<SecondaryKey<T::AccountId>> = None;
 
         <DidRecords<T>>::mutate(target_did, |record| {
@@ -1486,12 +1498,12 @@ impl<T: Trait> Module<T> {
         MultiPurposeNonce::put(&new_nonce);
 
         // 1 Check constraints.
-        // 1.1. Primary key is not linked to any identity.
+        // Primary key is not linked to any identity.
         ensure!(
             Self::can_link_account_key_to_did(&sender),
             Error::<T>::AlreadyLinked
         );
-        // 1.2. Primary key is not part of secondary keys.
+        // Primary key is not part of secondary keys.
         ensure!(
             !secondary_keys
                 .iter()
@@ -1502,11 +1514,11 @@ impl<T: Trait> Module<T> {
         let block_hash = <system::Module<T>>::block_hash(<system::Module<T>>::block_number());
         let did = IdentityId(blake2_256(&(USER, block_hash, new_nonce).encode()));
 
-        // 1.3. Make sure there's no pre-existing entry for the DID
+        // Make sure there's no pre-existing entry for the DID
         // This should never happen but just being defensive here
         Self::ensure_no_id_record(did)?;
 
-        // 1.4. Secondary keys can be linked to the new identity.
+        // Secondary keys can be linked to the new identity.
         for sk in &secondary_keys {
             if let Signatory::Account(ref key) = sk.signer {
                 ensure!(
@@ -1516,7 +1528,7 @@ impl<T: Trait> Module<T> {
             }
         }
 
-        // 1.5. Charge the given fee.
+        // Charge the given fee.
         if let Some(op) = protocol_fee_data {
             T::ProtocolFee::charge_fee(op)?;
         }
@@ -1549,6 +1561,28 @@ impl<T: Trait> Module<T> {
                 .collect(),
         ));
         Ok(did)
+    }
+
+    fn ensure_perms_limited(perms: &Permissions) -> DispatchResult {
+        if let Some(len) = perms.asset.elems_len() {
+            ensure_length_ok::<T>(len as u32)?;
+        }
+        if let Some(len) = perms.portfolio.elems_len() {
+            ensure_length_ok::<T>(len as u32)?;
+        }
+        if let SubsetRestriction(Some(set)) = &perms.extrinsic {
+            ensure_length_ok::<T>(set.len() as u32)?;
+            for elem in set {
+                ensure_string_limited::<T>(&elem.pallet_name)?;
+                if let SubsetRestriction(Some(set)) = &elem.dispatchable_names {
+                    ensure_length_ok::<T>(set.len() as u32)?;
+                    for elem in set {
+                        ensure_string_limited::<T>(elem)?;
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     /// It adds a new claim without any previous security check.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -2030,11 +2030,6 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    /// Emit an unexpected error event that should be investigated manually
-    pub fn emit_unexpected_error(error: Option<DispatchError>) {
-        Self::deposit_event(RawEvent::UnexpectedError(error));
-    }
-
     #[cfg(feature = "runtime-benchmarks")]
     /// Links a did with an identity
     pub fn link_did(account: T::AccountId, did: IdentityId) {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -691,7 +691,7 @@ decl_module! {
             let mut record = <DidRecords<T>>::get(did);
 
             // Ensure we won't have too many keys.
-            ensure_length_ok::<T>(record.secondary_keys.len().saturating_add(additional_keys.len()) as u32)?;
+            ensure_length_ok::<T>(record.secondary_keys.len().saturating_add(additional_keys.len()))?;
 
             // 1. Verify signatures.
             for si_with_auth in additional_keys.iter() {
@@ -1565,17 +1565,17 @@ impl<T: Trait> Module<T> {
 
     fn ensure_perms_length_limited(perms: &Permissions) -> DispatchResult {
         if let Some(len) = perms.asset.elems_len() {
-            ensure_length_ok::<T>(len as u32)?;
+            ensure_length_ok::<T>(len)?;
         }
         if let Some(len) = perms.portfolio.elems_len() {
-            ensure_length_ok::<T>(len as u32)?;
+            ensure_length_ok::<T>(len)?;
         }
         if let SubsetRestriction(Some(set)) = &perms.extrinsic {
-            ensure_length_ok::<T>(set.len() as u32)?;
+            ensure_length_ok::<T>(set.len())?;
             for elem in set {
                 ensure_string_limited::<T>(&elem.pallet_name)?;
                 if let SubsetRestriction(Some(set)) = &elem.dispatchable_names {
-                    ensure_length_ok::<T>(set.len() as u32)?;
+                    ensure_length_ok::<T>(set.len())?;
                     for elem in set {
                         ensure_string_limited::<T>(elem)?;
                     }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -561,7 +561,7 @@ decl_module! {
         ) {
             let from_did = Self::ensure_perms(origin)?;
             if let AuthorizationData::JoinIdentity(perms) = &authorization_data {
-                Self::ensure_perms_limited(perms)?;
+                Self::ensure_perms_length_limited(perms)?;
             }
             Self::add_auth(from_did, target, authorization_data, expiry);
         }
@@ -697,7 +697,7 @@ decl_module! {
             for si_with_auth in additional_keys.iter() {
                 let si: SecondaryKey<T::AccountId> = si_with_auth.secondary_key.clone().into();
 
-                Self::ensure_perms_limited(&si.permissions)?;
+                Self::ensure_perms_length_limited(&si.permissions)?;
 
                 // Get account_id from signer
                 let account_id = match si.signer {
@@ -1192,7 +1192,7 @@ impl<T: Trait> Module<T> {
         signer: &Signatory<T::AccountId>,
         mut permissions: Permissions,
     ) -> DispatchResult {
-        Self::ensure_perms_limited(&permissions)?;
+        Self::ensure_perms_length_limited(&permissions)?;
 
         let mut new_s_item: Option<SecondaryKey<T::AccountId>> = None;
 
@@ -1563,7 +1563,7 @@ impl<T: Trait> Module<T> {
         Ok(did)
     }
 
-    fn ensure_perms_limited(perms: &Permissions) -> DispatchResult {
+    fn ensure_perms_length_limited(perms: &Permissions) -> DispatchResult {
         if let Some(len) = perms.asset.elems_len() {
             ensure_length_ok::<T>(len as u32)?;
         }

--- a/pallets/pips/Cargo.toml
+++ b/pallets/pips/Cargo.toml
@@ -13,6 +13,7 @@ polymesh-runtime-common = { path = "../runtime/common", default-features = false
 pallet-group = { path = "../group", default-features = false }
 pallet-identity = { path = "../identity", default-features = false }
 pallet-balances = { path = "../balances", default-features = false }
+pallet-base = { path = "../base", default-features = false }
 pallet-treasury = { path = "../treasury", default-features = false }
 
 # General

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -117,6 +117,7 @@ use polymesh_common_utilities::{
     },
     with_transaction, CommonTrait, Context, MaybeBlock, GC_DID,
 };
+use pallet_base::ensure_string_limited;
 use polymesh_primitives::IdentityId;
 use polymesh_primitives_derive::VecU8StrongTyped;
 use polymesh_runtime_common::PipsEnactSnapshotMaximumWeight;
@@ -398,6 +399,7 @@ pub trait Trait:
     + pallet_timestamp::Trait
     + IdentityTrait
     + CommonTrait
+    + pallet_base::Trait
 {
     /// Currency type for this module.
     type Currency: LockableCurrencyExt<Self::AccountId, Moment = Self::BlockNumber>;
@@ -724,12 +726,20 @@ decl_module! {
             url: Option<Url>,
             description: Option<PipDescription>,
         ) {
-            // 1. Infer the proposer from `origin`.
+            // Infer the proposer from `origin`.
             let proposer = Self::ensure_infer_proposer(origin)?;
 
             let did = Self::current_did_or_missing()?;
 
-            // 2. Add a deposit for community PIPs.
+            // Ensure strings are limited in length.
+            if let Some(s) = &url {
+                ensure_string_limited::<T>(s)?;
+            }
+            if let Some(s) = &description {
+                ensure_string_limited::<T>(s)?;
+            }
+
+            // Add a deposit for community PIPs.
             if let Proposer::Community(ref proposer) = proposer {
                 // ...but first make sure active PIP limit isn't crossed.
                 // This doesn't apply to committee PIPs.
@@ -747,10 +757,10 @@ decl_module! {
                 ensure!(deposit.is_zero(), Error::<T>::NotFromCommunity);
             }
 
-            // 3. Charge protocol fees, even for committee PIPs.
+            // Charge protocol fees, even for committee PIPs.
             <T as IdentityTrait>::ProtocolFee::charge_fee(ProtocolOp::PipsPropose)?;
 
-            // 4. Construct and add PIP to storage.
+            // Construct and add PIP to storage.
             let id = Self::next_pip_id();
             let created_at = <system::Module<T>>::block_number();
             let expiry = Self::pending_pip_expiry() + created_at;
@@ -772,12 +782,12 @@ decl_module! {
             });
             ActivePipCount::mutate(|count| *count += 1);
 
-            // 5. Schedule for expiry, as long as `Pending`, at block with number `expiring_at`.
+            // Schedule for expiry, as long as `Pending`, at block with number `expiring_at`.
             if let MaybeBlock::Some(expiring_at) = expiry {
                 Self::schedule_pip_for_expiry(id, expiring_at);
             }
 
-            // 6. Record the deposit and as a signal if we have a community PIP.
+            // Record the deposit and as a signal if we have a community PIP.
             if let Proposer::Community(ref proposer) = proposer {
                 <Deposits<T>>::insert(id, &proposer, DepositInfo {
                     owner: proposer.clone(),
@@ -798,7 +808,7 @@ decl_module! {
                 CommitteePips::append(id);
             }
 
-            // 7. Emit the event.
+            // Emit the event.
             Self::deposit_event(RawEvent::ProposalCreated(
                 did,
                 proposer,

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -95,7 +95,7 @@ use codec::{Decode, Encode, FullCodec};
 use core::{cmp::Ordering, mem};
 use frame_support::{
     debug, decl_error, decl_event, decl_module, decl_storage,
-    dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo},
+    dispatch::{DispatchResult, DispatchResultWithPostInfo},
     ensure,
     storage::IterableStorageMap,
     traits::{
@@ -106,7 +106,7 @@ use frame_support::{
     StorageValue,
 };
 use frame_system::{self as system, ensure_root, ensure_signed, RawOrigin};
-use pallet_base::ensure_string_limited;
+use pallet_base::ensure_opt_string_limited;
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
     constants::{schedule_name_prefix::*, PIP_MAX_REPORTING_SIZE},
@@ -734,7 +734,6 @@ decl_module! {
             // Ensure strings are limited in length.
             ensure_opt_string_limited::<T>(url.as_deref())?;
             ensure_opt_string_limited::<T>(description.as_deref())?;
-            let proposal_data = Self::reportable_proposal_data(&*proposal)?;
 
             // Add a deposit for community PIPs.
             if let Proposer::Community(ref proposer) = proposer {
@@ -762,6 +761,7 @@ decl_module! {
             let created_at = <system::Module<T>>::block_number();
             let expiry = Self::pending_pip_expiry() + created_at;
             let transaction_version = <T::Version as Get<RuntimeVersion>>::get().transaction_version;
+            let proposal_data = Self::reportable_proposal_data(&*proposal);
             <ProposalMetadata<T>>::insert(id, PipsMetadata {
                 id,
                 created_at,
@@ -1558,17 +1558,15 @@ impl<T: Trait> Module<T> {
         queue
     }
 
-    /// Returns a reportable representation of a proposal taking care that the reported data are not
-    /// too large.
-    fn reportable_proposal_data(proposal: &T::Proposal) -> Result<ProposalData, DispatchError> {
+    /// Returns a reportable representation of a proposal,
+    /// taking care that the reported data isn't too large.
+    fn reportable_proposal_data(proposal: &T::Proposal) -> ProposalData {
         let encoded_proposal = proposal.encode();
-        let proposal_data = if encoded_proposal.len() > PIP_MAX_REPORTING_SIZE {
+        if encoded_proposal.len() > PIP_MAX_REPORTING_SIZE {
             ProposalData::Hash(BlakeTwo256::hash(encoded_proposal.as_slice()))
         } else {
-            ensure_string_limited::<T>(&encoded_proposal)?;
             ProposalData::Proposal(encoded_proposal)
-        };
-        Ok(proposal_data)
+        }
     }
 }
 

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -95,7 +95,7 @@ use codec::{Decode, Encode, FullCodec};
 use core::{cmp::Ordering, mem};
 use frame_support::{
     debug, decl_error, decl_event, decl_module, decl_storage,
-    dispatch::{DispatchResult, DispatchError, DispatchResultWithPostInfo},
+    dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo},
     ensure,
     storage::IterableStorageMap,
     traits::{
@@ -106,6 +106,7 @@ use frame_support::{
     StorageValue,
 };
 use frame_system::{self as system, ensure_root, ensure_signed, RawOrigin};
+use pallet_base::ensure_string_limited;
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
     constants::{schedule_name_prefix::*, PIP_MAX_REPORTING_SIZE},
@@ -117,7 +118,6 @@ use polymesh_common_utilities::{
     },
     with_transaction, CommonTrait, Context, MaybeBlock, GC_DID,
 };
-use pallet_base::ensure_string_limited;
 use polymesh_primitives::IdentityId;
 use polymesh_primitives_derive::VecU8StrongTyped;
 use polymesh_runtime_common::PipsEnactSnapshotMaximumWeight;

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -732,12 +732,8 @@ decl_module! {
             let did = Self::current_did_or_missing()?;
 
             // Ensure strings are limited in length.
-            if let Some(s) = &url {
-                ensure_string_limited::<T>(s)?;
-            }
-            if let Some(s) = &description {
-                ensure_string_limited::<T>(s)?;
-            }
+            ensure_opt_string_limited::<T>(url.as_deref())?;
+            ensure_opt_string_limited::<T>(description.as_deref())?;
             let proposal_data = Self::reportable_proposal_data(&*proposal)?;
 
             // Add a deposit for community PIPs.

--- a/pallets/portfolio/Cargo.toml
+++ b/pallets/portfolio/Cargo.toml
@@ -11,6 +11,7 @@ polymesh-primitives = { path = "../../primitives", default-features = false }
 
 # Our Pallets
 pallet-balances = { path = "../balances", default-features = false  }
+pallet-base = { path = "../base", default-features = false  }
 pallet-identity = { path = "../identity", default-features = false  }
 pallet-permissions = { path = "../permissions", default-features = false }
 

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -82,7 +82,7 @@ pub trait WeightInfo {
     fn rename_portfolio(i: u32) -> Weight;
 }
 
-pub trait Trait: CommonTrait + IdentityTrait {
+pub trait Trait: CommonTrait + IdentityTrait + pallet_base::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     type WeightInfo: WeightInfo;
 }
@@ -382,6 +382,7 @@ impl<T: Trait> Module<T> {
 
     /// Ensures that there is no portfolio with the desired `name` yet.
     fn ensure_name_unique(did: &IdentityId, name: &PortfolioName) -> DispatchResult {
+        pallet_base::ensure_string_limited::<T>(name)?;
         let name_uniq = Portfolios::iter_prefix(&did).all(|n| &n.1 != name);
         ensure!(name_uniq, Error::<T>::PortfolioNameAlreadyInUse);
         Ok(())

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -84,6 +84,11 @@ macro_rules! misc_pallet_impls {
             type SystemWeightInfo = polymesh_weights::frame_system::WeightInfo;
         }
 
+        impl pallet_base::Trait for Runtime {
+            type Event = Event;
+            type MaxLen = MaxLen;
+        }
+
         impl pallet_babe::Trait for Runtime {
             type WeightInfo = polymesh_weights::pallet_babe::WeightInfo;
             type EpochDuration = EpochDuration;

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -18,6 +18,7 @@ polymesh-extensions = { path = "../extensions", default-features = false }
 # Our pallets
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }
+pallet-base = { path = "../../base", default-features = false }
 pallet-bridge = { path = "../../bridge", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -74,7 +74,7 @@ parameter_types! {
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
     // Base:
-    pub const MaxLen: u32 = 256;
+    pub const MaxLen: u32 = 2048;
 
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -73,6 +73,9 @@ parameter_types! {
     pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
+    // Base:
+    pub const MaxLen: u32 = 256;
+
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;
 
@@ -373,6 +376,7 @@ construct_runtime!(
         CapitalDistribution: pallet_capital_distribution::{Module, Call, Storage, Event<T>} = 48,
         Checkpoint: pallet_checkpoint::{Module, Call, Storage, Event<T>, Config} = 49,
         TestUtils: pallet_test_utils::{Module, Call, Storage, Event<T> } = 50,
+        Base: pallet_base::{Module, Call, Event} = 51,
     }
 );
 

--- a/pallets/runtime/itn/Cargo.toml
+++ b/pallets/runtime/itn/Cargo.toml
@@ -18,6 +18,7 @@ polymesh-weights = { path = "../../weights", default-features = false }
 # Our pallets
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }
+pallet-base = { path = "../../base", default-features = false }
 pallet-bridge = { path = "../../bridge", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }
 pallet-compliance-manager = { path = "../../compliance-manager", default-features = false }

--- a/pallets/runtime/itn/src/runtime.rs
+++ b/pallets/runtime/itn/src/runtime.rs
@@ -72,7 +72,7 @@ parameter_types! {
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
     // Base:
-    pub const MaxLen: u32 = 256;
+    pub const MaxLen: u32 = 2048;
 
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;

--- a/pallets/runtime/itn/src/runtime.rs
+++ b/pallets/runtime/itn/src/runtime.rs
@@ -71,6 +71,9 @@ parameter_types! {
     pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
+    // Base:
+    pub const MaxLen: u32 = 256;
+
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;
 
@@ -350,6 +353,7 @@ construct_runtime!(
         Sto: pallet_sto::{Module, Call, Storage, Event<T>} = 42,
         Treasury: pallet_treasury::{Module, Call, Event<T>} = 43,
         Utility: pallet_utility::{Module, Call, Storage, Event} = 44,
+        Base: pallet_base::{Module, Call, Event} = 45,
     }
 );
 

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -18,6 +18,7 @@ polymesh-extensions = { path = "../extensions", default-features = false }
 # Our pallets
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }
+pallet-base = { path = "../../base", default-features = false }
 pallet-sto = { path = "../../sto", default-features = false }
 pallet-bridge = { path = "../../bridge", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -76,7 +76,7 @@ parameter_types! {
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
     // Base:
-    pub const MaxLen: u32 = 256;
+    pub const MaxLen: u32 = 2048;
 
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -75,6 +75,9 @@ parameter_types! {
     pub const EpochDuration: u64 = EPOCH_DURATION_IN_BLOCKS as u64;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 
+    // Base:
+    pub const MaxLen: u32 = 256;
+
     // Indices:
     pub const IndexDeposit: Balance = DOLLARS;
 
@@ -364,6 +367,7 @@ construct_runtime!(
         CapitalDistribution: pallet_capital_distribution::{Module, Call, Storage, Event<T>} = 48,
         Checkpoint: pallet_checkpoint::{Module, Call, Storage, Event<T>, Config} = 49,
         TestUtils: pallet_test_utils::{Module, Call, Storage, Event<T> } = 50,
+        Base: pallet_base::{Module, Call, Event} = 51,
     }
 );
 

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -12,6 +12,7 @@ polymesh-extensions = { path = "../extensions", default-features = false }
 
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }
+pallet-base = { path = "../../base", default-features = false }
 pallet-sto = { path = "../../sto", default-features = false }
 pallet-bridge = { path = "../../bridge", default-features = false }
 pallet-committee = { path = "../../committee", default-features = false }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -214,6 +214,7 @@ impl_outer_event! {
         system<T>,
         balances<T>,
         session,
+        pallet_base,
         pallet_pips<T>,
         pallet_treasury<T>,
         staking<T>,
@@ -246,6 +247,7 @@ parameter_types! {
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MaxLocks: u32 = 50;
+    pub const MaxLen: u32 = 256;
 }
 impl frame_system::Trait for Test {
     type BaseCallFilter = ();
@@ -273,6 +275,11 @@ impl frame_system::Trait for Test {
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
+}
+
+impl pallet_base::Trait for Test {
+    type Event = MetaEvent;
+    type MaxLen = MaxLen;
 }
 
 impl CommonTrait for Test {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -113,6 +113,7 @@ impl_outer_event! {
         identity<T>,
         balances<T>,
         multisig<T>,
+        pallet_base,
         bridge<T>,
         asset<T>,
         pips<T>,
@@ -294,6 +295,10 @@ impl CommonTrait for TestStorage {
     type Balance = Balance;
     type AssetSubTraitTarget = Asset;
     type BlockRewardsReserve = balances::Module<TestStorage>;
+}
+
+impl pallet_base::Trait for TestStorage {
+    type Event = Event;
 }
 
 impl balances::Trait for TestStorage {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -289,6 +289,7 @@ impl frame_system::Trait for TestStorage {
 parameter_types! {
     pub const ExistentialDeposit: u64 = 0;
     pub const MaxLocks: u32 = 50;
+    pub const MaxLen: u32 = 256;
 }
 
 impl CommonTrait for TestStorage {
@@ -299,6 +300,7 @@ impl CommonTrait for TestStorage {
 
 impl pallet_base::Trait for TestStorage {
     type Event = Event;
+    type MaxLen = MaxLen;
 }
 
 impl balances::Trait for TestStorage {

--- a/pallets/settlement/Cargo.toml
+++ b/pallets/settlement/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 polymesh-common-utilities = { path = "../common", default-features = false }
 pallet-balances = { path = "../balances", default-features = false  }
+pallet-base = { path = "../base", default-features = false  }
 pallet-portfolio = { path = "../portfolio", default-features = false  }
 pallet-identity = { path = "../identity", default-features = false  }
 pallet-asset = { path = "../asset", default-features = false  }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -64,6 +64,7 @@ use frame_support::{
 };
 use frame_system::{self as system, ensure_root, RawOrigin};
 use pallet_asset as asset;
+use pallet_base::ensure_string_limited;
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::{
     constants::{
@@ -500,6 +501,7 @@ decl_module! {
         #[weight = <T as Trait>::WeightInfo::create_venue(details.len() as u32, signers.len() as u32)]
         pub fn create_venue(origin, details: VenueDetails, signers: Vec<T::AccountId>, venue_type: VenueType) {
             let did = Identity::<T>::ensure_perms(origin)?;
+            ensure_string_limited::<T>(&details)?;
             let venue = Venue::new(did, details, venue_type);
             // NB: Venue counter starts with 1.
             let venue_counter = VenueCounter::mutate(|c| mem::replace(c, *c + 1));
@@ -527,6 +529,7 @@ decl_module! {
 
                 // Update details & type.
                 if let Some(details) = details {
+                    ensure_string_limited::<T>(&details)?;
                     venue.details = details;
                 }
                 if let Some(typ) = typ {

--- a/pallets/sto/Cargo.toml
+++ b/pallets/sto/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 pallet-asset = { path = "../asset", default-features = false  }
 pallet-balances = { path = "../balances", default-features = false  }
+pallet-base = { path = "../base", default-features = false  }
 pallet-compliance-manager = { path = "../compliance-manager", default-features = false  }
 pallet-identity = { path = "../identity", default-features = false  }
 pallet-permissions = { path = "../permissions", default-features = false }

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -163,7 +163,7 @@ pub trait WeightInfo {
     fn stop() -> Weight;
 }
 
-pub trait Trait: frame_system::Trait + IdentityTrait + SettlementTrait + PortfolioTrait {
+pub trait Trait: frame_system::Trait + IdentityTrait + SettlementTrait + PortfolioTrait + pallet_base::Trait {
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     /// Weight information for extrinsic of the sto pallet.
@@ -283,6 +283,8 @@ decl_module! {
             minimum_investment: T::Balance,
             fundraiser_name: FundraiserName
         ) {
+            pallet_base::ensure_string_limited::<T>(&fundraiser_name)?;
+
             let (did, secondary_key) = Self::ensure_perms_pia(origin, &offering_asset)?;
 
             VenueInfo::get(venue_id)

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -163,7 +163,9 @@ pub trait WeightInfo {
     fn stop() -> Weight;
 }
 
-pub trait Trait: frame_system::Trait + IdentityTrait + SettlementTrait + PortfolioTrait + pallet_base::Trait {
+pub trait Trait:
+    frame_system::Trait + IdentityTrait + SettlementTrait + PortfolioTrait + pallet_base::Trait
+{
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
     /// Weight information for extrinsic of the sto pallet.

--- a/primitives/src/compliance_manager.rs
+++ b/primitives/src/compliance_manager.rs
@@ -44,6 +44,13 @@ impl ComplianceRequirement {
         dedup_condition(&mut self.sender_conditions);
         dedup_condition(&mut self.receiver_conditions);
     }
+
+    /// Returns an iterator for all conditions in this requirement.
+    pub fn conditions(&self) -> impl Iterator<Item = &Condition> {
+        self.sender_conditions
+            .iter()
+            .chain(self.receiver_conditions.iter())
+    }
 }
 
 /// A compliance requirement along with its evaluation result

--- a/primitives/src/condition.rs
+++ b/primitives/src/condition.rs
@@ -104,20 +104,6 @@ impl TrustedIssuer {
             TrustedFor::Specific(ok_types) => ok_types.contains(&ty),
         }
     }
-
-    /// The complexity incurred from this trusted issuer.
-    pub fn complexity(&self) -> usize {
-        match &self.trusted_for {
-            TrustedFor::Any => 1,
-            TrustedFor::Specific(cts) => cts.len(),
-        }
-    }
-}
-
-/// Total complexity of a set of trusted issuers.
-pub fn trusted_issuers_complexity(tis: &[TrustedIssuer]) -> usize {
-    tis.iter()
-        .fold(0, |acc, ti| acc.saturating_add(ti.complexity()))
 }
 
 /// Create a `TrustedIssuer` trusted for any claim type.
@@ -173,10 +159,7 @@ impl Condition {
 
     /// Returns worst case complexity of a condition
     pub fn complexity(&self) -> (usize, usize) {
-        (
-            self.condition_type.complexity(),
-            trusted_issuers_complexity(&self.issuers),
-        )
+        (self.condition_type.complexity(), self.issuers.len())
     }
 }
 

--- a/primitives/src/condition.rs
+++ b/primitives/src/condition.rs
@@ -163,6 +163,13 @@ impl Condition {
                 claims.len()
             }
         };
-        (claims_count, self.issuers.len())
+        let tfs = self
+            .issuers
+            .iter()
+            .fold(0usize, |acc, ti| match &ti.trusted_for {
+                TrustedFor::Any => acc,
+                TrustedFor::Specific(cts) => acc.saturating_add(cts.len()),
+            });
+        (claims_count, self.issuers.len().saturating_add(tfs))
     }
 }


### PR DESCRIPTION
## changelog

### modified logic

- A base pallet has been added; moving `UnexpectedError` event from the pallet Identity to Base.
  The base pallet has an error `TooLong` that is triggered in cases listed below (protected, accounted for, etc.).
- `TrustedFor::Specific` is accounted for in complexity restrictions in the compliance manager.
- `Portfolio::{create_portfolio, rename_portfolio}` is now protected.
- TODO: more cases covered