### PR TITLE
MESH-1628/issue with duplicate secondary keys

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -932,10 +932,10 @@ impl<T: Trait> Module<T> {
                     Self::can_link_account_key_to_did(key),
                     Error::<T>::AlreadyLinked
                 );
-                // Charge the protocol fee after all checks.
-                charge_fee()?;
                 // Check that the new Identity has a valid CDD claim.
                 ensure!(Self::has_valid_cdd(target_did), Error::<T>::TargetHasNoCdd);
+                // Charge the protocol fee after all checks.
+                charge_fee()?;
                 // Update current did of the transaction to the newly joined did.
                 // This comes handy when someone uses a batch transaction to leave their identity, join another identity,
                 // and then do something as the new identity.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -680,6 +680,11 @@ decl_module! {
                         Error::<T>::AlreadyLinked
                     );
                 }
+                // 1.15. Check if secondary keys already contains this signer
+                ensure!(
+                    !record.contains_secondary_key(&si.signer),
+                    Error::<T>::AlreadyLinked
+                );
                 // 1.2. Offchain authorization is not revoked explicitly.
                 let si_signer_authorization = &(si.signer.clone(), authorization.clone());
                 ensure!(
@@ -925,6 +930,12 @@ impl<T: Trait> Module<T> {
         let charge_fee =
             || T::ProtocolFee::charge_fee(ProtocolOp::IdentityAddSecondaryKeysWithAuthorization);
 
+        // Check if secondary keys already contains this signer
+        let record = <DidRecords<T>>::get(target_did);
+        ensure!(
+            !record.contains_secondary_key(signer),
+            Error::<T>::AlreadyLinked
+        );
         // Link the secondary key.
         match signer {
             Signatory::Account(key) => {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -371,7 +371,7 @@ decl_module! {
 
             // Update secondary keys at Identity.
             <DidRecords<T>>::mutate(did, |record| {
-                (*record).remove_secondary_keys(signers_to_remove.clone().into_iter());
+                (*record).remove_secondary_keys(&signers_to_remove);
             });
 
             Self::deposit_event(RawEvent::SecondaryKeysRemoved(did, signers_to_remove));
@@ -1821,7 +1821,7 @@ impl<T: Trait> Module<T> {
         }
         // Update secondary keys at Identity.
         <DidRecords<T>>::mutate(did, |record| {
-            record.remove_secondary_keys(iter::once(signer.clone()));
+            record.remove_secondary_keys(&[signer.clone()]);
         });
         Self::deposit_event(RawEvent::SignerLeft(did, signer));
         Ok(())

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -382,8 +382,17 @@ fn do_add_permissions_to_multiple_tokens() {
     // remove all permissions
     set_bob_asset_permissions(0);
 
-    // bulk add
-    set_bob_asset_permissions(max_tokens);
+    // bulk add, reverse order
+    assert_ok!(Identity::set_permission_to_signer(
+        alice.origin(),
+        bob_signer,
+        Permissions {
+            asset: AssetPermissions::elems(
+                tokens[0..max_tokens].into_iter().rev().map(|t| t.clone())
+            ),
+            ..Default::default()
+        },
+    ));
 }
 
 #[test]

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -595,6 +595,73 @@ fn frozen_secondary_keys_cdd_verification_test_we() {
 }
 
 #[test]
+fn add_secondary_keys_with_ident_signer_test() {
+    ExtBuilder::default()
+        .monied(true)
+        .build()
+        .execute_with(&do_add_secondary_keys_with_ident_signer_test);
+}
+
+fn do_add_secondary_keys_with_ident_signer_test() {
+    let bob = User::new(AccountKeyring::Bob);
+    let bob_identity_signer = Signatory::Identity(bob.did);
+    let alice = User::new(AccountKeyring::Alice);
+
+    // Try addind the same secondary_key using `add_secondary_keys_with_authorization`
+    let add_secondary_key_with_auth = |signer, perms| {
+        let expires_at = 100u64;
+        let target_id_auth = |user: User| TargetIdAuthorization {
+            target_id: user.did,
+            nonce: Identity::offchain_authorization_nonce(user.did),
+            expires_at,
+        };
+        let authorization = target_id_auth(alice);
+        let auth_encoded = authorization.encode();
+        let auth_signature = H512::from(bob.ring.sign(&auth_encoded));
+
+        let bob_key = SecondaryKey::new(signer, perms);
+        let key_with_auth = SecondaryKeyWithAuth {
+            auth_signature,
+            secondary_key: bob_key.into(),
+        };
+        Identity::add_secondary_keys_with_authorization(
+            alice.origin(),
+            vec![key_with_auth],
+            expires_at,
+        )
+    };
+
+    let perm1 = Permissions::empty();
+    let perm2 = Permissions::from_pallet_permissions(vec![PalletPermissions::entire_pallet(
+        b"identity".into(),
+    )]);
+
+    // count alice's secondary keys.
+    let count_keys = || get_secondary_keys(alice.did).len();
+
+    // Add bob's identity signatory with empty permissions
+    let res = add_secondary_key_with_auth(bob_identity_signer, perm1.clone());
+    assert_ok!(res);
+    assert_eq!(count_keys(), 1);
+
+    // Add bob's identity signatory again with non-empty permissions
+    let res = add_secondary_key_with_auth(bob_identity_signer, perm2.clone());
+    // FIXME
+    //assert_noop!(res, Error::AlreadyLinked);
+    //assert_eq!(count_keys(), 1);
+    assert_ok!(res);
+    assert_eq!(count_keys(), 2);
+
+    // Add bob's identity signatory again.
+    let res = add_secondary_key_with_auth(bob_identity_signer, perm1.clone());
+    // FIXME
+    //assert_noop!(res, Error::AlreadyLinked);
+    //assert_eq!(count_keys(), 1);
+    assert_ok!(res);
+    assert_eq!(count_keys(), 3);
+}
+
+#[test]
 fn add_secondary_keys_with_permissions_test() {
     ExtBuilder::default()
         .monied(true)

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -383,7 +383,9 @@ fn do_add_permissions_to_multiple_tokens() {
     test_set_perms(AssetPermissions::empty());
 
     // bulk add in reverse order.
-    test_set_perms(AssetPermissions::elems(tokens[0..max_tokens].into_iter().rev().cloned()));
+    test_set_perms(AssetPermissions::elems(
+        tokens[0..max_tokens].into_iter().rev().cloned(),
+    ));
 }
 
 #[test]

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -648,17 +648,15 @@ fn do_add_secondary_keys_with_ident_signer_test() {
     let res = add_secondary_key_with_auth(bob_identity_signer, perm2.clone());
     // FIXME
     //assert_noop!(res, Error::AlreadyLinked);
-    //assert_eq!(count_keys(), 1);
     assert_ok!(res);
-    assert_eq!(count_keys(), 2);
+    assert_eq!(count_keys(), 1);
 
     // Add bob's identity signatory again.
     let res = add_secondary_key_with_auth(bob_identity_signer, perm1.clone());
     // FIXME
     //assert_noop!(res, Error::AlreadyLinked);
-    //assert_eq!(count_keys(), 1);
     assert_ok!(res);
-    assert_eq!(count_keys(), 3);
+    assert_eq!(count_keys(), 1);
 }
 
 #[test]

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -703,7 +703,6 @@ fn do_join_identity_as_identity_with_perm_test() {
     assert_eq!(count_keys(), 1);
 }
 
-
 #[test]
 fn add_secondary_keys_with_permissions_test() {
     ExtBuilder::default()

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -368,7 +368,7 @@ fn do_add_permissions_to_multiple_tokens() {
             alice.origin(),
             bob_signer,
             Permissions {
-                asset: AssetPermissions::elems(tokens[0..num_token].into_iter().map(|t| t.clone())),
+                asset: AssetPermissions::elems(tokens[0..num_token].into_iter().cloned()),
                 ..Default::default()
             },
         ));
@@ -387,9 +387,7 @@ fn do_add_permissions_to_multiple_tokens() {
         alice.origin(),
         bob_signer,
         Permissions {
-            asset: AssetPermissions::elems(
-                tokens[0..max_tokens].into_iter().rev().map(|t| t.clone())
-            ),
+            asset: AssetPermissions::elems(tokens[0..max_tokens].into_iter().rev().cloned()),
             ..Default::default()
         },
     ));

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -714,15 +714,11 @@ fn do_remove_secondary_keys_test() {
         )])
         .into(),
     );
-    assert_ok!(result);
-    // FIXME: use this after the fix.
-    //assert_noop!(result, Error::NotASigner);
+    assert_noop!(result, Error::NotASigner);
 
     // Check DidRecords
     let keys = get_secondary_keys(alice.did);
-    assert_eq!(keys.len(), 2);
-    // FIXME: used this after the fix
-    //assert_eq!(keys.len(), 1);
+    assert_eq!(keys.len(), 1);
 
     // Check identity map
     assert_eq!(Identity::get_identity(&bob_key), None);
@@ -751,10 +747,7 @@ fn do_remove_secondary_keys_test() {
 
     // Check DidRecords
     let keys = get_secondary_keys(alice.did);
-    // 2 x bob_key
-    assert_eq!(keys.len(), 2);
-    // FIXME: used this after the fix
-    //assert_eq!(keys.len(), 0);
+    assert_eq!(keys.len(), 0);
 }
 
 #[test]

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -363,34 +363,27 @@ fn do_add_permissions_to_multiple_tokens() {
         })
         .collect();
 
-    let set_bob_asset_permissions = |num_token| {
+    let test_set_perms = |asset| {
         assert_ok!(Identity::set_permission_to_signer(
             alice.origin(),
             bob_signer,
             Permissions {
-                asset: AssetPermissions::elems(tokens[0..num_token].into_iter().cloned()),
+                asset,
                 ..Default::default()
             },
         ));
     };
 
-    // add one-by-one
+    // add one-by-one.
     for num in 0..max_tokens {
-        set_bob_asset_permissions(num);
+        test_set_perms(AssetPermissions::elems(tokens[0..num].into_iter().cloned()));
     }
 
-    // remove all permissions
-    set_bob_asset_permissions(0);
+    // remove all permissions.
+    test_set_perms(AssetPermissions::empty());
 
-    // bulk add, reverse order
-    assert_ok!(Identity::set_permission_to_signer(
-        alice.origin(),
-        bob_signer,
-        Permissions {
-            asset: AssetPermissions::elems(tokens[0..max_tokens].into_iter().rev().cloned()),
-            ..Default::default()
-        },
-    ));
+    // bulk add in reverse order.
+    test_set_perms(AssetPermissions::elems(tokens[0..max_tokens].into_iter().rev().cloned()));
 }
 
 #[test]
@@ -605,7 +598,7 @@ fn do_add_secondary_keys_with_ident_signer_test() {
     let bob_identity_signer = Signatory::Identity(bob.did);
     let alice = User::new(AccountKeyring::Alice);
 
-    // Try addind the same secondary_key using `add_secondary_keys_with_authorization`
+    // Try adding the same `secondary_key` using `add_secondary_keys_with_authorization`.
     let add_secondary_key_with_auth = |signer, perms| {
         let expires_at = 100u64;
         let target_id_auth = |user: User| TargetIdAuthorization {

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -57,10 +57,14 @@ where
     /// It removes `keys_to_remove` from secondary keys.
     pub fn remove_secondary_keys(
         &mut self,
-        mut signers_to_remove: impl Iterator<Item = Signatory<AccountId>>,
+        signers_to_remove: &[Signatory<AccountId>],
     ) -> &mut Self {
-        self.secondary_keys
-            .retain(|curr_si| !signers_to_remove.any(|signer| curr_si.signer == signer));
+        self.secondary_keys.retain(|curr_si| {
+            signers_to_remove
+                .into_iter()
+                .find(|&signer| curr_si.signer == *signer)
+                .is_none()
+        });
         self
     }
 }

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -47,7 +47,6 @@ where
     }
 
     /// It adds `new_secondary_keys` to `self`.
-    /// It also keeps its internal list sorted and removes duplicate elements.
     pub fn add_secondary_keys(
         &mut self,
         new_secondary_keys: impl IntoIterator<Item = SecondaryKey<AccountId>>,

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -41,6 +41,14 @@ where
         }
     }
 
+    /// Check if `signer` is already a secondary key.
+    pub fn contains_secondary_key(
+        &self,
+        signer: &Signatory<AccountId>,
+    ) -> bool {
+        self.secondary_keys.iter().any(|sk| sk.signer == *signer)
+    }
+
     /// It adds `new_secondary_keys` to `self`.
     /// It also keeps its internal list sorted and removes duplicate elements.
     pub fn add_secondary_keys(
@@ -48,8 +56,6 @@ where
         new_secondary_keys: impl IntoIterator<Item = SecondaryKey<AccountId>>,
     ) -> &mut Self {
         self.secondary_keys.extend(new_secondary_keys);
-        self.secondary_keys.sort();
-        self.secondary_keys.dedup();
 
         self
     }

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -63,7 +63,7 @@ where
     ) -> &mut Self {
         self.secondary_keys.retain(|curr_si| {
             signers_to_remove
-                .into_iter()
+                .iter()
                 .find(|&signer| curr_si.signer == *signer)
                 .is_none()
         });

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -42,10 +42,7 @@ where
     }
 
     /// Check if `signer` is already a secondary key.
