### PR TITLE
MESH-1600, MESH-1601, MESH-1590, MESH-1591

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1627,7 +1627,9 @@ impl<T: Trait> Module<T> {
         Self::ensure_asset_fresh(&ticker)?;
         let ticker_details = Self::ticker_registration(&ticker);
 
-        <Identity<T>>::consume_auth(ticker_details.owner, Signatory::from(to_did), auth_id)?;
+        let signer = Signatory::from(to_did);
+        let auth = <Identity<T>>::check_auth(ticker_details.owner, &signer, auth_id)?;
+        <Identity<T>>::take_auth(&signer, &auth);
 
         Self::transfer_ticker(ticker, to_did, ticker_details.owner);
         ClassicTickers::remove(&ticker); // Not a classic ticker anymore if it was.
@@ -1702,7 +1704,10 @@ impl<T: Trait> Module<T> {
         auth_id: u64,
     ) -> DispatchResult {
         let owner = Self::token_details(ticker).owner_did;
-        <Identity<T>>::consume_auth(owner, Signatory::from(to_did), auth_id)
+        let signer = Signatory::from(to_did);
+        let auth = <Identity<T>>::check_auth(owner, &signer, auth_id)?;
+        <Identity<T>>::take_auth(&signer, &auth);
+        Ok(())
     }
 
     /// RPC: Function allows external users to know whether the transfer extrinsic

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -312,8 +312,8 @@ decl_storage! {
             <identity::Module<T>>::unsafe_join_identity(
                 creator_did,
                 Permissions::default(),
-                Signatory::Account(multisig_id.clone())
-            ).expect("cannot link the bridge multisig");
+                &Signatory::Account(multisig_id.clone())
+            );
             debug::info!("Joined identity {} as signer {}", creator_did, multisig_id);
             multisig_id
         }): T::AccountId;

--- a/pallets/common/src/benchs/asset.rs
+++ b/pallets/common/src/benchs/asset.rs
@@ -10,7 +10,8 @@ use polymesh_primitives::{
 };
 
 use frame_system::RawOrigin;
-use sp_std::{convert::TryFrom, prelude::*};
+use sp_std::convert::TryFrom;
+use sp_std::vec;
 
 pub type ResultTicker = Result<Ticker, &'static str>;
 

--- a/pallets/common/src/benchs/asset.rs
+++ b/pallets/common/src/benchs/asset.rs
@@ -87,23 +87,3 @@ where
 
     Ok(ticker)
 }
-
-/// Given a number, this function generates a ticker with
-/// A-Z, least number of characters in Lexicographic order
-pub fn generate_ticker(n: u64) -> Vec<u8> {
-    fn calc_base26(n: u64, base_26: &mut Vec<u8>) {
-        if n >= 26 {
-            // Subtracting 1 is not required and shouldn't be done for a proper base_26 conversion
-            // However, without this hack, B will be the first char after a bump in number of chars.
-            // i.e. the sequence will go A,B...Z,BA,BB...ZZ,BAA. We want the sequence to start with A.
-            // Subtracting 1 here means we are doing 1 indexing rather than 0.
-            // i.e. A = 1, B = 2 instead of A = 0, B = 1
-            calc_base26((n / 26) - 1, base_26);
-        }
-        let character = n % 26 + 65;
-        base_26.push(character as u8);
-    }
-    let mut base_26 = Vec::new();
-    calc_base26(n, &mut base_26);
-    base_26
-}

--- a/pallets/common/src/benchs/asset.rs
+++ b/pallets/common/src/benchs/asset.rs
@@ -4,14 +4,12 @@ use crate::{
     traits::{asset::AssetFnTrait, identity::Trait as IdentityTrait},
 };
 
+use frame_system::RawOrigin;
 use polymesh_primitives::{
     asset::{AssetName, AssetType},
     Ticker,
 };
-
-use frame_system::RawOrigin;
-use sp_std::convert::TryFrom;
-use sp_std::vec;
+use sp_std::{convert::TryFrom, vec};
 
 pub type ResultTicker = Result<Ticker, &'static str>;
 

--- a/pallets/common/src/benchs/mod.rs
+++ b/pallets/common/src/benchs/mod.rs
@@ -22,7 +22,7 @@ mod user_builder;
 pub use user_builder::{uid_from_name_and_idx, AccountIdOf, UserBuilder};
 
 mod asset;
-pub use asset::{generate_ticker, make_asset, make_indivisible_asset, make_ticker, ResultTicker};
+pub use asset::{make_asset, make_indivisible_asset, make_ticker, ResultTicker};
 
 pub fn user<T: Trait + TestUtilsFn<<T as SysTrait>::AccountId>>(
     prefix: &'static str,

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -251,16 +251,16 @@ decl_module! {
             with_transaction(|| {
                 // Call underlying function
                 <pallet_contracts::Module<T>>::put_code(origin, code)?;
-                // Update the storage.
-                <TemplateInfo<T>>::insert(code_hash, TemplateDetails {
-                    instantiation_fee,
-                    owner: did,
-                    frozen: false
-                });
-                <MetadataOfTemplate<T>>::insert(code_hash, meta_info);
                 // Charge the protocol fee
                 T::ProtocolFee::charge_fee(ProtocolOp::ContractsPutCode)
             })?;
+            // Update the storage.
+            <TemplateInfo<T>>::insert(code_hash, TemplateDetails {
+                instantiation_fee,
+                owner: did,
+                frozen: false
+            });
+            <MetadataOfTemplate<T>>::insert(code_hash, meta_info);
         }
 
         // Simply forwards to the `call` function in the Contract module.

--- a/pallets/corporate-actions/src/ballot/mod.rs
+++ b/pallets/corporate-actions/src/ballot/mod.rs
@@ -107,22 +107,22 @@ type CA<T> = ca::Module<T>;
 
 /// A wrapper for a motion title.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Decode, Encode, VecU8StrongTyped)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Decode, Encode, VecU8StrongTyped)]
 pub struct MotionTitle(pub Vec<u8>);
 
 /// A wrapper for a motion info link.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Decode, Encode, VecU8StrongTyped)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Decode, Encode, VecU8StrongTyped)]
 pub struct MotionInfoLink(pub Vec<u8>);
 
 /// A wrapper for a choice's title.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Decode, Encode, VecU8StrongTyped)]
+#[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Decode, Encode, VecU8StrongTyped)]
 pub struct ChoiceTitle(pub Vec<u8>);
 
 /// Details about motions
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, PartialEq, Eq, Default, Debug, Encode, Decode)]
 pub struct Motion {
     /// Title of the motion
     pub title: MotionTitle,

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -149,7 +149,7 @@ benchmarks! {
         for x in 0..i {
             let signer = Signatory::Account(account("key", x, SEED));
             signatories.push(signer.clone());
-            Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), signer)?;
+            Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), &signer);
         }
     }: _(target.origin, signatories.clone())
 
@@ -240,7 +240,7 @@ benchmarks! {
         let new_user = UserBuilder::<T>::default().generate_did().build("key");
         let signatory = Signatory::Identity(new_user.did());
 
-        Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), signatory)?;
+        Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), &signatory);
 
     }: _(new_user.origin, target.did())
 
@@ -260,7 +260,7 @@ benchmarks! {
         let call: T::Proposal = frame_system::Call::<T>::remark(vec![]).into();
         let boxed_proposal = Box::new(call);
 
-        Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), Signatory::Identity(key.did()))?;
+        Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), &Signatory::Identity(key.did()));
         Module::<T>::set_context_did(Some(key.did()));
     }: _(key.origin, target.did(), boxed_proposal)
 
