### PR TITLE
Authorization refactor; nix `accept_authorization` for explicit extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,7 +4347,7 @@ dependencies = [
 name = "pallet-asset"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.7.1",
  "frame-benchmarking 3.1.0",
  "frame-support",
  "frame-system",

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 serde_json = "1.0.48"
 rustc-hex = { version = "2.1.0", default-features = false }
 hex-literal = "0.2.1"
-arrayvec = { version = "0.5.1", default-features = false }
+arrayvec = { version = "0.7.1", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -24,7 +24,7 @@ use polymesh_common_utilities::{
     TestUtilsFn,
 };
 //use polymesh_contracts::ExtensionInfo;
-use polymesh_primitives::{asset::AssetName, ticker::TICKER_LEN, Signatory, Ticker};
+use polymesh_primitives::{AuthorizationData, asset::AssetName, ticker::TICKER_LEN, Signatory, Ticker};
 //use polymesh_primitives::{ExtensionAttributes, SmartExtension};
 use sp_io::hashing::keccak_256;
 use sp_std::{convert::TryInto, iter, prelude::*};

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -24,7 +24,9 @@ use polymesh_common_utilities::{
     TestUtilsFn,
 };
 //use polymesh_contracts::ExtensionInfo;
-use polymesh_primitives::{AuthorizationData, asset::AssetName, ticker::TICKER_LEN, Signatory, Ticker};
+use polymesh_primitives::{
+    asset::AssetName, ticker::TICKER_LEN, AuthorizationData, Signatory, Ticker,
+};
 //use polymesh_primitives::{ExtensionAttributes, SmartExtension};
 use sp_io::hashing::keccak_256;
 use sp_std::{convert::TryInto, iter, prelude::*};

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -439,7 +439,7 @@ benchmarks! {
             AuthorizationData::BecomeAgent(ticker, AgentGroup::Full),
             None,
         );
-        identity::Module::<T>::accept_authorization(pia.origin().into(), auth_id)?;
+        pallet_external_agents::Module::<T>::accept_become_agent(pia.origin().into(), auth_id)?;
         emulate_controller_transfer::<T>(ticker, investor.did(), pia.did());
         let portfolio_to = PortfolioId::default_portfolio(investor.did());
     }: _(pia.origin, ticker, 500u32.into(), portfolio_to)

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1716,7 +1716,7 @@ impl<T: Config> Module<T> {
 
         // Charge protocol fees.
         T::ProtocolFee::charge_fees(&{
-            let mut fees = ArrayVec::<[_; 2]>::new();
+            let mut fees = ArrayVec::<_, 2>::new();
             if available {
                 fees.push(ProtocolOp::AssetRegisterTicker);
             }

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -31,26 +31,6 @@ use sp_std::prelude::Vec;
 
 /// This trait is used by the `identity` pallet to interact with the `pallet-asset`.
 pub trait AssetSubTrait<Balance> {
-    /// Accept and process a ticker transfer
-    ///
-    /// # Arguments
-    /// * `to` did of the receiver.
-    /// * `from` sender of the authorization.
-    /// * `ticker` that is being transferred.
-    fn accept_ticker_transfer(to: IdentityId, from: IdentityId, ticker: Ticker) -> DispatchResult;
-
-    /// Accept and process a token ownership transfer
-    ///
-    /// # Arguments
-    /// * `to` did of the receiver.
-    /// * `from` sender of the authorization.
-    /// * `ticker` that is being transferred.
-    fn accept_asset_ownership_transfer(
-        to: IdentityId,
-        from: IdentityId,
-        ticker: Ticker,
-    ) -> DispatchResult;
-
     /// Update the `ticker` balance of `target_did` under `scope_id`. Clean up the balances related
     /// to any previous valid `old_scope_ids`.
     ///

--- a/pallets/common/src/traits/external_agents.rs
+++ b/pallets/common/src/traits/external_agents.rs
@@ -9,6 +9,7 @@ pub trait WeightInfo {
     fn abdicate() -> Weight;
     fn change_group_builtin() -> Weight;
     fn change_group_custom() -> Weight;
+    fn accept_become_agent() -> Weight;
 }
 
 pub trait Config: frame_system::Config + crate::balances::Config {

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -27,14 +27,14 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::{
     decl_event,
-    dispatch::{DispatchResult, PostDispatchInfo},
+    dispatch::PostDispatchInfo,
     traits::{Currency, EnsureOrigin, Get, GetCallMetadata},
     weights::{GetDispatchInfo, Weight},
     Parameter,
 };
 use polymesh_primitives::{
-    agent::AgentGroup, secondary_key::api::SecondaryKey, AuthorizationData, DispatchableName,
-    IdentityClaim, IdentityId, InvestorUid, PalletName, Permissions, Signatory, Ticker,
+    secondary_key::api::SecondaryKey, AuthorizationData, DispatchableName, IdentityClaim,
+    IdentityId, InvestorUid, PalletName, Permissions, Signatory, Ticker,
 };
 use sp_core::H512;
 use sp_runtime::traits::{Dispatchable, IdentifyAccount, Member, Verify};
@@ -98,17 +98,6 @@ pub trait WeightInfo {
     fn revoke_claim_by_index() -> Weight;
 }
 
-/// The link between the identity and external agents pallet for becoming agent authorization.
-pub trait IdentityToExternalAgents {
-    /// Accept from `from`, for `did`, the role as an agent of `ticker` with `group`.
-    fn accept_become_agent(
-        did: IdentityId,
-        from: IdentityId,
-        ticker: Ticker,
-        group: AgentGroup,
-    ) -> DispatchResult;
-}
-
 /// The module's configuration trait.
 pub trait Config: CommonConfig + pallet_timestamp::Config + crate::traits::base::Config {
     /// The overarching event type.
@@ -141,9 +130,6 @@ pub trait Config: CommonConfig + pallet_timestamp::Config + crate::traits::base:
 
     /// Weight information for extrinsics in the identity pallet.
     type WeightInfo: WeightInfo;
-
-    /// Negotiates between External Agents and the Identity pallet.
-    type ExternalAgents: IdentityToExternalAgents;
 
     /// Identity functions
     type IdentityFn: IdentityFnTrait<Self::AccountId>;

--- a/pallets/common/src/traits/multisig.rs
+++ b/pallets/common/src/traits/multisig.rs
@@ -18,25 +18,10 @@
 //! The interface allows to process addition of a multisig signer from modules other than the
 //! multisig module itself.
 
-use frame_support::dispatch::DispatchResult;
-use polymesh_primitives::{IdentityId, Signatory};
-
 use sp_std::vec::Vec;
 
 /// This trait is used to add a signer to a multisig and enable unlinking multisig from an identity
 pub trait MultiSigSubTrait<AccountId> {
-    /// Accepts and adds a multisig signer.
-    ///
-    /// # Arguments
-    /// * `signer` - DID/key of the signer
-    /// * `from` - The DID that sent the authorization
-    /// * `multisig` - The multisig address
-    fn accept_multisig_signer(
-        signer: Signatory<AccountId>,
-        from: IdentityId,
-        multisig: AccountId,
-    ) -> DispatchResult;
-
     /// Fetches signers of a multisig
     ///
     /// # Arguments

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -32,18 +32,6 @@ use sp_std::vec::Vec;
 
 /// This trait is used to accept custody of a portfolio
 pub trait PortfolioSubTrait<Balance, AccountId: Encode + Decode> {
-    /// Accepts custody of a portfolio
-    ///
-    /// # Arguments
-    /// * `to` - DID of the new custodian
-    /// * `from` - Sender of the authorization
-    /// * `pid` - The old portfolio ID
-    fn accept_portfolio_custody(
-        to: IdentityId,
-        from: IdentityId,
-        pid: PortfolioId,
-    ) -> DispatchResult;
-
     /// Checks that the custodian is authorized for the portfolio
     ///
     /// # Arguments
@@ -88,6 +76,7 @@ pub trait WeightInfo {
     fn move_portfolio_funds(i: u32) -> Weight;
     fn rename_portfolio(i: u32) -> Weight;
     fn quit_portfolio_custody() -> Weight;
+    fn accept_portfolio_custody() -> Weight;
 }
 
 pub trait Config: CommonConfig + identity::Config + base::Config {

--- a/pallets/external-agents/src/lib.rs
+++ b/pallets/external-agents/src/lib.rs
@@ -496,16 +496,8 @@ impl<T: Config> Module<T> {
             Some(AgentGroup::Custom(ag_id)) => {
                 GroupPermissions::get(ticker, ag_id).unwrap_or_else(ExtrinsicPermissions::empty)
             }
-            // Anything but extrinsics in this pallet & `accept_authorization`.
-            Some(AgentGroup::ExceptMeta) => SubsetRestriction::excepts(IntoIter::new([
-                // `Identity::accept_authorization` needs to be excluded.
-                in_pallet(
-                    "Identity",
-                    SubsetRestriction::elem("accept_authorization".into()),
-                ),
-                // `ExternalAgents` needs to be excluded.
-                pallet("ExternalAgents"),
-            ])),
+            // Anything but extrinsics in this pallet.
+            Some(AgentGroup::ExceptMeta) => SubsetRestriction::except(pallet("ExternalAgents")),
             // Pallets `CorporateAction`, `CorporateBallot`, and `CapitalDistribution`.
             Some(AgentGroup::PolymeshV1CAA) => elems([
                 pallet("CorporateAction"),

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -584,12 +584,8 @@ decl_module! {
             Self::ensure_auth_unexpired(auth.expiry)?;
 
             match (signer.clone(), auth.authorization_data) {
-                (Signatory::Identity(did), AuthorizationData::TransferTicker(ticker)) =>
-                    T::AssetSubTraitTarget::accept_ticker_transfer(did, from, ticker),
                 (Signatory::Identity(did), AuthorizationData::BecomeAgent(ticker, group)) =>
                     T::ExternalAgents::accept_become_agent(did, from, ticker, group),
-                (Signatory::Identity(did), AuthorizationData::TransferAssetOwnership(ticker)) =>
-                    T::AssetSubTraitTarget::accept_asset_ownership_transfer(did, from, ticker),
                 (Signatory::Identity(did), AuthorizationData::PortfolioCustody(pid)) =>
                     T::Portfolio::accept_portfolio_custody(did, from, pid),
                 (Signatory::Account(key), AuthorizationData::RotatePrimaryKey(_)) =>
@@ -600,14 +596,14 @@ decl_module! {
                     | AuthorizationData::NoData
                     | AuthorizationData::AddMultiSigSigner(..)
                     | AuthorizationData::JoinIdentity(..)
+                    | AuthorizationData::TransferTicker(..)
+                    | AuthorizationData::TransferAssetOwnership(..)
                     | AuthorizationData::TransferPrimaryIssuanceAgent(..)
                     | AuthorizationData::TransferCorporateActionAgent(..)
                 )
                 | (Signatory::Identity(_), AuthorizationData::RotatePrimaryKey(..))
                 | (Signatory::Account(_),
-                    AuthorizationData::TransferTicker(..)
                     | AuthorizationData::BecomeAgent(..)
-                    | AuthorizationData::TransferAssetOwnership(..)
                     | AuthorizationData::PortfolioCustody(..)
                 ) => fail!(AuthorizationError::BadType)
             }?;

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -17,7 +17,7 @@ use crate::*;
 use core::convert::TryInto;
 use frame_benchmarking::benchmarks;
 use polymesh_common_utilities::{
-    benchs::{AccountIdOf, user, User},
+    benchs::{user, AccountIdOf, User},
     TestUtilsFn,
 };
 use polymesh_primitives::{AuthorizationData, PortfolioName, Signatory};
@@ -29,7 +29,8 @@ fn make_worst_memo() -> Option<Memo> {
     Some(Memo([7u8; 32]))
 }
 
-fn owner_portfolio<T: Config + TestUtilsFn<<T as frame_system::Config>::AccountId>>() -> (User<T>, PortfolioId) {
+fn owner_portfolio<T: Config + TestUtilsFn<<T as frame_system::Config>::AccountId>>(
+) -> (User<T>, PortfolioId) {
     let owner = user::<T>("owner", 0);
 
     let name = PortfolioName(vec![65u8; PORTFOLIO_NAME_LEN as usize]);
@@ -50,7 +51,10 @@ fn add_auth<T: Config>(owner: &User<T>, custodian: &User<T>, pid: PortfolioId) -
 }
 
 fn assert_custodian<T: Config>(pid: PortfolioId, custodian: &User<T>, holds: bool) {
-    assert_eq!(PortfolioCustodian::get(&pid), holds.then(|| custodian.did()));
+    assert_eq!(
+        PortfolioCustodian::get(&pid),
+        holds.then(|| custodian.did())
+    );
     assert_eq!(PortfoliosInCustody::get(&custodian.did(), &pid), holds);
 }
 

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -57,8 +57,8 @@ use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
 pub use polymesh_common_utilities::traits::portfolio::{Config, Event, RawEvent, WeightInfo};
 use polymesh_common_utilities::CommonConfig;
 use polymesh_primitives::{
-    identity_id::PortfolioValidityResult, storage_migration_ver, IdentityId, PortfolioId,
-    PortfolioKind, PortfolioName, PortfolioNumber, SecondaryKey, Ticker, extract_auth,
+    extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, IdentityId,
+    PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber, SecondaryKey, Ticker,
 };
 use sp_arithmetic::traits::{CheckedSub, Saturating};
 use sp_std::{iter, mem, prelude::Vec};

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -211,7 +211,6 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type ProtocolFee = pallet_protocol_fee::Module<Runtime>;
     type GCVotingMajorityOrigin = VMO<GovernanceCommittee>;
     type WeightInfo = polymesh_weights::pallet_identity::WeightInfo;
-    type ExternalAgents = ExternalAgents;
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;

--- a/pallets/runtime/itn/src/runtime.rs
+++ b/pallets/runtime/itn/src/runtime.rs
@@ -212,7 +212,6 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type ProtocolFee = pallet_protocol_fee::Module<Runtime>;
     type GCVotingMajorityOrigin = VMO<GovernanceCommittee>;
     type WeightInfo = polymesh_weights::pallet_identity::WeightInfo;
-    type ExternalAgents = ExternalAgents;
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -212,7 +212,6 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type ProtocolFee = pallet_protocol_fee::Module<Runtime>;
     type GCVotingMajorityOrigin = VMO<GovernanceCommittee>;
     type WeightInfo = polymesh_weights::pallet_identity::WeightInfo;
-    type ExternalAgents = ExternalAgents;
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -41,9 +41,9 @@ use polymesh_primitives::{
     calendar::{
         CalendarPeriod, CalendarUnit, CheckpointId, CheckpointSchedule, FixedOrVariableCalendarUnit,
     },
-    AccountId, AssetIdentifier, AssetPermissions, AuthorizationData, Document, DocumentId,
-    IdentityId, InvestorUid, Moment, Permissions, PortfolioId, PortfolioName, SecondaryKey,
-    Signatory, Ticker,
+    AccountId, AssetIdentifier, AssetPermissions, AuthorizationData, AuthorizationError, Document,
+    DocumentId, IdentityId, InvestorUid, Moment, Permissions, PortfolioId, PortfolioName,
+    SecondaryKey, Signatory, Ticker,
 };
 use rand::Rng;
 use sp_io::hashing::keccak_256;
@@ -581,7 +581,7 @@ fn transfer_ticker() {
 
         assert_noop!(
             Asset::accept_ticker_transfer(bob.origin(), auth_id),
-            AssetError::NoTickerTransferAuth
+            AuthorizationError::BadType
         );
 
         let auth_id = add_auth(AuthorizationData::TransferTicker(ticker), now() + 100);
@@ -726,7 +726,7 @@ fn transfer_token_ownership() {
 
         assert_noop!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id),
-            AssetError::NotTickerOwnershipTransferAuth
+            AuthorizationError::BadType
         );
 
         auth_id = Identity::add_auth(

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -36,6 +36,7 @@ type ComplianceManager = compliance_manager::Module<TestStorage>;
 type CDDGroup = group::Module<TestStorage, group::Instance2>;
 type Moment = u64;
 type Origin = <TestStorage as frame_system::Config>::Origin;
+type ExternalAgents = pallet_external_agents::Module<TestStorage>;
 type EAError = pallet_external_agents::Error<TestStorage>;
 
 macro_rules! assert_invalid_transfer {
@@ -1185,7 +1186,7 @@ fn can_verify_restriction_with_primary_issuance_agent_we() {
         AuthorizationData::BecomeAgent(ticker, AgentGroup::Full),
         None,
     );
-    assert_ok!(Identity::accept_authorization(issuer.origin(), auth_id));
+    assert_ok!(ExternalAgents::accept_become_agent(issuer.origin(), auth_id));
     let amount = 1_000;
 
     // Provide scope claim for sender and receiver.

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -1186,7 +1186,10 @@ fn can_verify_restriction_with_primary_issuance_agent_we() {
         AuthorizationData::BecomeAgent(ticker, AgentGroup::Full),
         None,
     );
-    assert_ok!(ExternalAgents::accept_become_agent(issuer.origin(), auth_id));
+    assert_ok!(ExternalAgents::accept_become_agent(
+        issuer.origin(),
+        auth_id
+    ));
     let amount = 1_000;
 
     // Provide scope claim for sender and receiver.

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -128,7 +128,7 @@ fn add_caa_auth(ticker: Ticker, from: User, to: User) -> u64 {
 
 fn transfer_caa(ticker: Ticker, from: User, to: User) -> DispatchResult {
     let auth_id = add_caa_auth(ticker, from, to);
-    Identity::accept_authorization(to.origin(), auth_id)?;
+    ExternalAgents::accept_become_agent(to.origin(), auth_id)?;
     ExternalAgents::abdicate(from.origin(), ticker)?;
     Ok(())
 }
@@ -332,7 +332,7 @@ fn only_owner_caa_invite() {
     test(|ticker, [_, caa, other]| {
         let auth_id = add_caa_auth(ticker, other, caa);
         assert_noop!(
-            Identity::accept_authorization(caa.origin(), auth_id),
+            ExternalAgents::accept_become_agent(caa.origin(), auth_id),
             EAError::UnauthorizedAgent
         );
     });

--- a/pallets/runtime/tests/src/external_agents_test.rs
+++ b/pallets/runtime/tests/src/external_agents_test.rs
@@ -44,10 +44,10 @@ fn add_become_agent(
     let auth = Id::add_auth(from.did, sig, data, None);
     match expected {
         Ok(_) => {
-            assert_ok!(Id::accept_authorization(to.origin(), auth));
+            assert_ok!(ExternalAgents::accept_become_agent(to.origin(), auth));
         }
         Err(e) => {
-            assert_noop!(Id::accept_authorization(to.origin(), auth), e);
+            assert_noop!(ExternalAgents::accept_become_agent(to.origin(), auth), e);
         }
     };
 }

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1646,7 +1646,7 @@ fn cdd_register_did_test_we() {
 
     let dave_auth_id = get_last_auth_id(&dave_si.signer);
 
-    assert_ok!(Identity::accept_authorization(
+    assert_ok!(Identity::join_identity_as_key(
         Origin::signed(dave),
         dave_auth_id
     ));
@@ -1658,7 +1658,7 @@ fn cdd_register_did_test_we() {
     let alice_auth_id = get_last_auth_id(&alice_si.signer);
 
     TestStorage::set_current_identity(&alice_id);
-    assert_ok!(Identity::accept_authorization(
+    assert_ok!(Identity::join_identity_as_identity(
         Origin::signed(alice),
         alice_auth_id
     ));
@@ -2026,13 +2026,13 @@ fn add_permission_with_secondary_key() {
             println!("Print the protocol base fee: {:?}", PROTOCOL_OP_BASE_FEE);
 
             // accept the auth_id
-            assert_ok!(Identity::accept_authorization(
+            assert_ok!(Identity::join_identity_as_key(
                 Origin::signed(bob_acc),
                 bob_auth_id
             ));
 
             // accept the auth_id
-            assert_ok!(Identity::accept_authorization(
+            assert_ok!(Identity::join_identity_as_key(
                 Origin::signed(charlie_acc),
                 charlie_auth_id
             ));
@@ -2236,7 +2236,7 @@ fn ext_join_identity_as_identity() {
         let auth_id = get_last_auth_id(&bob.did.into());
         assert_noop!(
             Identity::join_identity_as_identity(bob.origin(), auth_id),
-            AuthorizationError::Invalid
+            AuthorizationError::BadType
         );
 
         setup_join_identity(&alice, &bob);

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -37,7 +37,7 @@ fn set_custodian_ok(current_custodian: User, new_custodian: User, portfolio_id: 
         AuthorizationData::PortfolioCustody(portfolio_id),
         None,
     );
-    assert_ok!(Identity::accept_authorization(
+    assert_ok!(Portfolio::accept_portfolio_custody(
         new_custodian.origin(),
         auth_id
     ));
@@ -459,19 +459,19 @@ fn can_take_custody_of_portfolios() {
 
         let auth_id = add_auth(bob, bob);
         assert_noop!(
-            Identity::accept_authorization(bob.origin(), auth_id),
+            Portfolio::accept_portfolio_custody(bob.origin(), auth_id),
             AuthorizationError::Unauthorized
         );
 
         // Can not accept an invalid auth
         assert_noop!(
-            Identity::accept_authorization(bob.origin(), auth_id + 1),
+            Portfolio::accept_portfolio_custody(bob.origin(), auth_id + 1),
             AuthorizationError::Invalid
         );
 
         // Can accept a valid custody transfer auth
         let auth_id = add_auth(owner, bob);
-        assert_ok!(Identity::accept_authorization(bob.origin(), auth_id));
+        assert_ok!(Portfolio::accept_portfolio_custody(bob.origin(), auth_id));
 
         assert_ok!(Portfolio::ensure_portfolio_custody(
             owner_default_portfolio,
@@ -498,7 +498,7 @@ fn can_take_custody_of_portfolios() {
         // Owner can not issue authorization for custody transfer of a portfolio they don't have custody of
         let auth_id = add_auth(owner, owner);
         assert_noop!(
-            Identity::accept_authorization(owner.origin(), auth_id),
+            Portfolio::accept_portfolio_custody(owner.origin(), auth_id),
             AuthorizationError::Unauthorized
         );
 

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -2951,7 +2951,7 @@ fn multiple_custodian_settlement() {
                 AuthorizationData::PortfolioCustody(PortfolioId::user_portfolio(bob_did, bob_num)),
                 None,
             );
-            assert_ok!(Identity::accept_authorization(
+            assert_ok!(Portfolio::accept_portfolio_custody(
                 alice_signed.clone(),
                 auth_id
             ));
@@ -3068,7 +3068,10 @@ fn multiple_custodian_settlement() {
                 )),
                 None,
             );
-            assert_ok!(Identity::accept_authorization(bob_signed.clone(), auth_id2));
+            assert_ok!(Portfolio::accept_portfolio_custody(
+                bob_signed.clone(),
+                auth_id2
+            ));
 
             // Bob fails to approve the instruction with both of his portfolios since he doesn't have custody for the second one
             let portfolios_bob = vec![

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -469,13 +469,6 @@ impl IdentityToExternalAgents for Test {
 }
 
 impl MultiSigSubTrait<AccountId> for Test {
-    fn accept_multisig_signer(
-        _: Signatory<AccountId>,
-        _: IdentityId,
-        _: AccountId,
-    ) -> DispatchResult {
-        unimplemented!()
-    }
     fn get_key_signers(_multisig: &AccountId) -> Vec<AccountId> {
         unimplemented!()
     }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -41,7 +41,6 @@ use polymesh_common_utilities::{
         asset::AssetSubTrait,
         balances::{AccountData, CheckCdd},
         group::{GroupTrait, InactiveMember},
-        identity::IdentityToExternalAgents,
         multisig::MultiSigSubTrait,
         portfolio::PortfolioSubTrait,
         transaction_payment::{CddAndFeeDetails, ChargeTxFee},
@@ -448,17 +447,6 @@ impl AssetSubTrait<Balance> for Test {
     }
     fn scope_id_of(_: &Ticker, _: &IdentityId) -> ScopeId {
         ScopeId::from(0u128)
-    }
-}
-
-impl IdentityToExternalAgents for Test {
-    fn accept_become_agent(
-        _: IdentityId,
-        _: IdentityId,
-        _: Ticker,
-        _: AgentGroup,
-    ) -> DispatchResult {
-        Ok(())
     }
 }
 

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -442,12 +442,6 @@ impl GroupTrait<Moment> for Test {
 }
 
 impl AssetSubTrait<Balance> for Test {
-    fn accept_ticker_transfer(_: IdentityId, _: IdentityId, _: Ticker) -> DispatchResult {
-        Ok(())
-    }
-    fn accept_asset_ownership_transfer(_: IdentityId, _: IdentityId, _: Ticker) -> DispatchResult {
-        Ok(())
-    }
     fn update_balance_of_scope_id(_: ScopeId, _: IdentityId, _: Ticker) {}
     fn balance_of_at_scope(_: &ScopeId, _: &IdentityId) -> Balance {
         0

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -476,9 +476,6 @@ impl MultiSigSubTrait<AccountId> for Test {
 }
 
 impl PortfolioSubTrait<Balance, AccountId> for Test {
-    fn accept_portfolio_custody(_: IdentityId, _: IdentityId, _: PortfolioId) -> DispatchResult {
-        unimplemented!()
-    }
     fn ensure_portfolio_custody(_: PortfolioId, _: IdentityId) -> DispatchResult {
         unimplemented!()
     }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -48,9 +48,8 @@ use polymesh_common_utilities::{
     },
 };
 use polymesh_primitives::{
-    agent::AgentGroup, identity_id::GenesisIdentityRecord, Authorization, AuthorizationData, CddId,
-    Claim, IdentityId, InvestorUid, Moment, Permissions, PortfolioId, ScopeId, SecondaryKey,
-    Signatory, Ticker,
+    identity_id::GenesisIdentityRecord, Authorization, AuthorizationData, CddId, Claim, IdentityId,
+    InvestorUid, Moment, Permissions, PortfolioId, ScopeId, SecondaryKey, Signatory, Ticker,
 };
 use sp_core::H256;
 use sp_npos_elections::{
@@ -341,7 +340,6 @@ impl polymesh_common_utilities::traits::identity::Config for Test {
     type ProtocolFee = protocol_fee::Module<Test>;
     type GCVotingMajorityOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = polymesh_weights::pallet_identity::WeightInfo;
-    type ExternalAgents = Test;
     type IdentityFn = identity::Module<Test>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -501,7 +501,6 @@ impl polymesh_common_utilities::traits::identity::Config for TestStorage {
     type ProtocolFee = protocol_fee::Module<TestStorage>;
     type GCVotingMajorityOrigin = VMO<committee::Instance1>;
     type WeightInfo = polymesh_weights::pallet_identity::WeightInfo;
-    type ExternalAgents = ExternalAgents;
     type IdentityFn = identity::Module<TestStorage>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;

--- a/pallets/weights/src/pallet_external_agents.rs
+++ b/pallets/weights/src/pallet_external_agents.rs
@@ -39,4 +39,9 @@ impl pallet_external_agents::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(8 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
+    fn accept_become_agent() -> Weight {
+        (109_562_000 as Weight)
+            .saturating_add(DbWeight::get().reads(10 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -31,7 +31,14 @@ impl pallet_portfolio::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn quit_portfolio_custody() -> Weight {
-        // TODO
-        100_000_000 as Weight
+        (116_199_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(7 as Weight))
+            .saturating_add(T::DbWeight::get().writes(2 as Weight))
     }
+    fn accept_portfolio_custody() -> Weight {
+        (98_413_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(8 as Weight))
+            .saturating_add(T::DbWeight::get().writes(5 as Weight))
+    }
+
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -32,13 +32,12 @@ impl pallet_portfolio::WeightInfo for WeightInfo {
     }
     fn quit_portfolio_custody() -> Weight {
         (116_199_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(7 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn accept_portfolio_custody() -> Weight {
         (98_413_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(8 as Weight))
-            .saturating_add(T::DbWeight::get().writes(5 as Weight))
+            .saturating_add(DbWeight::get().reads(8 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
-
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -892,14 +892,12 @@
                 "AttestPrimaryKeyRotation": "",
                 "RotatePrimaryKey": "",
                 "TransferTicker": "",
-                "TransferPrimaryIssuanceAgent": "",
                 "AddMultiSigSigner": "",
                 "TransferAssetOwnership": "",
                 "JoinIdentity": "",
                 "PortfolioCustody": "",
                 "Custom": "",
-                "NoData": "",
-                "TransferCorporateActionAgent": ""
+                "NoData": ""
             }
         },
         "ProposalDetails": {

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -64,12 +64,8 @@ impl<T> AuthorizationData<T> {
             Self::AttestPrimaryKeyRotation(..) => AuthorizationType::AttestPrimaryKeyRotation,
             Self::RotatePrimaryKey(..) => AuthorizationType::RotatePrimaryKey,
             Self::TransferTicker(..) => AuthorizationType::TransferTicker,
-            Self::TransferPrimaryIssuanceAgent(..) => {
-                AuthorizationType::TransferPrimaryIssuanceAgent
-            }
-            Self::TransferCorporateActionAgent(..) => {
-                AuthorizationType::TransferCorporateActionAgent
-            }
+            Self::TransferPrimaryIssuanceAgent(..) => AuthorizationType::NoData,
+            Self::TransferCorporateActionAgent(..) => AuthorizationType::NoData,
             Self::BecomeAgent(..) => AuthorizationType::BecomeAgent,
             Self::AddMultiSigSigner(..) => AuthorizationType::AddMultiSigSigner,
             Self::TransferAssetOwnership(..) => AuthorizationType::TransferAssetOwnership,
@@ -92,8 +88,6 @@ pub enum AuthorizationType {
     RotatePrimaryKey,
     /// Authorization to transfer a ticker.
     TransferTicker,
-    /// Authorization to transfer a token's primary issuance agent.
-    TransferPrimaryIssuanceAgent,
     /// Authorization to add some key int a multi signer.
     AddMultiSigSigner,
     /// Authorization to transfer the asset ownership to other identity.
@@ -106,8 +100,6 @@ pub enum AuthorizationType {
     Custom,
     /// Undefined authorization.
     NoData,
-    /// Not in use anymore.
-    TransferCorporateActionAgent,
     /// Authorization to become an agent of a ticker.
     BecomeAgent,
 }
@@ -121,13 +113,17 @@ impl<AccountId> Default for AuthorizationData<AccountId> {
 /// Status of an Authorization after consume is called on it.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum AuthorizationError {
-    /// Auth does not exist
+    /// Auth identified by an `auth_id` for a given `target` does not exist.
+    /// The `target` might be wrong or the `auth_id` was never created at all.
     Invalid,
     /// Caller not authorized or the identity who created
-    /// this authorization is not authorized to create this authorization
+    /// this authorization is not authorized to create this authorization.
     Unauthorized,
-    /// Auth expired already
+    /// Auth expired already.
     Expired,
+    /// The extrinsic expected a different `AuthorizationType`
+    /// than what the `data.auth_type()` is.
+    BadType,
 }
 
 impl From<AuthorizationError> for DispatchError {
@@ -138,6 +134,7 @@ impl From<AuthorizationError> for DispatchError {
                 DispatchError::Other("Illegal use of Authorization")
             }
             AuthorizationError::Expired => DispatchError::Other("Authorization expired"),
+            AuthorizationError::BadType => DispatchError::Other("Authorization type is wrong"),
         }
     }
 }
@@ -157,4 +154,15 @@ pub struct Authorization<AccountId, Moment> {
 
     /// Authorization id of this authorization
     pub auth_id: u64,
+}
+
+/// Extract the authoriation variant's data, or bail.
+#[macro_export]
+macro_rules! extract_auth {
+    ($data:expr, $variant:ident ( $($f:ident),*) ) => {
+        match $data {
+            $crate::authorization::AuthorizationData::$variant($($f),*) => $($f),*,
+            _ => frame_support::fail!($crate::authorization::AuthorizationError::BadType),
+        }
+    }
 }

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -161,7 +161,7 @@ pub struct Authorization<AccountId, Moment> {
 macro_rules! extract_auth {
     ($data:expr, $variant:ident ( $($f:ident),*) ) => {
         match $data {
-            $crate::authorization::AuthorizationData::$variant($($f),*) => $($f),*,
+            $crate::authorization::AuthorizationData::$variant($($f),*) => ($($f),*),
             _ => frame_support::fail!($crate::authorization::AuthorizationError::BadType),
         }
     }

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -7,4 +7,4 @@ if [[ -z "${pallet}" ]]; then
 fi
 
 cargo build --release --features=runtime-benchmarks && \
-./target/release/polymesh benchmark -p=${pallet} -e=* -s 200 -r 10 --execution Wasm --wasm-execution Compiled --output
+./target/release/polymesh benchmark -p=${pallet} -e=* -s 200 -r 10 --execution Wasm --wasm-execution Compiled --output ${pallet}.rs


### PR DESCRIPTION
## changelog

### modified API

- Removed `Identity::accept_authorization` in favor of `ExternalAgents::accept_become_agent`, `Portfolio::accept_portfolio_custody`, 
- Merge some error types into `AuthorizationError::BadType`.
- Cleanup `AuthorizationType`, removing `TransferPrimaryIssuanceAgent` and `TransferCorporateActionAgent` variants.
