### PR TITLE
MESH-1656/bridge freezing permissions

### DIFF
--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -894,7 +894,11 @@ impl<T: Config> Module<T> {
     }
 
     fn set_freeze(origin: T::Origin, freeze: bool) -> DispatchResult {
-        let did = Self::ensure_freeze_admin_did(origin)?;
+        let did = if freeze {
+            Self::ensure_freeze_admin_did(origin)?
+        } else {
+            Self::ensure_admin_did(origin)?
+        };
 
         let (event, error) = match freeze {
             true => (RawEvent::Frozen(did), Error::<T>::Frozen),

--- a/pallets/runtime/tests/src/bridge.rs
+++ b/pallets/runtime/tests/src/bridge.rs
@@ -278,7 +278,7 @@ fn do_test_freeze_admins(_signers: &[AccountId]) {
         assert!(!Bridge::frozen());
 
         if can_freeze {
-            // User is not allowed to freeze the bridge.
+            // User is allowed to freeze the bridge.
             assert_ok!(Bridge::freeze(user.origin()));
             assert!(Bridge::frozen());
         } else {

--- a/pallets/runtime/tests/src/bridge.rs
+++ b/pallets/runtime/tests/src/bridge.rs
@@ -1,6 +1,6 @@
 use super::{
     fast_forward_blocks, next_block,
-    storage::{Call, TestStorage},
+    storage::{Call, TestStorage, User},
     ExtBuilder,
 };
 
@@ -216,11 +216,11 @@ fn cannot_call_bridge_callback_extrinsics() {
 }
 
 #[test]
-fn can_freeze_and_unfreeze_bridge() {
-    test_with_controller(&do_freeze_and_unfreeze_bridge)
+fn can_admin_freeze_and_unfreeze_bridge() {
+    test_with_controller(&do_admin_freeze_and_unfreeze_bridge)
 }
 
-fn do_freeze_and_unfreeze_bridge(signers: &[AccountId]) {
+fn do_admin_freeze_and_unfreeze_bridge(signers: &[AccountId]) {
     let alice = Alice.to_account_id();
     let admin = signed_admin();
     let proposal = alice_proposal_tx(AMOUNT);
@@ -261,6 +261,100 @@ fn do_freeze_and_unfreeze_bridge(signers: &[AccountId]) {
     // Now the tokens are issued.
     assert_eq!(alice_balance(), starting_alices_balance + AMOUNT);
     let _ = ensure_tx_status(alice, 1, BridgeTxStatus::Handled);
+}
+
+#[test]
+fn test_freeze_admins() {
+    test_with_controller(&do_test_freeze_admins)
+}
+
+fn do_test_freeze_admins(_signers: &[AccountId]) {
+    let eve = User::existing(Eve);
+    let ferdie = User::existing(Ferdie);
+    let admin = signed_admin();
+
+    let test_freeze_allowed = |user: User| {
+        // Make sure we start with the bridge unfrozen.
+        assert!(!Bridge::frozen());
+
+        assert_ok!(Bridge::freeze(user.origin()));
+        assert!(Bridge::frozen());
+
+        // Unfreeze the bridge.
+        assert_ok!(Bridge::unfreeze(user.origin()));
+        assert!(!Bridge::frozen());
+    };
+    let test_freeze_denied = |user: User| {
+        // Make sure we start with the bridge unfrozen.
+        assert!(!Bridge::frozen());
+
+        // User is not allowed to freeze the bridge.
+        assert_noop!(
+            Bridge::freeze(user.origin()),
+            Error::BadAdmin
+        );
+        assert!(!Bridge::frozen());
+
+        // Use admin to freeze the bridge.
+        assert_ok!(Bridge::freeze(admin.clone()));
+        assert!(Bridge::frozen());
+
+        // User is not allowed to unfreeze the bridge.
+        assert_noop!(
+            Bridge::unfreeze(user.origin()),
+            Error::BadAdmin
+        );
+        assert!(Bridge::frozen());
+
+        // Use admin to unfreeze the bridge.
+        assert_ok!(Bridge::unfreeze(admin.clone()));
+        assert!(!Bridge::frozen());
+    };
+    let add_freeze_admin = |user: User| {
+        // Use admin to add a freeze admin.
+        assert_ok!(Bridge::add_freeze_admin(admin.clone(), user.acc()));
+        assert!(Bridge::freeze_admins(user.acc()));
+
+        // Check that they can freeze/unfreeze the bridge.
+        test_freeze_allowed(user);
+    };
+    let remove_freeze_admin = |user: User| {
+        // Use admin to remove a freeze admin.
+        assert_ok!(Bridge::remove_freeze_admin(admin.clone(), user.acc()));
+        assert!(!Bridge::freeze_admins(user.acc()));
+
+        // Check that they cannot freeze/unfreeze the bridge.
+        test_freeze_denied(user);
+    };
+
+    // Eve and Ferdie are not freeze admins.
+    test_freeze_denied(eve);
+    test_freeze_denied(ferdie);
+
+    // Add Eve as a freeze admin.
+    add_freeze_admin(eve);
+
+    // Ferdie is still denied.
+    test_freeze_denied(ferdie);
+
+    // Add Ferdie as a freeze admin.
+    add_freeze_admin(ferdie);
+
+    // Test that Eve can still freeze/unfreeze the bridge.
+    test_freeze_allowed(eve);
+
+    // Remove Eve from freeze admins.
+    remove_freeze_admin(eve);
+
+    // Test that Ferdie can still freeze/unfreeze the bridge.
+    test_freeze_allowed(ferdie);
+
+    // Remove Ferdie from freeze admins.
+    remove_freeze_admin(ferdie);
+
+    // Both Eve and Ferdie are no longer freeze admins.
+    test_freeze_denied(eve);
+    test_freeze_denied(ferdie);
 }
 
 #[test]

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -1,6 +1,5 @@
 use crate::TestStorage;
 use confidential_identity::mocked::make_investor_uid as make_investor_uid_v2;
-use frame_support::traits::GenesisBuild;
 use pallet_asset::{self as asset, TickerRegistrationConfig};
 use pallet_balances as balances;
 use pallet_bridge::BridgeTx;

--- a/pallets/runtime/tests/src/signed_extra.rs
+++ b/pallets/runtime/tests/src/signed_extra.rs
@@ -9,7 +9,6 @@ use polymesh_runtime_develop::{
 };
 
 use frame_support::{
-    traits::GenesisBuild,
     weights::{DispatchClass, DispatchInfo},
 };
 use frame_system::{CheckEra, CheckGenesis, CheckNonce, CheckSpecVersion, CheckTxVersion};

--- a/pallets/runtime/tests/src/signed_extra.rs
+++ b/pallets/runtime/tests/src/signed_extra.rs
@@ -8,9 +8,7 @@ use polymesh_runtime_develop::{
     Runtime,
 };
 
-use frame_support::{
-    weights::{DispatchClass, DispatchInfo},
-};
+use frame_support::weights::{DispatchClass, DispatchInfo};
 use frame_system::{CheckEra, CheckGenesis, CheckNonce, CheckSpecVersion, CheckTxVersion};
 use sp_io::TestExternalities;
 use sp_runtime::{generic, traits::SignedExtension};

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -24,7 +24,7 @@ use frame_support::{
     dispatch::DispatchResult,
     parameter_types,
     traits::{
-        Contains, Currency, FindAuthor, GenesisBuild, Get, Imbalance, KeyOwnerProofSystem,
+        Contains, Currency, FindAuthor, Get, Imbalance, KeyOwnerProofSystem,
         OnFinalize, OnInitialize, OnUnbalanced, OneSessionHandler,
     },
     weights::{constants::RocksDbWeight, DispatchInfo, Weight},

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -24,8 +24,8 @@ use frame_support::{
     dispatch::DispatchResult,
     parameter_types,
     traits::{
-        Contains, Currency, FindAuthor, Get, Imbalance, KeyOwnerProofSystem,
-        OnFinalize, OnInitialize, OnUnbalanced, OneSessionHandler,
+        Contains, Currency, FindAuthor, Get, Imbalance, KeyOwnerProofSystem, OnFinalize,
+        OnInitialize, OnUnbalanced, OneSessionHandler,
     },
     weights::{constants::RocksDbWeight, DispatchInfo, Weight},
     IterableStorageMap, StorageDoubleMap, StorageMap, StorageValue,

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -5511,7 +5511,7 @@ fn test_reward_scheduling() {
                 }
             );
             let _part_for_10 = Perbill::from_rational_approximation::<u32>(1000, 1125);
-            let part_for_20 = Perbill::from_rational_approximation::<u32>(1000, 1375);
+            let _part_for_20 = Perbill::from_rational_approximation::<u32>(1000, 1375);
             let part_for_100_from_10 = Perbill::from_rational_approximation::<u32>(125, 1125);
             let part_for_100_from_20 = Perbill::from_rational_approximation::<u32>(375, 1375);
 

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -71,6 +71,28 @@ macro_rules! assert_permissioned_identity_prefs {
     };
 }
 
+// Polymath: Re-implement `assert_eq_uvec` from substrate to fix compile warnings.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! assert_eq_uvec {
+    ( $x:expr, $y:expr $(,)? ) => {
+        $crate::__assert_eq_uvec!($x, $y);
+        $crate::__assert_eq_uvec!($y, $x);
+    };
+}
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __assert_eq_uvec {
+    ( $x:expr, $y:expr ) => {
+        $x.iter().for_each(|e| {
+            // Polymath: removed the un-needed `format!`.
+            if !$y.contains(e) {
+                panic!("vectors not equal: {:?} != {:?}", $x, $y);
+            }
+        });
+    };
+}
+
 mod mock;
 use chrono::prelude::Utc;
 use codec::Decode;
@@ -94,7 +116,6 @@ use sp_staking::{
     offence::{OffenceDetails, OnOffenceHandler},
     SessionIndex,
 };
-use substrate_test_utils::assert_eq_uvec;
 
 #[test]
 fn force_unstake_works() {
@@ -3278,7 +3299,6 @@ mod offchain_phragmen {
     use sp_npos_elections::StakedAssignment;
     use sp_runtime::transaction_validity::TransactionSource;
     use std::sync::Arc;
-    use substrate_test_utils::assert_eq_uvec;
 
     fn percent(x: u16) -> OffchainAccuracy {
         OffchainAccuracy::from_percent(x)


### PR DESCRIPTION
## changelog

### new features

- Add support for multiple freeze admin accounts to the bridge pallet.

### modified API

- New extrinsics `add_freeze_admin` and `remove_freeze_admin` to `bridge` pallet.  These can only be called by the current bridge admin to add/remove freeze admins.
- New events `FreezeAdminAdded` and `FreezeAdminRemoved`.

### modified logic

- Bridge extrinsic `freeze` can now be called by any of the freeze admin accounts.