### PR TITLE
[WIP] MESH-1640/issue with add secondary keys with auth

### DIFF
--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -522,6 +522,67 @@ fn frozen_secondary_keys_cdd_verification_test_we() {
 }
 
 #[test]
+fn add_secondary_keys_with_ident_signer_test() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(&do_add_secondary_keys_with_ident_signer_test);
+}
+
+fn do_add_secondary_keys_with_ident_signer_test() {
+    let bob = User::new(AccountKeyring::Bob);
+    let bob_account_signer = Signatory::Account(bob.acc());
+    let bob_identity_signer = Signatory::Identity(bob.did);
+    let alice = User::new(AccountKeyring::Alice);
+
+    // Try addind the same secondary_key using `add_secondary_keys_with_authorization`
+    let add_secondary_key_with_auth = |signer| {
+        let expires_at = 100u64;
+        let target_id_auth = |user: User| TargetIdAuthorization {
+            target_id: user.did,
+            nonce: Identity::offchain_authorization_nonce(user.did),
+            expires_at,
+        };
+        let authorization = target_id_auth(alice);
+        let auth_encoded = authorization.encode();
+        let auth_signature = H512::from(bob.ring.sign(&auth_encoded));
+
+        let bob_key = SecondaryKey::new(signer, Permissions::empty());
+        let key_with_auth = SecondaryKeyWithAuth {
+            auth_signature,
+            secondary_key: bob_key.into(),
+        };
+        Identity::add_secondary_keys_with_authorization(
+            alice.origin(),
+            vec![key_with_auth],
+            expires_at
+        )
+    };
+
+    // Add bob with account signatory
+    assert_noop!(
+        add_secondary_key_with_auth(bob_account_signer),
+        Error::AlreadyLinked
+    );
+
+    // Add bob with identity signatory
+    let res = add_secondary_key_with_auth(bob_identity_signer);
+    // FIXME
+    //assert_noop!(res, Error::AlreadyLinked);
+    assert_ok!(res);
+    // Add bob again with identity signatory
+    let res = add_secondary_key_with_auth(bob_identity_signer);
+    // FIXME
+    //assert_noop!(res, Error::AlreadyLinked);
+    assert_ok!(res);
+    // Add bob with identity signatory
+    let res = add_secondary_key_with_auth(bob_identity_signer);
+    // FIXME
+    //assert_noop!(res, Error::AlreadyLinked);
+    assert_ok!(res);
+}
+
+#[test]
 fn remove_secondary_keys_test() {
     ExtBuilder::default()
         .monied(true)

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -564,9 +564,7 @@ fn do_add_secondary_keys_with_ident_signer_test() {
     )]);
 
     // count alice's secondary keys.
-    let count_keys = || {
-        Identity::did_records(&alice.did).secondary_keys.len()
-    };
+    let count_keys = || Identity::did_records(&alice.did).secondary_keys.len();
 
     // Add bob's identity signatory with empty permissions
     let res = add_secondary_key_with_auth(bob_identity_signer, perm1.clone());

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -555,7 +555,7 @@ fn do_add_secondary_keys_with_ident_signer_test() {
         Identity::add_secondary_keys_with_authorization(
             alice.origin(),
             vec![key_with_auth],
-            expires_at
+            expires_at,
         )
     };
 


### PR DESCRIPTION
Add test case and fix the 1-to-1 constraint check.

## changelog

### new features

None.

### modified API

None.

### modified logic

- Fix 1-to-1 account to DID constraint check in `add_secondary_keys_with_authoration`
