### PR TITLE
MESH-1625: Move out `CADetails` from `CorporateAction`

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -445,4 +445,15 @@ benchmarks! {
     verify {
         assert_eq!(Module::<T>::balance_of(ticker, investor.did()), 500u32.into());
     }
+
+    register_custom_asset_type {
+        let n in 1 .. T::MaxLen::get() as u32;
+
+        let id = Module::<T>::custom_type_id_seq();
+        let owner = owner::<T>();
+        let ty = vec![b'X'; n as usize];
+    }: _(owner.origin, ty)
+    verify {
+        assert_ne!(id, Module::<T>::custom_type_id_seq());
+    }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -112,8 +112,7 @@ use polymesh_primitives::{
     extract_auth,
     statistics::TransferManagerResult,
     storage_migrate_on, storage_migration_ver, AssetIdentifier, Balance, Document, DocumentId,
-    IdentityId, MetaVersion as ExtVersion, PortfolioId, ScopeId, SmartExtension,
-    SmartExtensionType, Ticker,
+    IdentityId, PortfolioId, ScopeId, Ticker,
 };
 use sp_runtime::traits::Zero;
 #[cfg(feature = "std")]
@@ -358,12 +357,14 @@ decl_storage! {
         /// The total balances of tokens issued in all recorded funding rounds.
         /// (ticker, funding round) -> balance
         IssuedInFundingRound get(fn issued_in_funding_round): map hasher(blake2_128_concat) (Ticker, FundingRoundName) => Balance;
+        /*
         /// List of Smart extension added for the given tokens.
         /// ticker, AccountId (SE address) -> SmartExtension detail
         pub ExtensionDetails get(fn extension_details): map hasher(blake2_128_concat) (Ticker, T::AccountId) => SmartExtension<T::AccountId>;
         /// List of Smart extension added for the given tokens and for the given type.
         /// ticker, type of SE -> address/AccountId of SE
         pub Extensions get(fn extensions): map hasher(blake2_128_concat) (Ticker, SmartExtensionType) => Vec<T::AccountId>;
+        */
         /// The set of frozen assets implemented as a membership map.
         /// ticker -> bool
         pub Frozen get(fn frozen): map hasher(blake2_128_concat) Ticker => bool;
@@ -380,8 +381,10 @@ decl_storage! {
         pub AssetDocumentsIdSequence get(fn asset_documents_id_sequence): map hasher(blake2_128_concat) Ticker => DocumentId;
         /// Ticker registration details on Polymath Classic / Ethereum.
         pub ClassicTickers get(fn classic_ticker_registration): map hasher(blake2_128_concat) Ticker => Option<ClassicTickerRegistration>;
+        /*
         /// Supported extension version.
         pub CompatibleSmartExtVersion get(fn compatible_extension_version): map hasher(blake2_128_concat) SmartExtensionType => ExtVersion;
+        */
         /// Balances get stored on the basis of the `ScopeId`.
         /// Right now it is only helpful for the UI purposes but in future it can be used to do miracles on-chain.
         /// (ScopeId, IdentityId) => Balance.
@@ -400,8 +403,10 @@ decl_storage! {
         config(classic_migration_tconfig): TickerRegistrationConfig<T::Moment>;
         config(classic_migration_contract_did): IdentityId;
         config(reserved_country_currency_codes): Vec<Ticker>;
+        /*
         /// Smart Extension supported version at genesis.
         config(versions): Vec<(SmartExtensionType, ExtVersion)>;
+        */
         build(|config: &GenesisConfig<T>| {
             use frame_system::RawOrigin;
 
@@ -419,13 +424,15 @@ decl_storage! {
             for currency_ticker in &config.reserved_country_currency_codes {
                 <Module<T>>::unverified_register_ticker(&currency_ticker, fiat_tickers_reservation_did, None);
             }
+
+            /*
             config.versions
                 .iter()
                 .filter(|(t, _)| !<CompatibleSmartExtVersion>::contains_key(&t))
                 .for_each(|(se_type, ver)| {
                     CompatibleSmartExtVersion::insert(se_type, ver);
             });
-
+            */
         });
     }
 }
@@ -924,8 +931,10 @@ decl_error! {
         InvalidGranularity,
         /// The asset must be frozen.
         NotFrozen,
+        /*
         /// No such smart extension.
         NoSuchSmartExtension,
+        */
         /// Transfer validation check failed.
         InvalidTransfer,
         /// The sender balance is not sufficient.

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -23,8 +23,7 @@ use polymesh_primitives::asset::{AssetName, AssetType, CustomAssetTypeId, Fundin
 use polymesh_primitives::ethereum::EthereumAddress;
 use polymesh_primitives::migrate::MigrationError;
 use polymesh_primitives::{
-    AssetIdentifier, Balance, Document, DocumentId, IdentityId, PortfolioId, ScopeId,
-    SmartExtensionName, SmartExtensionType, Ticker,
+    AssetIdentifier, Balance, Document, DocumentId, IdentityId, PortfolioId, ScopeId, Ticker,
 };
 use sp_std::prelude::Vec;
 
@@ -206,6 +205,7 @@ decl_event! {
         /// An event carrying the name of the current funding round of a ticker.
         /// Parameters: caller DID, ticker, funding round name.
         FundingRoundSet(IdentityId, Ticker, FundingRoundName),
+        /*
         /// Emitted when extension is added successfully.
         /// caller DID, ticker, extension AccountId, extension name, type of smart Extension
         ExtensionAdded(IdentityId, Ticker, AccountId, SmartExtensionName, SmartExtensionType),
@@ -215,6 +215,7 @@ decl_event! {
         /// Emitted when extension get archived.
         /// caller DID, ticker, AccountId
         ExtensionUnArchived(IdentityId, Ticker, AccountId),
+        */
         /// A new document attached to an asset
         DocumentAdded(IdentityId, Ticker, DocumentId, Document),
         /// A document removed from an asset

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -19,7 +19,7 @@ use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, Get, UnixTime};
 use frame_support::weights::Weight;
-use polymesh_primitives::asset::{AssetName, AssetType, FundingRoundName};
+use polymesh_primitives::asset::{AssetName, AssetType, CustomAssetTypeId, FundingRoundName};
 use polymesh_primitives::ethereum::EthereumAddress;
 use polymesh_primitives::migrate::MigrationError;
 use polymesh_primitives::{
@@ -105,6 +105,7 @@ pub trait WeightInfo {
     fn archive_extension() -> Weight;
     fn unarchive_extension() -> Weight;
     fn controller_transfer() -> Weight;
+    fn register_custom_asset_type(n: u32) -> Weight;
 }
 
 /// The module's configuration trait.
@@ -228,5 +229,11 @@ decl_event! {
         /// Event for when a forced transfer takes place.
         /// caller DID/ controller DID, ticker, Portfolio of token holder, value.
         ControllerTransfer(IdentityId, Ticker, PortfolioId, Balance),
+        /// A custom asset type already exists on-chain.
+        /// caller DID, the ID of the custom asset type, the string contents registered.
+        CustomAssetTypeExists(IdentityId, CustomAssetTypeId, Vec<u8>),
+        /// A custom asset type was registered on-chain.
+        /// caller DID, the ID of the custom asset type, the string contents registered.
+        CustomAssetTypeRegistered(IdentityId, CustomAssetTypeId, Vec<u8>),
     }
 }

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -217,7 +217,7 @@ pub struct CADetails(pub Vec<u8>);
 
 /// Defines how to identify a CA's associated checkpoint, if any.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug, Migrate)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug)]
 pub enum CACheckpoint {
     /// CA uses a record date scheduled to occur in the future.
     /// Checkpoint ID will be taken after the record date.
@@ -225,7 +225,7 @@ pub enum CACheckpoint {
     /// Since a schedule can be recurring,
     /// the `u64` stores the number of checkpoints before the CA was made.
     /// This allows indexing into the list of CPs, getting exactly the right one.
-    Scheduled(ScheduleId, #[migrate_with(0)] u64),
+    Scheduled(ScheduleId, u64),
     /// CA uses an existing checkpoint ID which was recorded in the past.
     Existing(CheckpointId),
 }
@@ -233,12 +233,11 @@ pub enum CACheckpoint {
 /// Defines the record date, at which impact should be calculated,
 /// along with checkpoint info to assess the impact at the date.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug, Migrate)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug)]
 pub struct RecordDate {
     /// When the impact should be calculated, or already has.
     pub date: Moment,
     /// Info used to determine the `CheckpointId` once `date` has passed.
-    #[migrate]
     pub checkpoint: CACheckpoint,
 }
 
@@ -265,10 +264,11 @@ pub struct CorporateAction {
     /// When the CA was declared off-chain.
     pub decl_date: Moment,
     /// Date at which any impact, if any, should be calculated.
-    #[migrate(RecordDate)]
     pub record_date: Option<RecordDate>,
-    /// Free-form text up to a limit.
-    pub details: CADetails,
+    /// UNUSED! Data moved to `Details` storage map.
+    #[migrate_from(CADetails)]
+    #[migrate_with(())]
+    pub details: (),
     /// The identities this CA is relevant to.
     pub targets: TargetIdentities,
     /// The default withholding tax at the time of CA creation.
@@ -403,12 +403,16 @@ decl_storage! {
         /// so we can infer `Ticker => CAId`. Therefore, we don't need a double map.
         pub CADocLink get(fn ca_doc_link): map hasher(blake2_128_concat) CAId => Vec<DocumentId>;
 
+        /// Associates details in free-form text with a CA by its ID.
+        /// (CAId => CADetails)
+        pub Details get(fn details): map hasher(blake2_128_concat) CAId => CADetails;
+
         /// Storage version.
-        StorageVersion get(fn storage_version) build(|_| Version::new(1).unwrap()): Version;
+        StorageVersion get(fn storage_version) build(|_| Version::new(3).unwrap()): Version;
     }
 }
 
-storage_migration_ver!(2);
+storage_migration_ver!(3);
 
 // Public interface for this runtime module.
 decl_module! {
@@ -422,17 +426,27 @@ decl_module! {
         const MaxDidWhts: u32 = T::MaxDidWhts::get();
 
         fn on_runtime_upgrade() -> Weight {
-            storage_migrate_on!(StorageVersion::get(), 1, {
-                use polymesh_primitives::migrate::{Empty, migrate_map};
-                migrate_map::<CorporateActionOld, _>(b"CorporateActions", b"CorporateActions", |_| Empty);
-            });
-
             storage_migrate_on!(StorageVersion::get(), 2, {
                 StorageKeyIterator::<Ticker, IdentityId, Blake2_128Concat>::new(b"CorporateActions", b"Agent")
                     .drain()
                     .for_each(|(ticker, agent)| {
                         ExternalAgents::<T>::add_agent_if_not(ticker, agent, AgentGroup::PolymeshV1CAA).unwrap();
                     });
+            });
+
+            storage_migrate_on!(StorageVersion::get(), 3, {
+                use core::mem;
+                use polymesh_primitives::migrate::{Empty, Migrate, migrate_double_map_only_values};
+                migrate_double_map_only_values::<_, _, Blake2_128Concat, _, Blake2_128Concat, _, _, ()>(
+                    b"CorporateAction",
+                    b"CorporateActions",
+                    |ticker: Ticker, local_id: LocalCAId, mut old: CorporateActionOld| {
+                        let id = CAId { ticker, local_id };
+                        Details::insert(id, mem::take(&mut old.details));
+                        old.migrate(Empty).ok_or(())
+                    }
+                )
+                .for_each(drop);
             });
 
             0
@@ -640,15 +654,16 @@ decl_module! {
                 kind,
                 decl_date,
                 record_date,
-                details,
+                details: (),
                 targets,
                 default_withholding_tax,
                 withholding_tax,
             };
             CorporateActions::insert(ticker, id.local_id, ca.clone());
+            Details::insert(id, details.clone());
 
             // Emit event.
-            Self::deposit_event(Event::CAInitiated(caa, id, ca));
+            Self::deposit_event(Event::CAInitiated(caa, id, ca, details));
         }
 
         /// Link the given CA `id` to the given `docs`.
@@ -727,6 +742,7 @@ decl_module! {
             Self::dec_strong_ref_count(ca_id, ca.record_date);
             CorporateActions::remove(ca_id.ticker, ca_id.local_id);
             CADocLink::remove(ca_id);
+            Details::remove(ca_id);
             Self::deposit_event(Event::CARemoved(caa, ca_id));
         }
 
@@ -803,8 +819,8 @@ decl_event! {
         /// (New CAA DID, Ticker, New CAA DID).
         CAATransferred(IdentityId, Ticker, IdentityId),
         /// A CA was initiated.
-        /// (CAA DID, CA id, the CA)
-        CAInitiated(EventDid, CAId, CorporateAction),
+        /// (CAA DID, CA id, the CA, the CA details)
+        CAInitiated(EventDid, CAId, CorporateAction, CADetails),
         /// A CA was linked to a set of docs.
         /// (CAA, CA Id, List of doc identifiers)
         CALinkedToDoc(IdentityId, CAId, Vec<DocumentId>),

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -1390,7 +1390,7 @@ fn classic_ticker_genesis_works() {
             ..standard_config
         },
         reserved_country_currency_codes: vec![],
-        versions: vec![],
+        //versions: vec![],
     };
 
     // Define expected ticker data after genesis.
@@ -1690,7 +1690,7 @@ fn classic_ticker_claim_works() {
         },
         classic_migration_contract_did: 0.into(),
         reserved_country_currency_codes: vec![],
-        versions: vec![],
+        //versions: vec![],
     };
 
     // Define the fees and initial balance.

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -17,7 +17,7 @@ use pallet_corporate_actions::{
     ballot::{BallotMeta, BallotTimeRange, BallotVote, Motion, Votes},
     distribution::{self, Distribution, PER_SHARE_PRECISION},
     CACheckpoint, CADetails, CAId, CAIdSequence, CAKind, CorporateAction, CorporateActions,
-    LocalCAId, RecordDate, RecordDateSpec, TargetIdentities, TargetTreatment,
+    Details, LocalCAId, RecordDate, RecordDateSpec, TargetIdentities, TargetTreatment,
     TargetTreatment::{Exclude, Include},
     Tax,
 };
@@ -483,7 +483,8 @@ fn initiate_corporate_action_details() {
     test(|ticker, [owner, ..]| {
         assert_ok!(CA::set_max_details_length(root(), 2));
         let init_ca = |details: &str| -> DispatchResult {
-            let ca = init_ca(
+            let id = next_ca_id(ticker);
+            init_ca(
                 owner,
                 ticker,
                 CAKind::Other,
@@ -493,7 +494,7 @@ fn initiate_corporate_action_details() {
                 None,
                 None,
             )?;
-            assert_eq!(details.as_bytes(), ca.details.as_slice());
+            assert_eq!(details.as_bytes(), Details::get(id).as_slice());
             Ok(())
         };
         assert_ok!(init_ca("f"));

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -414,11 +414,13 @@ impl ExtBuilder {
             registration_length: Some(10000),
         };
         asset::GenesisConfig::<TestStorage> {
+            /*
             versions: vec![
                 (SmartExtensionType::TransferManager, 5000),
                 (SmartExtensionType::Offerings, 5000),
                 (SmartExtensionType::SmartWallet, 5000),
             ],
+            */
             classic_migration_tickers: vec![],
             classic_migration_contract_did: IdentityId::from(1),
             classic_migration_tconfig: ticker_registration_config.clone(),

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -13,7 +13,7 @@ use polymesh_common_utilities::{
 };
 use polymesh_primitives::{
     cdd_id::InvestorUid, identity_id::GenesisIdentityRecord, AccountId, Identity, IdentityId,
-    PosRatio, Signatory, SmartExtensionType,
+    PosRatio, Signatory,
 };
 use sp_io::TestExternalities;
 use sp_runtime::{Perbill, Storage};

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -121,4 +121,11 @@ impl pallet_asset::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(19 as Weight))
             .saturating_add(DbWeight::get().writes(8 as Weight))
     }
+    fn register_custom_asset_type(n: u32) -> Weight {
+        (73_110_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((12_000 as Weight).saturating_mul(n as Weight))
+            .saturating_add(DbWeight::get().reads(8 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1125,7 +1125,6 @@
       "kind": "CAKind",
       "decl_date": "Moment",
       "record_date": "Option<RecordDate>",
-      "details": "Text",
       "targets": "TargetIdentities",
       "default_withholding_tax": "Tax",
       "withholding_tax": "Vec<(IdentityId, Tax)>"

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -40,6 +40,7 @@
       "filing_date": "Option<Moment>"
     },
     "Version": "u8",
+    "CustomAssetTypeId": "u32",
     "AssetType": {
       "_enum": {
         "EquityCommon": "",
@@ -51,7 +52,7 @@
         "RevenueShareAgreement": "",
         "StructuredProduct": "",
         "Derivative": "",
-        "Custom": "Vec<u8>",
+        "Custom": "CustomAssetTypeId",
         "StableCoin": ""
       }
     },

--- a/primitives/src/asset.rs
+++ b/primitives/src/asset.rs
@@ -28,8 +28,12 @@ use sp_std::prelude::Vec;
 )]
 pub struct AssetName(pub Vec<u8>);
 
+/// The ID of a custom asset type.
+#[derive(Encode, Decode, Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct CustomAssetTypeId(pub u32);
+
 /// The type of security represented by a token.
-#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
+#[derive(Encode, Decode, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AssetType {
     /// Common stock - a security that represents ownership in a corporation.
     EquityCommon,
@@ -61,7 +65,7 @@ pub enum AssetType {
     /// swaps.
     Derivative,
     /// Anything else.
-    Custom(Vec<u8>),
+    Custom(CustomAssetTypeId),
     /// Stablecoins are cryptocurrencies designed to minimize the volatility of the price of the stablecoin,
     /// relative to some "stable" asset or basket of assets.
     /// A stablecoin can be pegged to a cryptocurrency, fiat money, or to exchange-traded commodities.
@@ -70,7 +74,7 @@ pub enum AssetType {
 
 impl Default for AssetType {
     fn default() -> Self {
-        Self::Custom(b"undefined".to_vec())
+        Self::EquityCommon
     }
 }
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -11,7 +11,7 @@ use polymesh_common_utilities::{
 };
 use polymesh_primitives::{
     identity_id::GenesisIdentityRecord, AccountId, IdentityId, Moment, PosRatio, SecondaryKey,
-    Signatory, Signature, SmartExtensionType, Ticker,
+    Signatory, Signature, Ticker,
 };
 use sc_chain_spec::ChainType;
 use sc_service::Properties;
@@ -118,11 +118,13 @@ macro_rules! asset {
                 // Reservations will expire at end of 2021
                 registration_length: Some(1640995199999),
             },
+            /*
             versions: vec![
                 (SmartExtensionType::TransferManager, 5000),
                 (SmartExtensionType::Offerings, 5000),
                 (SmartExtensionType::SmartWallet, 5000),
             ],
+            */
             // Always use the first id, whomever that may be.
             classic_migration_contract_did: IdentityId::from(1),
             classic_migration_tickers: classic_reserved_tickers(),


### PR DESCRIPTION
## changelog

### modified API

- Moved field `CorporateAction.details: CADetails` into its own storage item `Details: CAId => CADetails`.