### PR TITLE
MESH-1627/improve identity tests - Part 1

### DIFF
--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -382,8 +382,17 @@ fn do_add_permissions_to_multiple_tokens() {
     // remove all permissions
     set_bob_asset_permissions(0);
 
-    // bulk add
-    set_bob_asset_permissions(max_tokens);
+    // bulk add, reverse order
+    assert_ok!(Identity::set_permission_to_signer(
+        alice.origin(),
+        bob_signer,
+        Permissions {
+            asset: AssetPermissions::elems(
+                tokens[0..max_tokens].into_iter().rev().map(|t| t.clone())
+            ),
+            ..Default::default()
+        },
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Only new tests.  No API/logic changes.

There are 3 `FIXME`s in identity_test for the secondary key issues.  Those will need to be updated once the secondary_key issues have been resolved.