### PR TITLE
Minor GC related fixes

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -814,7 +814,6 @@ decl_module! {
         pub fn gc_add_cdd_claim(
             origin,
             target: IdentityId,
-            expiry: Option<T::Moment>,
         ) {
             T::GCVotingMajorityOrigin::ensure_origin(origin)?;
             Self::add_systematic_cdd_claims(&[target], SystematicIssuers::Committee);

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -815,9 +815,9 @@ decl_module! {
             origin,
             target: IdentityId,
             expiry: Option<T::Moment>,
-        ) -> DispatchResult {
+        ) {
             T::GCVotingMajorityOrigin::ensure_origin(origin)?;
-            Self::base_add_cdd_claim(target, Claim::default_cdd_id(), GC_DID, expiry)
+            Self::add_systematic_cdd_claims(&[target], SystematicIssuers::Committee);
         }
 
         /// Assuming this is executed by the GC voting majority, removes an existing cdd claim record.

--- a/pallets/runtime/itn/src/runtime.rs
+++ b/pallets/runtime/itn/src/runtime.rs
@@ -299,9 +299,10 @@ construct_runtime!(
         // Polymesh Committees
         // CddServiceProviders: Genesis config deps: Identity
         CddServiceProviders: pallet_group::<Instance2>::{Module, Call, Storage, Event<T>, Config<T>} = 8,
+
+        PolymeshCommittee: pallet_committee::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>} = 10,
         // CommitteeMembership: Genesis config deps: PolymeshCommittee, Identity.
         CommitteeMembership: pallet_group::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>} = 9,
-        PolymeshCommittee: pallet_committee::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>} = 10,
         TechnicalCommittee: pallet_committee::<Instance3>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>} = 11,
         // TechnicalCommitteeMembership: Genesis config deps: TechnicalCommittee, Identity
         TechnicalCommitteeMembership: pallet_group::<Instance3>::{Module, Call, Storage, Event<T>, Config<T>} = 12,

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -22,8 +22,8 @@ use polymesh_common_utilities::{
     SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::{
-    AuthorizationData, AuthorizationType, CddId, Claim, ClaimType, IdentityClaim, IdentityId, InvestorUid,
-    Permissions, Scope, SecondaryKey, Signatory, Ticker, TransactionError,
+    AuthorizationData, AuthorizationType, CddId, Claim, ClaimType, IdentityClaim, IdentityId,
+    InvestorUid, Permissions, Scope, SecondaryKey, Signatory, Ticker, TransactionError,
 };
 use polymesh_runtime_develop::{fee_details::CddHandler, runtime::Call};
 use sp_core::crypto::AccountId32;

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -22,7 +22,7 @@ use polymesh_common_utilities::{
     SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::{
-    AuthorizationData, AuthorizationType, Claim, ClaimType, IdentityClaim, IdentityId, InvestorUid,
+    AuthorizationData, AuthorizationType, CddId, Claim, ClaimType, IdentityClaim, IdentityId, InvestorUid,
     Permissions, Scope, SecondaryKey, Signatory, Ticker, TransactionError,
 };
 use polymesh_runtime_develop::{fee_details::CddHandler, runtime::Call};
@@ -119,19 +119,17 @@ fn gc_add_remove_cdd_claim() {
         let fetch =
             || Identity::fetch_claim(target_did, ClaimType::CustomerDueDiligence, GC_DID, None);
 
-        assert_ok!(Identity::gc_add_cdd_claim(
-            gc_vmo(),
-            target_did,
-            Some(100u64)
-        ));
+        assert_ok!(Identity::gc_add_cdd_claim(gc_vmo(), target_did));
+
+        let cdd_id = CddId::new_v1(target_did, InvestorUid::from(target_did.as_ref()));
         assert_eq!(
             fetch(),
             Some(IdentityClaim {
                 claim_issuer: GC_DID,
                 issuance_date: 0,
                 last_update_date: 0,
-                expiry: Some(100),
-                claim: Claim::default_cdd_id(),
+                expiry: None,
+                claim: Claim::CustomerDueDiligence(cdd_id)
             })
         );
 


### PR DESCRIPTION
- GC committee is now initialized before the GC group so that GC group can add members to the committee
- The `gc_add_cdd_claim`  function now uses `add_systematic_cdd_claims` so that GC does not need to be a CDD issuer