@@ -274,7 +274,7 @@ benchmarks! {
         let key = UserBuilder::<T>::default().build("key");
         let signatory = Signatory::Account(key.account);
 
-        Module::<T>::unsafe_join_identity(target.did(), Permissions::empty(), signatory.clone())?;
+        Module::<T>::unsafe_join_identity(target.did(), Permissions::empty(), &signatory);
     }: _(target.origin, signatory, Permissions::default().into())
 
     freeze_secondary_keys {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -933,22 +933,23 @@ impl<T: Trait> Module<T> {
         // Not really needed unless we allow identities to be deleted.
         Self::ensure_id_record_exists(auth.authorized_by)?;
 
-        Self::consume_auth(auth.authorized_by, signer.clone(), auth_id)?;
-
-        Self::base_join_identity(auth.authorized_by, permissions.into(), signer)
+        let auth = Self::check_auth(auth.authorized_by, &signer, auth_id)?;
+        Self::base_join_identity(auth.authorized_by, permissions.into(), &signer)?;
+        Self::take_auth(&signer, &auth);
+        Ok(())
     }
 
     /// Joins an identity as signer
     pub fn base_join_identity(
         target_did: IdentityId,
         permissions: Permissions,
-        signer: Signatory<T::AccountId>,
+        signer: &Signatory<T::AccountId>,
     ) -> DispatchResult {
         let charge_fee =
             || T::ProtocolFee::charge_fee(ProtocolOp::IdentityAddSecondaryKeysWithAuthorization);
 
         // Link the secondary key.
-        match &signer {
+        match signer {
             Signatory::Account(key) => {
                 ensure!(
                     Self::can_link_account_key_to_did(key),
@@ -968,23 +969,22 @@ impl<T: Trait> Module<T> {
             Signatory::Identity(_) => charge_fee()?,
         }
 
-        Self::unsafe_join_identity(target_did, permissions, signer)
+        Self::unsafe_join_identity(target_did, permissions, signer);
+        Ok(())
     }
 
     /// Joins an identity as signer
     pub fn unsafe_join_identity(
         target_did: IdentityId,
         permissions: Permissions,
-        signer: Signatory<T::AccountId>,
-    ) -> DispatchResult {
+        signer: &Signatory<T::AccountId>,
+    ) {
         // Link the secondary key.
-        let sk = SecondaryKey::new(signer, permissions);
+        let sk = SecondaryKey::new(signer.clone(), permissions);
         <DidRecords<T>>::mutate(target_did, |identity| {
             identity.add_secondary_keys(iter::once(sk.clone()));
         });
         Self::deposit_event(RawEvent::SecondaryKeysAdded(target_did, vec![sk.into()]));
-
-        Ok(())
     }
 
     /// Adds an authorization.
@@ -1040,29 +1040,33 @@ impl<T: Trait> Module<T> {
         Self::deposit_event(event(id, acc, auth_id))
     }
 
-    /// Consumes an authorization.
+    /// Consumes an authorization, removing it from storage.
+    pub fn take_auth(
+        target: &Signatory<T::AccountId>,
+        auth: &Authorization<T::AccountId, T::Moment>,
+    ) {
+        <Authorizations<T>>::remove(&target, auth.auth_id);
+        <AuthorizationsGiven<T>>::remove(auth.authorized_by, auth.auth_id);
+        Self::deposit_event(RawEvent::AuthorizationConsumed(
+            target.as_identity().cloned(),
+            target.as_account().cloned(),
+            auth.auth_id,
+        ));
+    }
+
     /// Checks if the auth has not expired and the caller is authorized to consume this auth.
-    pub fn consume_auth(
+    pub fn check_auth(
         from: IdentityId,
-        target: Signatory<T::AccountId>,
+        target: &Signatory<T::AccountId>,
         auth_id: u64,
-    ) -> DispatchResult {
-        let auth = Self::ensure_authorization(&target, auth_id)?;
+    ) -> Result<Authorization<T::AccountId, T::Moment>, DispatchError> {
+        let auth = Self::ensure_authorization(target, auth_id)?;
         ensure!(auth.authorized_by == from, AuthorizationError::Unauthorized);
         if let Some(expiry) = auth.expiry {
             let now = <pallet_timestamp::Module<T>>::get();
             ensure!(expiry > now, AuthorizationError::Expired);
         }
-
-        <Authorizations<T>>::remove(&target, auth_id);
-        <AuthorizationsGiven<T>>::remove(auth.authorized_by, auth_id);
-
-        Self::deposit_event(RawEvent::AuthorizationConsumed(
-            target.as_identity().cloned(),
-            target.as_account().cloned(),
-            auth_id,
-        ));
-        Ok(())
+        Ok(auth)
     }
 
     pub fn ensure_authorization(
@@ -1116,8 +1120,10 @@ impl<T: Trait> Module<T> {
             rotation_auth.authorization_data
         {
             // consume owner's authorization
-            Self::consume_auth(rotation_for_did, signer, rotation_auth_id)?;
-            Self::unsafe_primary_key_rotation(sender, rotation_for_did, optional_cdd_auth_id)
+            let auth = Self::check_auth(rotation_for_did, &signer, rotation_auth_id)?;
+            Self::unsafe_primary_key_rotation(sender, rotation_for_did, optional_cdd_auth_id)?;
+            Self::take_auth(&signer, &auth);
+            Ok(())
         } else {
             Err(Error::<T>::UnknownAuthorization.into())
         }
@@ -1143,22 +1149,24 @@ impl<T: Trait> Module<T> {
 
             match cdd_auth.authorization_data {
                 AuthorizationData::AttestPrimaryKeyRotation(ref attestation_for_did) => {
-                    // Attestor must be a CDD service provider
+                    // Attestor must be a CDD service provider.
                     ensure!(
                         T::CddServiceProviders::is_member(&cdd_auth.authorized_by),
                         Error::<T>::NotCddProviderAttestation
                     );
 
-                    // Make sure authorizations are for the same DID
+                    // Ensure authorizations are for the same DID.
                     ensure!(
                         rotation_for_did == *attestation_for_did,
                         Error::<T>::AuthorizationsNotForSameDids
                     );
 
-                    // consume CDD service provider's authorization
-                    // here we pass the known authorising identity to consume_auth, rather than the expected authorising identity
-                    // as we've already checked the validity above
-                    Self::consume_auth(cdd_auth.authorized_by, signer, cdd_auth_id)?;
+                    // Consume CDD service provider's authorization.
+                    // Here we pass the known authorising identity to `check_auth`,
+                    // rather than the expected authorising identity,
+                    // as we've already checked the validity above.
+                    let auth = Self::check_auth(cdd_auth.authorized_by, &signer, cdd_auth_id)?;
+                    Self::take_auth(&signer, &auth);
                 }
                 _ => return Err(Error::<T>::UnknownAuthorization.into()),
             }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -476,7 +476,8 @@ decl_module! {
             let _ = T::ChargeTxFeeTarget::charge_fee(
                 proposal.encode().len().try_into().unwrap_or_default(),
                 proposal.get_dispatch_info())
-                    .map_err(|_| Error::<T>::FailedToChargeFee)?;
+                    .map_err(|_| Error::<T>::FailedToChargeFee,
+            )?;
 
             // 2. Actions
             T::CddHandler::set_current_identity(&target_did);

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -473,11 +473,10 @@ decl_module! {
             );
 
             // 1.5 charge fee
-            let _ = T::ChargeTxFeeTarget::charge_fee(
+            T::ChargeTxFeeTarget::charge_fee(
                 proposal.encode().len().try_into().unwrap_or_default(),
-                proposal.get_dispatch_info())
-                    .map_err(|_| Error::<T>::FailedToChargeFee,
-            )?;
+                proposal.get_dispatch_info()
+            ).map_err(|_| Error::<T>::FailedToChargeFee)?;
 
             // 2. Actions
             T::CddHandler::set_current_identity(&target_did);

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -935,7 +935,7 @@ impl<T: Trait> Module<T> {
 
         let auth = Self::check_auth(auth.authorized_by, &signer, auth_id)?;
         Self::base_join_identity(auth.authorized_by, permissions.into(), &signer)?;
-        Self::take_auth(&signer, &auth);
+        Self::unchecked_take_auth(&signer, &auth);
         Ok(())
     }
 
@@ -1041,7 +1041,7 @@ impl<T: Trait> Module<T> {
     }
 
     /// Consumes an authorization, removing it from storage.
-    pub fn take_auth(
+    pub fn unchecked_take_auth(
         target: &Signatory<T::AccountId>,
         auth: &Authorization<T::AccountId, T::Moment>,
     ) {
@@ -1122,7 +1122,7 @@ impl<T: Trait> Module<T> {
             // consume owner's authorization
             let auth = Self::check_auth(rotation_for_did, &signer, rotation_auth_id)?;
             Self::unsafe_primary_key_rotation(sender, rotation_for_did, optional_cdd_auth_id)?;
-            Self::take_auth(&signer, &auth);
+            Self::unchecked_take_auth(&signer, &auth);
             Ok(())
         } else {
             Err(Error::<T>::UnknownAuthorization.into())
@@ -1166,7 +1166,7 @@ impl<T: Trait> Module<T> {
                     // rather than the expected authorising identity,
                     // as we've already checked the validity above.
                     let auth = Self::check_auth(cdd_auth.authorized_by, &signer, cdd_auth_id)?;
-                    Self::take_auth(&signer, &auth);
+                    Self::unchecked_take_auth(&signer, &auth);
                 }
                 _ => return Err(Error::<T>::UnknownAuthorization.into()),
             }

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1072,7 +1072,7 @@ impl<T: Trait> Module<T> {
         let ms_identity = <MultiSigToIdentity<T>>::get(&multisig);
 
         let auth = <Identity<T>>::check_auth(ms_identity, &signer, auth_id)?;
-        <Identity<T>>::take_auth(&signer, &auth);
+        <Identity<T>>::unchecked_take_auth(&signer, &auth);
         <MultiSigSigners<T>>::insert(multisig.clone(), signer.clone(), signer.clone());
         <NumberOfSigners<T>>::mutate(multisig.clone(), |x| *x += 1u64);
 

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -529,7 +529,7 @@ decl_module! {
         /// # Arguments
         /// * `multi_sig` - multi sig address
         #[weight = <T as Trait>::WeightInfo::make_multisig_signer()]
-        pub fn make_multisig_signer(origin, multisig: T::AccountId) -> DispatchResult {
+        pub fn make_multisig_signer(origin, multisig: T::AccountId) {
             let sender = ensure_signed(origin)?;
             Self::ensure_ms(&multisig)?;
             let sender_did = Context::current_identity_or::<Identity<T>>(&sender)?;
@@ -541,8 +541,8 @@ decl_module! {
                     // it instead of b"_".
                     iter::once(PalletPermissions::entire_pallet(b"multisig".as_ref().into()))
                 ),
-                Signatory::Account(multisig)
-            )
+                &Signatory::Account(multisig)
+            );
         }
 
         /// Adds a multisig as the primary key of the current did if the current DID is the creator
@@ -1071,7 +1071,8 @@ impl<T: Trait> Module<T> {
 
         let ms_identity = <MultiSigToIdentity<T>>::get(&multisig);
 
-        <Identity<T>>::consume_auth(ms_identity, signer.clone(), auth_id)?;
+        let auth = <Identity<T>>::check_auth(ms_identity, &signer, auth_id)?;
+        <Identity<T>>::take_auth(&signer, &auth);
         <MultiSigSigners<T>>::insert(multisig.clone(), signer.clone(), signer.clone());
         <NumberOfSigners<T>>::mutate(multisig.clone(), |x| *x += 1u64);
 

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -16,7 +16,7 @@
 use crate::*;
 use frame_benchmarking::benchmarks;
 use polymesh_common_utilities::{
-    benchs::{generate_ticker, AccountIdOf, UserBuilder},
+    benchs::{AccountIdOf, UserBuilder},
     TestUtilsFn,
 };
 use polymesh_primitives::PortfolioName;
@@ -57,7 +57,7 @@ benchmarks! {
         let a in 1 .. 500;
         let mut items = Vec::with_capacity(a as usize);
         let target = UserBuilder::<T>::default().generate_did().build("target");
-        let first_ticker = Ticker::try_from(generate_ticker(0u64).as_slice()).unwrap();
+        let first_ticker = Ticker::try_from(Ticker::generate(0u64).as_slice()).unwrap();
         let amount = T::Balance::from(10u32);
         let portfolio_name = PortfolioName(vec![65u8; 5]);
         let next_portfolio_num = NextPortfolioNumber::get(&target.did());
@@ -65,7 +65,7 @@ benchmarks! {
         let user_portfolio = PortfolioId::user_portfolio(target.did(), next_portfolio_num.clone());
 
         for x in 0..a as u64 {
-            let ticker = Ticker::try_from(generate_ticker(x).as_slice()).unwrap();
+            let ticker = Ticker::try_from(Ticker::generate(x).as_slice()).unwrap();
             items.push(MovePortfolioItem {
                 ticker,
                 amount: amount,

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -20,7 +20,7 @@ use polymesh_common_utilities::{
     TestUtilsFn,
 };
 use polymesh_primitives::PortfolioName;
-use sp_std::{convert::TryFrom, prelude::*};
+use sp_std::prelude::*;
 
 benchmarks! {
     where_clause { where T: TestUtilsFn<AccountIdOf<T>> }

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -57,7 +57,7 @@ benchmarks! {
         let a in 1 .. 500;
         let mut items = Vec::with_capacity(a as usize);
         let target = UserBuilder::<T>::default().generate_did().build("target");
-        let first_ticker = Ticker::try_from(Ticker::generate(0u64).as_slice()).unwrap();
+        let first_ticker = Ticker::generate_into(0u64);
         let amount = T::Balance::from(10u32);
         let portfolio_name = PortfolioName(vec![65u8; 5]);
         let next_portfolio_num = NextPortfolioNumber::get(&target.did());
@@ -65,7 +65,7 @@ benchmarks! {
         let user_portfolio = PortfolioId::user_portfolio(target.did(), next_portfolio_num.clone());
 
         for x in 0..a as u64 {
-            let ticker = Ticker::try_from(Ticker::generate(x).as_slice()).unwrap();
+            let ticker = Ticker::generate_into(x);
             items.push(MovePortfolioItem {
                 ticker,
                 amount: amount,

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -580,12 +580,9 @@ impl<T: Trait> PortfolioSubTrait<T::Balance, T::AccountId> for Module<T> {
         };
 
         let current_custodian = PortfolioCustodian::get(&portfolio_id).unwrap_or(portfolio_id.did);
-
-        <identity::Module<T>>::consume_auth(
-            current_custodian,
-            Signatory::from(new_custodian),
-            auth_id,
-        )?;
+        let signer = Signatory::from(new_custodian);
+        let auth = <identity::Module<T>>::check_auth(current_custodian, &signer, auth_id)?;
+        <identity::Module<T>>::take_auth(&signer, &auth);
 
         // Transfer custody of `portfolio_id` over to `new_custodian`, removing it from `current_custodian`.
         if portfolio_id.did == new_custodian {

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -582,7 +582,7 @@ impl<T: Trait> PortfolioSubTrait<T::Balance, T::AccountId> for Module<T> {
         let current_custodian = PortfolioCustodian::get(&portfolio_id).unwrap_or(portfolio_id.did);
         let signer = Signatory::from(new_custodian);
         let auth = <identity::Module<T>>::check_auth(current_custodian, &signer, auth_id)?;
-        <identity::Module<T>>::take_auth(&signer, &auth);
+        <identity::Module<T>>::unchecked_take_auth(&signer, &auth);
 
         // Transfer custody of `portfolio_id` over to `new_custodian`, removing it from `current_custodian`.
         if portfolio_id.did == new_custodian {

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -79,7 +79,7 @@ fn set_time_to_now() {
     Timestamp::set_timestamp(now());
 }
 
-fn max_len() -> u32 {
+crate fn max_len() -> u32 {
     <TestStorage as pallet_base::Trait>::MaxLen::get()
 }
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -83,7 +83,7 @@ fn max_len() -> u32 {
     <TestStorage as pallet_base::Trait>::MaxLen::get()
 }
 
-fn max_len_bytes<R: From<Vec<u8>>>(add: u32) -> R {
+crate fn max_len_bytes<R: From<Vec<u8>>>(add: u32) -> R {
     bytes_of_len(b'A', (max_len() + add) as usize)
 }
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -2364,7 +2364,7 @@ fn create_asset_errors(owner: Public, other: Public) {
     let name_max_length = <TestStorage as AssetTrait>::AssetNameMaxLength::get() + 1;
     let input_expected = vec![
         (
-            bytes_of_len(b'A', name_max_length),
+            bytes_of_len(b'A', name_max_length as usize),
             TOTAL_SUPPLY,
             true,
             None,

--- a/pallets/runtime/tests/src/balances_test.rs
+++ b/pallets/runtime/tests/src/balances_test.rs
@@ -9,7 +9,7 @@ use polymesh_common_utilities::traits::balances::{Memo, RawEvent as BalancesRawE
 use polymesh_runtime_develop::{runtime, Runtime};
 
 use frame_support::{
-    assert_err, assert_ok,
+    assert_noop, assert_ok,
     traits::Currency,
     weights::{DispatchInfo, Weight},
 };
@@ -234,7 +234,7 @@ fn burn_account_balance_works() {
         let total_issuance1 = Balances::total_issuance();
         assert_eq!(total_issuance1, total_issuance0 - burn_amount);
         let fat_finger_burn_amount = std::u128::MAX;
-        assert_err!(
+        assert_noop!(
             Balances::burn_account_balance(Origin::signed(alice_pub), fat_finger_burn_amount),
             Error::InsufficientBalance
         );

--- a/pallets/runtime/tests/src/bridge.rs
+++ b/pallets/runtime/tests/src/bridge.rs
@@ -7,7 +7,7 @@ use super::{
 };
 
 use frame_support::{
-    assert_err, assert_ok,
+    assert_noop, assert_ok,
     storage::IterableStorageDoubleMap,
     traits::{Currency, OnInitialize},
     weights::Weight,
@@ -142,7 +142,7 @@ fn can_issue_to_identity_we() {
         Bridge::bridge_tx_details(AccountKeyring::Alice.public(), &1).status,
         BridgeTxStatus::Handled
     );
-    assert_err!(
+    assert_noop!(
         Bridge::handle_bridge_tx(Origin::signed(controller), bridge_tx),
         Error::ProposalAlreadyHandled
     );
@@ -217,7 +217,7 @@ fn cannot_propose_without_controller() {
             amount,
             tx_hash: Default::default(),
         };
-        assert_err!(
+        assert_noop!(
             Bridge::propose_bridge_tx(alice, bridge_tx),
             Error::ControllerNotSet,
         );
@@ -229,7 +229,7 @@ fn cannot_call_bridge_callback_extrinsics() {
     ExtBuilder::default().build().execute_with(|| {
         let alice_account = AccountKeyring::Alice.public();
         let alice = Origin::signed(alice_account);
-        assert_err!(
+        assert_noop!(
             Bridge::change_controller(alice.clone(), alice_account),
             Error::BadAdmin,
         );
@@ -239,7 +239,7 @@ fn cannot_call_bridge_callback_extrinsics() {
             amount: 1_000_000,
             tx_hash: Default::default(),
         };
-        assert_err!(Bridge::handle_bridge_tx(alice, bridge_tx), Error::BadCaller);
+        assert_noop!(Bridge::handle_bridge_tx(alice, bridge_tx), Error::BadCaller);
     });
 }
 
@@ -351,7 +351,7 @@ fn do_freeze_and_unfreeze_bridge() {
         BridgeTxStatus::Handled
     );
     // Attempt to handle the same transaction again.
-    assert_err!(
+    assert_noop!(
         Bridge::handle_bridge_tx(Origin::signed(controller), bridge_tx),
         Error::ProposalAlreadyHandled
     );

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -6,7 +6,7 @@ use super::{
     ExtBuilder,
 };
 use chrono::prelude::Utc;
-use frame_support::{assert_err, assert_noop, assert_ok, traits::Currency};
+use frame_support::{assert_noop, assert_ok, traits::Currency};
 use pallet_asset::{self as asset, Error as AssetError, SecurityToken};
 use pallet_balances as balances;
 use pallet_compliance_manager::{self as compliance_manager, Error as CMError};
@@ -310,7 +310,7 @@ fn should_add_and_verify_compliance_requirement_we() {
         ticker,
         1
     )); // OK; latest == 3
-    assert_err!(
+    assert_noop!(
         ComplianceManager::remove_compliance_requirement(token_owner_signed.clone(), ticker, 1),
         CMError::<TestStorage>::InvalidComplianceRequirementId
     ); // BAD OK; latest == 3, but 1 was just removed.
@@ -587,7 +587,7 @@ fn should_successfully_add_and_use_default_issuers_we() {
     ));
 
     // Failed because trusted issuer identity not exist
-    assert_err!(
+    assert_noop!(
         ComplianceManager::add_default_trusted_claim_issuer(
             token_owner_signed.clone(),
             ticker,
@@ -856,7 +856,7 @@ fn should_modify_vector_of_trusted_issuer_we() {
     };
 
     // Failed because sender is not the owner of the ticker
-    assert_err!(
+    assert_noop!(
         ComplianceManager::change_compliance_requirement(
             receiver_signed.clone(),
             ticker,
@@ -872,7 +872,7 @@ fn should_modify_vector_of_trusted_issuer_we() {
     };
 
     // Failed because passed id is not valid
-    assert_err!(
+    assert_noop!(
         ComplianceManager::change_compliance_requirement(
             token_owner_signed.clone(),
             ticker,

--- a/pallets/runtime/tests/src/group_test.rs
+++ b/pallets/runtime/tests/src/group_test.rs
@@ -7,7 +7,7 @@ use pallet_identity as identity;
 use polymesh_common_utilities::{traits::group::GroupTrait, Context};
 use polymesh_primitives::IdentityId;
 
-use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
+use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 use test_client::AccountKeyring;
 
 type CommitteeGroup = group::Module<TestStorage, group::Instance1>;
@@ -163,7 +163,7 @@ fn remove_member_works_we() {
 
     Context::set_current_identity::<Identity>(Some(non_root_did));
 
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::remove_member(non_root, IdentityId::from(3)),
         DispatchError::BadOrigin
     );
@@ -196,7 +196,7 @@ fn swap_member_works_we() {
     let non_root_did = get_identity_id(AccountKeyring::Charlie).unwrap();
 
     Context::set_current_identity::<Identity>(Some(non_root_did));
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::swap_member(non_root, alice_id, IdentityId::from(5)),
         DispatchError::BadOrigin
     );
@@ -231,7 +231,7 @@ fn reset_members_works_we() {
     let root = Origin::from(frame_system::RawOrigin::Root);
     let non_root = Origin::signed(AccountKeyring::Bob.public());
     let new_committee = (4..=6).map(IdentityId::from).collect::<Vec<_>>();
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::reset_members(non_root, new_committee.clone()),
         DispatchError::BadOrigin
     );
@@ -264,7 +264,7 @@ fn rage_quit_we() {
     // Ferdie is NOT a member
     assert_eq!(CommitteeGroup::is_member(&ferdie_did), false);
     Context::set_current_identity::<Identity>(Some(ferdie_did));
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::abdicate_membership(ferdie_signer),
         group::Error::<TestStorage, group::Instance1>::NoSuchMember
     );
@@ -285,7 +285,7 @@ fn rage_quit_we() {
     // Alice should not quit because she is the last member.
     assert_eq!(CommitteeGroup::is_member(&alice_did), true);
     Context::set_current_identity::<Identity>(Some(alice_did));
-    assert_err!(
+    assert_noop!(
         CommitteeGroup::abdicate_membership(alice_signer),
         group::Error::<TestStorage, group::Instance1>::LastMemberCannotQuit
     );

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1669,7 +1669,7 @@ fn add_investor_uniqueness_claim() {
 fn do_add_investor_uniqueness_claim() {
     let alice = User::new(AccountKeyring::Alice);
     let cdd_provider = AccountKeyring::Charlie.public();
-    let ticker = an_asset(alice);
+    let ticker = an_asset(alice, true);
     let initial_balance = Asset::balance_of(ticker, alice.did);
     let add_iu_claim =
         |investor_uid| provide_scope_claim(alice.did, ticker, investor_uid, cdd_provider, Some(1));

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -10,7 +10,7 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use frame_support::{assert_err, assert_ok, traits::Currency, StorageDoubleMap};
+use frame_support::{assert_noop, assert_err, assert_ok, traits::Currency, StorageDoubleMap};
 use pallet_balances as balances;
 use pallet_identity::{self as identity, Error};
 use polymesh_common_utilities::{
@@ -288,7 +288,7 @@ fn only_primary_key_can_add_secondary_key_permissions_with_externalities() {
     ));
 
     // Bob tries to get better permission by himself at `alice` Identity.
-    assert_err!(
+    assert_noop!(
         Identity::set_permission_to_signer(
             bob.clone(),
             Signatory::Account(bob_key),
@@ -298,7 +298,7 @@ fn only_primary_key_can_add_secondary_key_permissions_with_externalities() {
     );
 
     // Bob tries to remove Charlie's permissions at `alice` Identity.
-    assert_err!(
+    assert_noop!(
         Identity::set_permission_to_signer(
             bob,
             Signatory::Account(charlie_key),
@@ -344,7 +344,7 @@ fn freeze_secondary_keys_with_externalities() {
     );
 
     // Freeze secondary keys: bob & charlie.
-    assert_err!(
+    assert_noop!(
         Identity::freeze_secondary_keys(bob.clone()),
         Error::<TestStorage>::KeyNotAllowed
     );
@@ -471,7 +471,7 @@ fn frozen_secondary_keys_cdd_verification_test_we() {
         )),
         &AccountId32::from(AccountKeyring::Bob.public().0),
     );
-    assert_err!(
+    assert_noop!(
         payer,
         InvalidTransaction::Custom(TransactionError::MissingIdentity as u8)
     );
@@ -674,7 +674,7 @@ fn leave_identity_test_with_externalities() {
     // send funds to multisig
     assert_ok!(Balances::transfer(alice.clone(), musig_address.clone(), 1));
     // multisig tries leaving identity while it has funds
-    assert_err!(
+    assert_noop!(
         Identity::leave_identity_as_key(Origin::signed(musig_address.clone())),
         Error::<TestStorage>::MultiSigHasBalance
     );
@@ -846,7 +846,7 @@ fn one_step_join_id_with_ext() {
     // NOTE: We need to force the increment of account's nonce manually.
     System::inc_account_nonce(&a_pub);
 
-    assert_err!(
+    assert_noop!(
         Identity::add_secondary_keys_with_authorization(
             a.clone(),
             secondary_keys_with_auth[2..].to_owned(),
@@ -875,7 +875,7 @@ fn one_step_join_id_with_ext() {
         Signatory::Identity(e_id),
         eve_auth
     ));
-    assert_err!(
+    assert_noop!(
         Identity::add_secondary_keys_with_authorization(
             a,
             vec![eve_secondary_key_with_auth],
@@ -900,7 +900,7 @@ fn one_step_join_id_with_ext() {
         auth_signature: H512::from(AccountKeyring::Eve.sign(ferdie_auth.encode().as_slice())),
     };
 
-    assert_err!(
+    assert_noop!(
         Identity::add_secondary_keys_with_authorization(
             f,
             vec![ferdie_secondary_key_with_auth],
@@ -1322,7 +1322,7 @@ fn invalidate_cdd_claims_we() {
     // Move to time 8... CDD_1 is inactive: Its claims are valid.
     Timestamp::set_timestamp(8);
     assert_eq!(Identity::has_valid_cdd(alice_id), true);
-    assert_err!(
+    assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd), bob_acc, vec![]),
         Error::<TestStorage>::UnAuthorizedCddProvider
     );
@@ -1330,7 +1330,7 @@ fn invalidate_cdd_claims_we() {
     // Move to time 11 ... CDD_1 is expired: Its claims are invalid.
     Timestamp::set_timestamp(11);
     assert_eq!(Identity::has_valid_cdd(alice_id), false);
-    assert_err!(
+    assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd), bob_acc, vec![]),
         Error::<TestStorage>::UnAuthorizedCddProvider
     );

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -10,7 +10,7 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use frame_support::{assert_noop, assert_err, assert_ok, traits::Currency, StorageDoubleMap};
+use frame_support::{assert_noop, assert_ok, traits::Currency, StorageDoubleMap};
 use pallet_balances as balances;
 use pallet_identity::{self as identity, Error};
 use polymesh_common_utilities::{
@@ -366,7 +366,7 @@ fn freeze_secondary_keys_with_externalities() {
 
     // unfreeze all
     // commenting this because `default_identity` feature is not allowing to access None identity.
-    // assert_err!(
+    // assert_noop!(
     //     Identity::unfreeze_secondary_keys(bob.clone()),
     //     DispatchError::Other("Current identity is none and key is not linked to any identity")
     // );
@@ -734,7 +734,7 @@ fn enforce_uniqueness_keys_in_identity() {
         AuthorizationData::JoinIdentity(Permissions::empty()),
         None,
     );
-    assert_err!(
+    assert_noop!(
         Identity::join_identity(Signatory::Account(AccountKeyring::Bob.public()), auth_id),
         Error::<TestStorage>::AlreadyLinked
     );
@@ -1256,7 +1256,7 @@ fn add_identity_signers() {
             None,
         );
 
-        assert_err!(
+        assert_noop!(
             Identity::join_identity(dave_acc_signer, auth_id_for_acc2_to_acc),
             Error::<TestStorage>::AlreadyLinked
         );

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::an_asset,
+    asset_test::{an_asset, max_len, max_len_bytes},
     committee_test::gc_vmo,
     ext_builder::PROTOCOL_OP_BASE_FEE,
     storage::{
@@ -10,9 +10,10 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok, traits::Currency, StorageDoubleMap};
+use core::iter;
+use frame_support::{assert_noop, assert_ok, traits::Currency, StorageDoubleMap, StorageMap};
 use pallet_balances as balances;
-use pallet_identity::{self as identity, Error};
+use pallet_identity::{self as identity, DidRecords, Error};
 use polymesh_common_utilities::{
     traits::{
         group::GroupTrait,
@@ -22,11 +23,13 @@ use polymesh_common_utilities::{
     SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::{
-    AuthorizationData, AuthorizationType, Claim, ClaimType, IdentityClaim, IdentityId, InvestorUid,
-    Permissions, Scope, SecondaryKey, Signatory, Ticker, TransactionError,
+    AuthorizationData, AuthorizationType, Claim, ClaimType, DispatchableName, IdentityClaim,
+    IdentityId, InvestorUid, PalletName, PalletPermissions, Permissions, PortfolioId,
+    PortfolioNumber, Scope, SecondaryKey, Signatory, SubsetRestriction, Ticker, TransactionError,
 };
 use polymesh_runtime_develop::{fee_details::CddHandler, runtime::Call};
 use sp_core::crypto::AccountId32;
+use sp_core::sr25519::Public;
 use sp_core::H512;
 use sp_runtime::transaction_validity::InvalidTransaction;
 use std::convert::{From, TryFrom};
@@ -313,6 +316,22 @@ fn only_primary_key_can_add_secondary_key_permissions_with_externalities() {
         Signatory::Account(bob_key),
         Permissions::empty().into()
     ));
+}
+
+#[test]
+fn set_permission_to_signer_with_bad_perms() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob = AccountKeyring::Bob.public();
+        add_secondary_key(alice.did, Signatory::Account(bob));
+        test_with_bad_perms(alice.did, |perms| {
+            assert_too_long!(Identity::set_permission_to_signer(
+                alice.origin(),
+                Signatory::Account(bob),
+                perms,
+            ));
+        });
+    });
 }
 
 /// It verifies that frozen keys are recovered after `unfreeze` call.
@@ -779,6 +798,21 @@ fn add_remove_secondary_identities_with_externalities() {
     );
 }
 
+fn secondary_keys_with_auth(
+    keys: &[AccountKeyring],
+    ids: &[IdentityId],
+    auth_encoded: &[u8],
+) -> Vec<SecondaryKeyWithAuth<Public>> {
+    keys.iter()
+        .map(|acc| H512::from(acc.sign(&auth_encoded)))
+        .zip(ids.iter().map(|&id| SecondaryKey::from(id).into()))
+        .map(|(auth_signature, secondary_key)| SecondaryKeyWithAuth {
+            auth_signature,
+            secondary_key,
+        })
+        .collect()
+}
+
 #[test]
 fn one_step_join_id() {
     ExtBuilder::default()
@@ -787,127 +821,192 @@ fn one_step_join_id() {
 }
 
 fn one_step_join_id_with_ext() {
-    let a_id = register_keyring_account(AccountKeyring::Alice).unwrap();
-    let a_pub = AccountKeyring::Alice.public();
-    let a = Origin::signed(a_pub.clone());
-    let b_id = register_keyring_account(AccountKeyring::Bob).unwrap();
-    let c_id = register_keyring_account(AccountKeyring::Charlie).unwrap();
-    let d_id = register_keyring_account(AccountKeyring::Dave).unwrap();
+    let a = User::new(AccountKeyring::Alice);
+    let b = User::new(AccountKeyring::Bob);
+    let c = User::new(AccountKeyring::Charlie);
+    let d = User::new(AccountKeyring::Dave);
 
     let expires_at = 100u64;
-    let authorization = TargetIdAuthorization {
-        target_id: a_id.clone(),
-        nonce: Identity::offchain_authorization_nonce(a_id),
+    let target_id_auth = |user: User| TargetIdAuthorization {
+        target_id: user.did,
+        nonce: Identity::offchain_authorization_nonce(user.did),
         expires_at,
     };
+    let authorization = target_id_auth(a);
     let auth_encoded = authorization.encode();
 
-    let signatures = [
+    let keys = [
         AccountKeyring::Bob,
         AccountKeyring::Charlie,
         AccountKeyring::Dave,
-    ]
-    .iter()
-    .map(|acc| H512::from(acc.sign(&auth_encoded)))
-    .collect::<Vec<_>>();
-
-    let secondary_keys_with_auth = vec![
-        SecondaryKeyWithAuth {
-            secondary_key: SecondaryKey::from(b_id.clone()).into(),
-            auth_signature: signatures[0].clone(),
-        },
-        SecondaryKeyWithAuth {
-            secondary_key: SecondaryKey::from(c_id.clone()).into(),
-            auth_signature: signatures[1].clone(),
-        },
-        SecondaryKeyWithAuth {
-            secondary_key: SecondaryKey::from(d_id.clone()).into(),
-            auth_signature: signatures[2].clone(),
-        },
     ];
+    let secondary_keys_with_auth =
+        secondary_keys_with_auth(&keys, &[b.did, c.did, d.did], &auth_encoded);
 
-    assert_ok!(Identity::add_secondary_keys_with_authorization(
-        a.clone(),
-        secondary_keys_with_auth[..2].to_owned(),
-        expires_at
-    ));
+    let add = |user: User, auth| {
+        Identity::add_secondary_keys_with_authorization(user.origin(), auth, expires_at)
+    };
 
-    let secondary_keys = Identity::did_records(a_id).secondary_keys;
-    assert_eq!(
-        secondary_keys.iter().find(|si| **si == b_id).is_some(),
-        true
-    );
-    assert_eq!(
-        secondary_keys.iter().find(|si| **si == c_id).is_some(),
-        true
-    );
+    assert_ok!(add(a, secondary_keys_with_auth[..2].to_owned()));
+
+    let secondary_keys = Identity::did_records(a.did).secondary_keys;
+    let contains = |u: User| secondary_keys.iter().find(|si| **si == u.did).is_some();
+    assert_eq!(contains(b), true);
+    assert_eq!(contains(c), true);
 
     // Check reply attack. Alice's nonce is different now.
     // NOTE: We need to force the increment of account's nonce manually.
-    System::inc_account_nonce(&a_pub);
+    System::inc_account_nonce(a.acc());
 
     assert_noop!(
-        Identity::add_secondary_keys_with_authorization(
-            a.clone(),
-            secondary_keys_with_auth[2..].to_owned(),
-            expires_at
-        ),
+        add(a, secondary_keys_with_auth[2..].to_owned()),
         Error::<TestStorage>::InvalidAuthorizationSignature
     );
 
     // Check revoke off-chain authorization.
-    let e = Origin::signed(AccountKeyring::Eve.public());
-    let e_id = register_keyring_account(AccountKeyring::Eve).unwrap();
-    let eve_auth = TargetIdAuthorization {
-        target_id: a_id.clone(),
-        nonce: Identity::offchain_authorization_nonce(a_id),
-        expires_at,
-    };
+    let e = User::new(AccountKeyring::Eve);
+    let eve_auth = target_id_auth(a);
     assert_ne!(authorization.nonce, eve_auth.nonce);
 
     let eve_secondary_key_with_auth = SecondaryKeyWithAuth {
-        secondary_key: SecondaryKey::from(e_id).into(),
+        secondary_key: SecondaryKey::from(e.did).into(),
         auth_signature: H512::from(AccountKeyring::Eve.sign(eve_auth.encode().as_slice())),
     };
 
     assert_ok!(Identity::revoke_offchain_authorization(
-        e,
-        Signatory::Identity(e_id),
+        e.origin(),
+        Signatory::Identity(e.did),
         eve_auth
     ));
     assert_noop!(
-        Identity::add_secondary_keys_with_authorization(
-            a,
-            vec![eve_secondary_key_with_auth],
-            expires_at
-        ),
+        add(a, vec![eve_secondary_key_with_auth]),
         Error::<TestStorage>::AuthorizationHasBeenRevoked
     );
 
     // Check expire
-    System::inc_account_nonce(&a_pub);
+    System::inc_account_nonce(a.acc());
     Timestamp::set_timestamp(expires_at);
 
-    let f = Origin::signed(AccountKeyring::Ferdie.public());
-    let f_id = register_keyring_account(AccountKeyring::Ferdie).unwrap();
-    let ferdie_auth = TargetIdAuthorization {
-        target_id: a_id.clone(),
-        nonce: Identity::offchain_authorization_nonce(a_id),
-        expires_at,
-    };
+    let f = User::new(AccountKeyring::Ferdie);
+    let ferdie_auth = target_id_auth(a);
     let ferdie_secondary_key_with_auth = SecondaryKeyWithAuth {
-        secondary_key: SecondaryKey::from(f_id.clone()).into(),
+        secondary_key: SecondaryKey::from(f.did).into(),
         auth_signature: H512::from(AccountKeyring::Eve.sign(ferdie_auth.encode().as_slice())),
     };
 
     assert_noop!(
-        Identity::add_secondary_keys_with_authorization(
-            f,
-            vec![ferdie_secondary_key_with_auth],
-            expires_at
-        ),
+        add(f, vec![ferdie_secondary_key_with_auth]),
         Error::<TestStorage>::AuthorizationExpired
     );
+}
+
+fn test_with_bad_perms(did: IdentityId, test: impl Fn(Permissions)) {
+    test(Permissions {
+        asset: SubsetRestriction::elems((0..=max_len() as u64).map(Ticker::generate_into)),
+        ..<_>::default()
+    });
+    test(Permissions {
+        portfolio: SubsetRestriction::elems(
+            (0..=max_len() as u64)
+                .map(|n| PortfolioId::user_portfolio(did, PortfolioNumber::from(n))),
+        ),
+        ..<_>::default()
+    });
+    let test = |extrinsic| {
+        test(Permissions {
+            extrinsic,
+            ..<_>::default()
+        })
+    };
+    test(SubsetRestriction::elems(
+        (0..=max_len() as u64)
+            .map(Ticker::generate)
+            .map(PalletName::from)
+            .map(PalletPermissions::entire_pallet),
+    ));
+    test(SubsetRestriction::elem(PalletPermissions::entire_pallet(
+        max_len_bytes(1),
+    )));
+    test(SubsetRestriction::elem(PalletPermissions::new(
+        "".into(),
+        SubsetRestriction::elems(
+            (0..=max_len() as u64)
+                .map(Ticker::generate)
+                .map(DispatchableName::from),
+        ),
+    )));
+    test(SubsetRestriction::elem(PalletPermissions::new(
+        "".into(),
+        SubsetRestriction::elem(max_len_bytes(1)),
+    )));
+}
+
+#[test]
+fn add_secondary_keys_with_authorization_too_many_sks() {
+    ExtBuilder::default().build().execute_with(|| {
+        let user = User::new(AccountKeyring::Alice);
+        let bob = User::new(AccountKeyring::Bob);
+
+        let expires_at = 100;
+        let auth = || {
+            let auth = TargetIdAuthorization {
+                target_id: user.did,
+                nonce: Identity::offchain_authorization_nonce(user.did),
+                expires_at,
+            };
+            auth.encode()
+        };
+
+        // Test various length problems in `Permissions`.
+        test_with_bad_perms(bob.did, |perms| {
+            let auth_encoded = auth();
+            let auth_signature = H512::from(bob.ring.sign(&auth_encoded));
+
+            let secondary_key = SecondaryKey::new(bob.did.into(), perms).into();
+            let auths = vec![SecondaryKeyWithAuth {
+                auth_signature,
+                secondary_key,
+            }];
+            assert_too_long!(Identity::add_secondary_keys_with_authorization(
+                user.origin(),
+                auths,
+                expires_at
+            ));
+        });
+
+        // Populate with MAX SKs.
+        DidRecords::<TestStorage>::mutate(user.did, |rec| {
+            let sk = SecondaryKey {
+                signer: Signatory::Account(rec.primary_key),
+                permissions: Permissions::empty(),
+            };
+            rec.secondary_keys = iter::repeat(sk).take(max_len() as usize).collect();
+        });
+
+        // Fail at adding the {MAX + 1}th SK.
+        let auth_encoded = auth();
+        let auths = secondary_keys_with_auth(&[bob.ring], &[bob.did], &auth_encoded);
+        assert_too_long!(Identity::add_secondary_keys_with_authorization(
+            user.origin(),
+            auths,
+            expires_at
+        ));
+    });
+}
+
+#[test]
+fn adding_authorizations_bad_perms() {
+    ExtBuilder::default().build().execute_with(|| {
+        let user = User::new(AccountKeyring::Alice);
+        test_with_bad_perms(user.did, |perms| {
+            assert_too_long!(Identity::add_authorization(
+                user.origin(),
+                user.did.into(),
+                AuthorizationData::JoinIdentity(perms),
+                None
+            ));
+        });
+    });
 }
 
 #[test]

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -822,9 +822,6 @@ fn one_step_join_id() {
 
 fn one_step_join_id_with_ext() {
     let a = User::new(AccountKeyring::Alice);
-    let b = User::new(AccountKeyring::Bob);
-    let c = User::new(AccountKeyring::Charlie);
-    let d = User::new(AccountKeyring::Dave);
 
     let expires_at = 100u64;
     let target_id_auth = |user: User| TargetIdAuthorization {
@@ -840,8 +837,9 @@ fn one_step_join_id_with_ext() {
         AccountKeyring::Charlie,
         AccountKeyring::Dave,
     ];
+    let users @ [b, c, _] = keys.map(User::new);
     let secondary_keys_with_auth =
-        secondary_keys_with_auth(&keys, &[b.did, c.did, d.did], &auth_encoded);
+        secondary_keys_with_auth(&keys, &users.map(|u| u.did), &auth_encoded);
 
     let add = |user: User, auth| {
         Identity::add_secondary_keys_with_authorization(user.origin(), auth, expires_at)

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ext_builder;
 pub use ext_builder::ExtBuilder;
 
 #[cfg(test)]
+#[macro_use]
 mod asset_test;
 #[cfg(test)]
 mod balances_test;

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![feature(crate_visibility_modifier)]
-#![feature(bindings_after_at, bool_to_option)]
+#![feature(bindings_after_at, bool_to_option, array_map)]
 
 pub mod storage;
 pub use storage::{

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -2,7 +2,7 @@ use super::{
     storage::{get_last_auth_id, register_keyring_account, Call, TestStorage},
     ExtBuilder,
 };
-use frame_support::{assert_err, assert_ok, traits::OnInitialize};
+use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use pallet_balances as balances;
 use pallet_identity as identity;
 use pallet_multisig as multisig;
@@ -43,12 +43,12 @@ fn create_multisig() {
 
         assert_eq!(MultiSig::ms_signs_required(musig_address), 1);
 
-        assert_err!(
+        assert_noop!(
             MultiSig::create_multisig(alice.clone(), vec![], 10,),
             Error::NoSigners
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::create_multisig(
                 alice.clone(),
                 vec![Signatory::from(alice_did), Signatory::from(bob_did)],
@@ -57,7 +57,7 @@ fn create_multisig() {
             Error::RequiredSignaturesOutOfBounds
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::create_multisig(
                 alice.clone(),
                 vec![Signatory::from(alice_did), Signatory::from(bob_did)],
@@ -126,7 +126,7 @@ fn join_multisig() {
 
         let bob_auth_id2 = get_last_auth_id(&bob_signer);
         Context::set_current_identity::<Identity>(Some(alice_did));
-        assert_err!(
+        assert_noop!(
             MultiSig::accept_multisig_signer_as_key(bob.clone(), bob_auth_id2),
             Error::SignerAlreadyLinked
         );
@@ -461,7 +461,7 @@ fn add_multisig_signer() {
         assert!(Identity::change_cdd_requirement_for_mk_rotation(root.clone(), true).is_ok());
 
         Context::set_current_identity::<Identity>(Some(alice_did));
-        assert_err!(
+        assert_noop!(
             MultiSig::accept_multisig_signer_as_key(bob.clone(), bob_auth_id),
             Error::ChangeNotAllowed
         );
@@ -501,7 +501,7 @@ fn make_multisig_primary() {
             AccountKeyring::Alice.public()
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::make_multisig_primary(bob.clone(), musig_address.clone(), None),
             Error::IdentityNotCreator
         );
@@ -543,7 +543,7 @@ fn make_multisig_signer() {
             .find(|si| **si == musig_secondary)
             .is_none());
 
-        assert_err!(
+        assert_noop!(
             MultiSig::make_multisig_signer(bob.clone(), musig_address.clone()),
             Error::IdentityNotCreator
         );
@@ -608,7 +608,7 @@ fn remove_multisig_signers_via_creator() {
             true
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::remove_multisig_signers_via_creator(
                 bob.clone(),
                 musig_address.clone(),
@@ -635,7 +635,7 @@ fn remove_multisig_signers_via_creator() {
             false
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::remove_multisig_signers_via_creator(
                 alice.clone(),
                 musig_address.clone(),
@@ -684,7 +684,7 @@ fn add_multisig_signers_via_creator() {
             false
         );
 
-        assert_err!(
+        assert_noop!(
             MultiSig::add_multisig_signers_via_creator(
                 bob.clone(),
                 musig_address.clone(),
@@ -914,7 +914,7 @@ fn reject_proposals() {
             proposal_id2
         ));
         Context::set_current_identity::<Identity>(Some(dave_did));
-        assert_err!(
+        assert_noop!(
             MultiSig::approve_as_identity(dave.clone(), musig_address.clone(), proposal_id2),
             Error::ProposalAlreadyRejected
         );
@@ -988,7 +988,7 @@ fn expired_proposals() {
         // Approval fails when proposal has expired
         Timestamp::set_timestamp(expires_at);
         Context::set_current_identity::<Identity>(Some(charlie_did));
-        assert_err!(
+        assert_noop!(
             MultiSig::approve_as_identity(charlie.clone(), musig_address.clone(), proposal_id),
             Error::ProposalExpired
         );

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -1,5 +1,6 @@
 use super::{
     assert_event_exists,
+    asset_test::max_len_bytes,
     committee_test::{gc_vmo, set_members},
     storage::{
         fast_forward_blocks, make_remark_proposal, root, Call, EventTest, TestStorage, User,
@@ -491,6 +492,26 @@ fn proposal_details_are_correct() {
 
         assert_balance(alice.acc(), 300, 60);
         assert_votes(0, alice.acc(), 60);
+    });
+}
+
+#[test]
+fn proposal_limits_are_enforced() {
+    ExtBuilder::default().build().execute_with(|| {
+        let proposer = User::new(AccountKeyring::Alice).balance(300);
+        let propose = |url, desc| {
+            proposal(
+                &proposer.origin(),
+                &Proposer::Community(proposer.acc()),
+                make_remark_proposal(),
+                60,
+                Some(url),
+                Some(desc),
+            )
+        };
+        assert_too_long!(propose(max_len_bytes(1), max_len_bytes(0)));
+        assert_too_long!(propose(max_len_bytes(0), max_len_bytes(1)));
+        assert_ok!(propose(max_len_bytes(0), max_len_bytes(0)));
     });
 }
 

--- a/pallets/runtime/tests/src/pips_test.rs
+++ b/pallets/runtime/tests/src/pips_test.rs
@@ -498,6 +498,7 @@ fn proposal_details_are_correct() {
 #[test]
 fn proposal_limits_are_enforced() {
     ExtBuilder::default().build().execute_with(|| {
+        System::set_block_number(42);
         let proposer = User::new(AccountKeyring::Alice).balance(300);
         let propose = |url, desc| {
             proposal(

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -3,7 +3,7 @@ use super::{
     storage::{TestStorage, User},
     ExtBuilder,
 };
-use frame_support::{assert_err, assert_noop, assert_ok, StorageMap};
+use frame_support::{assert_noop, assert_ok, StorageMap};
 use pallet_asset::SecurityToken;
 use pallet_portfolio::MovePortfolioItem;
 use polymesh_common_utilities::portfolio::PortfolioSubTrait;
@@ -143,7 +143,7 @@ fn do_move_asset_from_portfolio() {
     let owner_user_portfolio = PortfolioId::user_portfolio(owner.did, num);
 
     // Attempt to move more than the total supply.
-    assert_err!(
+    assert_noop!(
         Portfolio::move_portfolio_funds(
             owner.origin(),
             owner_default_portfolio,
@@ -155,7 +155,7 @@ fn do_move_asset_from_portfolio() {
         ),
         Error::InsufficientPortfolioBalance
     );
-    assert_err!(
+    assert_noop!(
         Portfolio::ensure_portfolio_transfer_validity(
             &owner_default_portfolio,
             &owner_user_portfolio,
@@ -166,7 +166,7 @@ fn do_move_asset_from_portfolio() {
     );
 
     // Attempt to move to the same portfolio.
-    assert_err!(
+    assert_noop!(
         Portfolio::move_portfolio_funds(
             owner.origin(),
             owner_default_portfolio,
@@ -175,7 +175,7 @@ fn do_move_asset_from_portfolio() {
         ),
         Error::DestinationIsSamePortfolio
     );
-    assert_err!(
+    assert_noop!(
         Portfolio::ensure_portfolio_transfer_validity(
             &owner_default_portfolio,
             &owner_default_portfolio,
@@ -186,7 +186,7 @@ fn do_move_asset_from_portfolio() {
     );
 
     // Attempt to move to a non-existent portfolio.
-    assert_err!(
+    assert_noop!(
         Portfolio::ensure_portfolio_transfer_validity(
             &owner_default_portfolio,
             &PortfolioId::user_portfolio(owner.did, PortfolioNumber(666)),
@@ -197,7 +197,7 @@ fn do_move_asset_from_portfolio() {
     );
 
     // Attempt to move by another identity.
-    assert_err!(
+    assert_noop!(
         Portfolio::move_portfolio_funds(
             bob.origin(),
             owner_default_portfolio,
@@ -416,7 +416,7 @@ fn can_take_custody_of_portfolios() {
             owner_user_portfolio,
             bob.did
         ));
-        assert_err!(
+        assert_noop!(
             Portfolio::ensure_portfolio_custody(owner_user_portfolio, owner.did),
             Error::UnauthorizedCustodian
         );

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -1,15 +1,15 @@
 use super::{
+    asset_test::{a_token, basic_asset, max_len_bytes},
     storage::{TestStorage, User},
     ExtBuilder,
-    asset_test::{a_token, basic_asset, max_len_bytes}
 };
 use frame_support::{assert_err, assert_noop, assert_ok, StorageMap};
 use pallet_asset::SecurityToken;
 use pallet_portfolio::MovePortfolioItem;
 use polymesh_common_utilities::portfolio::PortfolioSubTrait;
 use polymesh_primitives::{
-    AuthorizationData, AuthorizationError, PortfolioId, PortfolioName,
-    PortfolioNumber, Signatory, Ticker,
+    AuthorizationData, AuthorizationError, PortfolioId, PortfolioName, PortfolioNumber, Signatory,
+    Ticker,
 };
 use test_client::AccountKeyring;
 

--- a/pallets/runtime/tests/src/protocol_fee.rs
+++ b/pallets/runtime/tests/src/protocol_fee.rs
@@ -3,7 +3,7 @@ use super::{
     storage::{register_keyring_account_with_balance, TestStorage},
     ExtBuilder,
 };
-use frame_support::{assert_err, assert_ok};
+use frame_support::{assert_noop, assert_ok};
 use polymesh_common_utilities::{
     protocol_fee::ProtocolOp, traits::transaction_payment::CddAndFeeDetails,
 };
@@ -34,7 +34,7 @@ fn can_charge_fee_batch() {
             Some(AccountKeyring::Alice.public())
         );
         assert_ok!(ProtocolFee::batch_charge_fee(ProtocolOp::AssetIssue, 7));
-        assert_err!(
+        assert_noop!(
             ProtocolFee::batch_charge_fee(ProtocolOp::AssetIssue, 7),
             Error::InsufficientAccountBalance
         );

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -1,8 +1,9 @@
 use super::{
+    asset_test::max_len_bytes,
     storage::{
         default_portfolio_vec, make_account, make_account_without_cdd,
         provide_scope_claim_to_multiple_parties, register_keyring_account, user_portfolio_vec,
-        TestStorage,
+        TestStorage, User,
     },
     ExtBuilder,
 };
@@ -123,6 +124,20 @@ pub fn next_block() {
 
 pub fn set_current_block_number(block: u64) {
     System::set_block_number(block);
+}
+
+#[test]
+fn venue_details_length_limited() {
+    ExtBuilder::default().build().execute_with(|| {
+        let actor = User::new(AccountKeyring::Alice);
+        let id = Settlement::venue_counter();
+        let create = |d| Settlement::create_venue(actor.origin(), d, vec![], VenueType::Exchange);
+        let update = |d| Settlement::update_venue(actor.origin(), id, Some(d), None);
+        assert_too_long!(create(max_len_bytes(1)));
+        assert_ok!(create(max_len_bytes(0)));
+        assert_too_long!(update(max_len_bytes(1)));
+        assert_ok!(update(max_len_bytes(0)));
+    });
 }
 
 #[test]

--- a/pallets/runtime/tests/src/treasury_test.rs
+++ b/pallets/runtime/tests/src/treasury_test.rs
@@ -1,9 +1,9 @@
 use super::{
-    storage::{register_keyring_account, TestStorage},
+    storage::{register_keyring_account, root, TestStorage},
     ExtBuilder,
 };
 
-use frame_support::{assert_err, assert_ok};
+use frame_support::{assert_noop, assert_ok};
 use pallet_balances as balances;
 use pallet_identity as identity;
 use pallet_treasury::{self as treasury, TreasuryTrait};
@@ -26,7 +26,6 @@ fn reimbursement_and_disbursement() {
 }
 
 fn reimbursement_and_disbursement_we() {
-    let root = Origin::from(frame_system::RawOrigin::Root);
     let alice = register_keyring_account(AccountKeyring::Alice).unwrap();
     let alice_acc = Origin::signed(AccountKeyring::Alice.public());
     let alice_pub = AccountKeyring::Alice.public();
@@ -56,7 +55,7 @@ fn reimbursement_and_disbursement_we() {
     // Providing a random DID to Root, In an ideal world root will have a valid DID
     let before_alice_balance = Balances::free_balance(&alice_pub);
     let before_bob_balance = Balances::free_balance(&bob_pub);
-    assert_ok!(Treasury::disbursement(root.clone(), beneficiaries));
+    assert_ok!(Treasury::disbursement(root(), beneficiaries));
     Context::set_current_identity::<Identity>(None);
     assert_eq!(Treasury::balance(), 400);
     assert_eq!(
@@ -67,7 +66,7 @@ fn reimbursement_and_disbursement_we() {
     assert_eq!(total_issuance, Balances::total_issuance());
 
     // Alice cannot make a disbursement to herself.
-    assert_err!(
+    assert_noop!(
         Treasury::disbursement(
             alice_acc,
             vec![Beneficiary {

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -8,7 +8,7 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use frame_support::{assert_err, assert_ok, dispatch::DispatchError};
+use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 use frame_system::EventRecord;
 use pallet_balances::Call as BalancesCall;
 use pallet_portfolio::Call as PortfolioCall;
@@ -195,7 +195,7 @@ fn _relay_unhappy_cases() {
         Call::Balances(BalancesCall::transfer(charlie, 59)),
     );
 
-    assert_err!(
+    assert_noop!(
         Utility::relay_tx(
             origin.clone(),
             bob,
@@ -205,7 +205,7 @@ fn _relay_unhappy_cases() {
         Error::InvalidSignature
     );
 
-    assert_err!(
+    assert_noop!(
         Utility::relay_tx(
             origin.clone(),
             bob,
@@ -222,7 +222,7 @@ fn _relay_unhappy_cases() {
         Call::Balances(BalancesCall::transfer(charlie, 59)),
     );
 
-    assert_err!(
+    assert_noop!(
         Utility::relay_tx(
             origin.clone(),
             bob,
@@ -294,7 +294,7 @@ fn batch_secondary_with_permissions() {
 
     // Call a disallowed extrinsic.
     let high_risk_name: PortfolioName = b"high risk".into();
-    assert_err!(
+    assert_noop!(
         Portfolio::create_portfolio(bob_origin.clone(), high_risk_name.clone()),
         pallet_permissions::Error::<TestStorage>::UnauthorizedCaller
     );

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -22,7 +22,7 @@ use pallet_contracts::ContractAddressFor;
 use pallet_identity as identity;
 use pallet_portfolio::PortfolioAssetBalances;
 use polymesh_common_utilities::{
-    benchs::{self, generate_ticker, user, AccountIdOf, User, UserBuilder},
+    benchs::{self, user, AccountIdOf, User, UserBuilder},
     constants::currency::POLY,
     traits::asset::AssetFnTrait,
     TestUtilsFn,
@@ -113,7 +113,7 @@ fn set_user_affirmations(instruction_id: u64, portfolio: PortfolioId, affirm: Af
 
 // create asset
 fn create_asset_<T: Trait>(owner: &User<T>) -> Ticker {
-    make_asset::<T>(owner, Some(generate_ticker(8u64)))
+    make_asset::<T>(owner, Some(Ticker::generate(8u64)))
 }
 
 // fund portfolio
@@ -130,7 +130,7 @@ fn setup_leg_and_portfolio<T: Trait + TestUtilsFn<AccountIdOf<T>>>(
     receiver_portfolios: &mut Vec<PortfolioId>,
 ) {
     let variance = index + 1;
-    let ticker = Ticker::try_from(generate_ticker(variance.into()).as_slice()).unwrap();
+    let ticker = Ticker::try_from(Ticker::generate(variance.into()).as_slice()).unwrap();
     let portfolio_from = generate_portfolio::<T>("", variance + 500, from_user);
     let _ = fund_portfolio::<T>(&portfolio_from, &ticker, 500u32.into());
     let portfolio_to = generate_portfolio::<T>("to_did", variance + 800, to_user);
@@ -174,7 +174,7 @@ fn populate_legs_for_instruction<T: Trait + TestUtilsFn<AccountIdOf<T>>>(
     index: u32,
     legs: &mut Vec<Leg<T::Balance>>,
 ) {
-    let ticker = Ticker::try_from(generate_ticker(index.into()).as_slice()).unwrap();
+    let ticker = Ticker::try_from(Ticker::generate(index.into()).as_slice()).unwrap();
     legs.push(Leg {
         from: generate_portfolio::<T>("from_did", index + 500, None),
         to: generate_portfolio::<T>("to_did", index + 800, None),
@@ -397,7 +397,7 @@ fn setup_affirm_instruction<T: Trait + TestUtilsFn<AccountIdOf<T>>>(
     let to_data = UserData::from(to);
 
     for n in 0..l {
-        tickers.push(make_asset::<T>(&from, Some(generate_ticker(n as u64 + 1))));
+        tickers.push(make_asset::<T>(&from, Some(Ticker::generate(n as u64 + 1))));
         emulate_portfolios::<T>(
             Some(from_data.clone()),
             Some(to_data.clone()),
@@ -789,7 +789,7 @@ benchmarks! {
         // Add instruction
         Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
         let instruction_id = 1;
-        let ticker = Ticker::try_from(generate_ticker(1u64).as_slice()).unwrap();
+        let ticker = Ticker::try_from(Ticker::generate(1u64).as_slice()).unwrap();
         let receipt = create_receipt_details::<T>(0, legs.first().unwrap().clone());
         let leg_id = 0;
         let amount = 100u128;

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -130,7 +130,7 @@ fn setup_leg_and_portfolio<T: Trait + TestUtilsFn<AccountIdOf<T>>>(
     receiver_portfolios: &mut Vec<PortfolioId>,
 ) {
     let variance = index + 1;
-    let ticker = Ticker::try_from(Ticker::generate(variance.into()).as_slice()).unwrap();
+    let ticker = Ticker::generate_into(variance.into());
     let portfolio_from = generate_portfolio::<T>("", variance + 500, from_user);
     let _ = fund_portfolio::<T>(&portfolio_from, &ticker, 500u32.into());
     let portfolio_to = generate_portfolio::<T>("to_did", variance + 800, to_user);
@@ -174,11 +174,10 @@ fn populate_legs_for_instruction<T: Trait + TestUtilsFn<AccountIdOf<T>>>(
     index: u32,
     legs: &mut Vec<Leg<T::Balance>>,
 ) {
-    let ticker = Ticker::try_from(Ticker::generate(index.into()).as_slice()).unwrap();
     legs.push(Leg {
         from: generate_portfolio::<T>("from_did", index + 500, None),
         to: generate_portfolio::<T>("to_did", index + 800, None),
-        asset: ticker,
+        asset: Ticker::generate_into(index.into()),
         amount: 100u32.into(),
     });
 }
@@ -789,7 +788,7 @@ benchmarks! {
         // Add instruction
         Module::<T>::base_add_instruction(did, venue_id, SettlementType::SettleOnAffirmation, None, None, legs.clone())?;
         let instruction_id = 1;
-        let ticker = Ticker::try_from(Ticker::generate(1u64).as_slice()).unwrap();
+        let ticker = Ticker::generate_into(1u64);
         let receipt = create_receipt_details::<T>(0, legs.first().unwrap().clone());
         let leg_id = 0;
         let amount = 100u128;

--- a/primitives/src/ticker.rs
+++ b/primitives/src/ticker.rs
@@ -77,6 +77,33 @@ impl Decode for Ticker {
 }
 
 impl Ticker {
+    /// Given a number, this function generates a ticker with
+    /// A-Z, least number of characters in Lexicographic order.
+    pub fn generate(n: u64) -> Vec<u8> {
+        fn calc_base26(n: u64, base_26: &mut Vec<u8>) {
+            if n >= 26 {
+                // Subtracting 1 is not required and shouldn't be done for a proper base_26 conversion
+                // However, without this hack, B will be the first char after a bump in number of chars.
+                // i.e. the sequence will go A,B...Z,BA,BB...ZZ,BAA. We want the sequence to start with A.
+                // Subtracting 1 here means we are doing 1 indexing rather than 0.
+                // i.e. A = 1, B = 2 instead of A = 0, B = 1
+                calc_base26((n / 26) - 1, base_26);
+            }
+            let character = n % 26 + 65;
+            base_26.push(character as u8);
+        }
+        let mut base_26 = Vec::new();
+        calc_base26(n, &mut base_26);
+        base_26
+    }
+
+    /// Given a number, this function generates a ticker with
+    /// A-Z, least number of characters in Lexicographic order.
+    /// Also convert it into the `Ticker` type.
+    pub fn generate_into(n: u64) -> Self {
+        Ticker::try_from(&*Ticker::generate(n)).unwrap()
+    }
+
     /// Computes the effective length of the ticker, that is, the length of the minimal prefix after
     /// which only zeros appear.
     pub fn len(&self) -> usize {
@@ -87,6 +114,7 @@ impl Ticker {
         }
         0
     }
+
     /// Returns `true` if the ticker is empty, that is, if it has no prefix of characters other than
     /// `0u8`.
     #[inline]

--- a/primitives/src/ticker.rs
+++ b/primitives/src/ticker.rs
@@ -19,6 +19,7 @@ use codec::{Decode, Encode, Error, Input};
 use polymesh_primitives_derive::{DeserializeU8StrongTyped, SerializeU8StrongTyped};
 
 use sp_std::convert::TryFrom;
+use sp_std::vec::Vec;
 
 /// Ticker length.
 pub const TICKER_LEN: usize = 12;


### PR DESCRIPTION
1. Fixes transactionality bugs.
2. Hardens tests via `assert_err!`s becoming `assert_noop!`s.
3. Nixes `simple_asset`.
4. Refactors `asset_test:secondary_key_not_authorized_for_asset`
4. Adds tests for string/list limits.