-    pub fn contains_secondary_key(
-        &self,
-        signer: &Signatory<AccountId>,
-    ) -> bool {
+    pub fn contains_secondary_key(&self, signer: &Signatory<AccountId>) -> bool {
         self.secondary_keys.iter().any(|sk| sk.signer == *signer)
     }
 

--- a/primitives/src/secondary_key.rs
+++ b/primitives/src/secondary_key.rs
@@ -310,7 +310,7 @@ where
     AccountId: Encode + Decode + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.signer == other.signer && self.permissions == other.permissions
+        self.signer == other.signer
     }
 }
 

--- a/primitives/src/secondary_key.rs
+++ b/primitives/src/secondary_key.rs
@@ -232,7 +232,7 @@ where
 }
 
 /// A secondary key is a signatory with defined permissions.
-#[derive(Encode, Decode, Default, Clone, Eq, Debug)]
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct SecondaryKey<AccountId: Encode + Decode> {
     /// The account or identity that is the signatory of this key.
@@ -305,15 +305,6 @@ where
     }
 }
 
-impl<AccountId> PartialEq for SecondaryKey<AccountId>
-where
-    AccountId: Encode + Decode + PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.signer == other.signer && self.permissions == other.permissions
-    }
-}
-
 impl<AccountId> PartialEq<IdentityId> for SecondaryKey<AccountId>
 where
     AccountId: Encode + Decode,
@@ -324,25 +315,6 @@ where
         } else {
             false
         }
-    }
-}
-
-impl<AccountId> PartialOrd for SecondaryKey<AccountId>
-where
-    AccountId: Encode + Decode + Ord,
-{
-    /// Any key is less than any Identity.
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.signer.partial_cmp(&other.signer)
-    }
-}
-
-impl<AccountId> Ord for SecondaryKey<AccountId>
-where
-    AccountId: Encode + Decode + Ord,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.signer.cmp(&other.signer)
     }
 }
 

--- a/primitives/src/secondary_key.rs
+++ b/primitives/src/secondary_key.rs
@@ -310,7 +310,7 @@ where
     AccountId: Encode + Decode + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.signer == other.signer
+        self.signer == other.signer && self.permissions == other.permissions
     }
 }
 


### PR DESCRIPTION

## changelog

### new features

None

### modified API

None.

### modified logic

- Fix bug with `PartialEq for SecondaryKey<AccountId>`
- Fix duplicate secondary key bug in `add_secondary_keys_with_authorization` and `join_identity_as_identity`.
- Fix bug with removing a secondary key.
- An `AlreadyLinked` error will be thrown if a secondary key already exists.
