### PR TITLE
Fix pk rotation

### DIFF
--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -32,6 +32,7 @@ use frame_support::{
     weights::{GetDispatchInfo, Weight},
     Parameter,
 };
+use polymesh_primitives::migrate::MigrationError;
 use polymesh_primitives::{
     secondary_key::api::SecondaryKey, AuthorizationData, DispatchableName, IdentityClaim,
     IdentityId, InvestorUid, PalletName, Permissions, Signatory, Ticker,
@@ -224,6 +225,9 @@ decl_event!(
 
         /// Forwarded Call - (calling DID, target DID, pallet name, function name)
         ForwardedCall(IdentityId, IdentityId, PalletName, DispatchableName),
+
+        /// Migration error event.
+        MigrationFailure(MigrationError<()>),
     }
 );
 

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -225,9 +225,6 @@ decl_event!(
 
         /// Forwarded Call - (calling DID, target DID, pallet name, function name)
         ForwardedCall(IdentityId, IdentityId, PalletName, DispatchableName),
-
-        /// Migration error event.
-        MigrationFailure(MigrationError<()>),
     }
 );
 

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -32,7 +32,6 @@ use frame_support::{
     weights::{GetDispatchInfo, Weight},
     Parameter,
 };
-use polymesh_primitives::migrate::MigrationError;
 use polymesh_primitives::{
     secondary_key::api::SecondaryKey, AuthorizationData, DispatchableName, IdentityClaim,
     IdentityId, InvestorUid, PalletName, Permissions, Signatory, Ticker,

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -188,7 +188,7 @@ benchmarks! {
 
         let owner_auth_id =  Module::<T>::add_auth(
             target.did(), signatory,
-            AuthorizationData::RotatePrimaryKey(target.did()),
+            AuthorizationData::RotatePrimaryKey,
             None,
         );
     }: _(new_key.origin, owner_auth_id, Some(cdd_auth_id))

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1055,7 +1055,7 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         let sender = ensure_signed(origin)?;
         let signer = Signatory::Account(sender.clone());
-        Self::accept_auth_with(&signer, rotation_auth_id, |data, target_did| {
+        Self::accept_auth_with(&signer, rotation_auth_id, |_, target_did| {
             Self::unsafe_primary_key_rotation(sender, target_did, optional_cdd_auth_id)
         })
     }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -279,9 +279,6 @@ decl_module! {
         const InitialPOLYX: <T::Balances as Currency<T::AccountId>>::Balance = T::InitialPOLYX::get().into();
 
         fn on_runtime_upgrade() -> Weight {
-            // Migrate `Authorizations`.
-            use frame_support::{Blake2_128Concat, Twox64Concat};
-
             let storage_ver = StorageVersion::get();
 
             storage_migrate_on!(storage_ver, 3, { Claims::translate(migration::migrate_claim); });

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1055,9 +1055,8 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         let sender = ensure_signed(origin)?;
         let signer = Signatory::Account(sender.clone());
-        Self::accept_auth_with(&signer, rotation_auth_id, |data, _| {
-            let rotation_for_did = extract_auth!(data, RotatePrimaryKey(r));
-            Self::unsafe_primary_key_rotation(sender, rotation_for_did, optional_cdd_auth_id)
+        Self::accept_auth_with(&signer, rotation_auth_id, |data, target_did| {
+            Self::unsafe_primary_key_rotation(sender, target_did, optional_cdd_auth_id)
         })
     }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -281,7 +281,6 @@ decl_module! {
         fn on_runtime_upgrade() -> Weight {
             // Migrate `Authorizations`.
             use frame_support::{Blake2_128Concat, Twox64Concat};
-            use polymesh_primitives::migrate::migrate_double_map_only_values;
 
             let storage_ver = StorageVersion::get();
 
@@ -289,13 +288,7 @@ decl_module! {
 
             // Migrate Authorizations.
             storage_migrate_on!(storage_ver, 4, {
-                migrate_double_map_only_values::<_, _, Blake2_128Concat, _, Twox64Concat, _, _, _>(
-                    b"Identity", b"Authorizations", migration::migrate_auth_v1::<T::AccountId, T::Moment>)
-                .for_each(|migrate_status| {
-                    if let Err(err) = migrate_status {
-                        Self::deposit_event( RawEvent::MigrationFailure(err));
-                    }
-                });
+                <Authorizations<T>>::translate(migration::migrate_auth_v1::<T::AccountId, T::Moment>);
             });
 
             // It's gonna be alot, so lets pretend its 0 anyways.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1055,7 +1055,9 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         let sender = ensure_signed(origin)?;
         let signer = Signatory::Account(sender.clone());
-        Self::accept_auth_with(&signer, rotation_auth_id, |_, target_did| {
+        Self::accept_auth_with(&signer, rotation_auth_id, |data, target_did| {
+            // Ensure Authorization is a `RotatePrimaryKey`.
+            extract_auth!(data, RotatePrimaryKey);
             Self::unsafe_primary_key_rotation(sender, target_did, optional_cdd_auth_id)
         })
     }

--- a/pallets/identity/src/migration.rs
+++ b/pallets/identity/src/migration.rs
@@ -60,7 +60,7 @@ pub fn migrate_auth_v1<AccountId, Moment>(
     _k1: Signatory<AccountId>,
     _k2: u64,
     auth: AuthV1<AccountId, Moment>,
-) -> Result<Authorization<AccountId, Moment>, ()> {
+) -> Option<Authorization<AccountId, Moment>> {
     let authorization_data = match auth.authorization_data {
         AuthDataV1::AttestPrimaryKeyRotation(did) => {
             AuthorizationData::AttestPrimaryKeyRotation(did)
@@ -87,7 +87,7 @@ pub fn migrate_auth_v1<AccountId, Moment>(
         }
     };
 
-    Ok(Authorization {
+    Some(Authorization {
         authorization_data,
         authorized_by: auth.authorized_by,
         expiry: auth.expiry,

--- a/pallets/identity/src/migration.rs
+++ b/pallets/identity/src/migration.rs
@@ -1,9 +1,13 @@
 use crate::types::{Claim1stKey, Claim2ndKey};
 
+use super::*;
 use confidential_identity::mocked::make_investor_uid;
-use polymesh_primitives::{CddId, Claim, ClaimType, IdentityClaim, IdentityId};
+use polymesh_primitives::{
+    agent::AgentGroup, Authorization, Balance, CddId, Claim, ClaimType, IdentityClaim, IdentityId,
+    PortfolioId, Ticker,
+};
 
-/// Migrate claim
+/// Migrate claim.
 pub fn migrate_claim(
     k1: Claim1stKey,
     _k2: Claim2ndKey,
@@ -22,4 +26,71 @@ fn migrate_cdd_claim(target: IdentityId, mut id_claim: IdentityClaim) -> Option<
 
     id_claim.claim = Claim::CustomerDueDiligence(cdd_id);
     Some(id_claim)
+}
+
+/// Authorization V1 data for two step processes.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub enum AuthDataV1<AccountId> {
+    AttestPrimaryKeyRotation(IdentityId),
+    RotatePrimaryKey(IdentityId),
+    TransferTicker(Ticker),
+    TransferPrimaryIssuanceAgent(Ticker),
+    AddMultiSigSigner(AccountId),
+    TransferAssetOwnership(Ticker),
+    JoinIdentity(Permissions),
+    PortfolioCustody(PortfolioId),
+    Custom(Ticker),
+    NoData,
+    TransferCorporateActionAgent(Ticker),
+    BecomeAgent(Ticker, AgentGroup),
+    AddRelayerPayingKey(AccountId, AccountId, Balance),
+}
+
+/// Authorization v1 struct.
+#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+pub struct AuthV1<AccountId, Moment> {
+    pub authorization_data: AuthDataV1<AccountId>,
+    pub authorized_by: IdentityId,
+    pub expiry: Option<Moment>,
+    pub auth_id: u64,
+}
+
+/// Migrate `AuthorizationData::RotatePrimaryKey`.
+pub fn migrate_auth_v1<AccountId, Moment>(
+    _k1: Signatory<AccountId>,
+    _k2: u64,
+    auth: AuthV1<AccountId, Moment>,
+) -> Result<Authorization<AccountId, Moment>, ()> {
+    let authorization_data = match auth.authorization_data {
+        AuthDataV1::AttestPrimaryKeyRotation(did) => {
+            AuthorizationData::AttestPrimaryKeyRotation(did)
+        }
+        AuthDataV1::RotatePrimaryKey(_) => AuthorizationData::RotatePrimaryKey,
+        AuthDataV1::TransferTicker(ticker) => AuthorizationData::TransferTicker(ticker),
+        AuthDataV1::TransferPrimaryIssuanceAgent(ticker) => {
+            AuthorizationData::TransferPrimaryIssuanceAgent(ticker)
+        }
+        AuthDataV1::AddMultiSigSigner(acc) => AuthorizationData::AddMultiSigSigner(acc),
+        AuthDataV1::TransferAssetOwnership(ticker) => {
+            AuthorizationData::TransferAssetOwnership(ticker)
+        }
+        AuthDataV1::JoinIdentity(perms) => AuthorizationData::JoinIdentity(perms),
+        AuthDataV1::PortfolioCustody(portfolio) => AuthorizationData::PortfolioCustody(portfolio),
+        AuthDataV1::Custom(ticker) => AuthorizationData::Custom(ticker),
+        AuthDataV1::NoData => AuthorizationData::NoData,
+        AuthDataV1::TransferCorporateActionAgent(ticker) => {
+            AuthorizationData::TransferCorporateActionAgent(ticker)
+        }
+        AuthDataV1::BecomeAgent(ticker, group) => AuthorizationData::BecomeAgent(ticker, group),
+        AuthDataV1::AddRelayerPayingKey(user, payer, limit) => {
+            AuthorizationData::AddRelayerPayingKey(user, payer, limit)
+        }
+    };
+
+    Ok(Authorization {
+        authorization_data,
+        authorized_by: auth.authorized_by,
+        expiry: auth.expiry,
+        auth_id: auth.auth_id,
+    })
 }

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -147,7 +147,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             by,
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
-            | (AuthorizationData::RotatePrimaryKey(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/itn/src/fee_details.rs
+++ b/pallets/runtime/itn/src/fee_details.rs
@@ -144,7 +144,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             by,
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
-            | (AuthorizationData::RotatePrimaryKey(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/testnet/src/fee_details.rs
+++ b/pallets/runtime/testnet/src/fee_details.rs
@@ -147,7 +147,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             by,
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
-            | (AuthorizationData::RotatePrimaryKey(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1516,7 +1516,7 @@ fn changing_primary_key_we() {
         Identity::add_auth(
             alice.did,
             Signatory::Account(ring.to_account_id()),
-            AuthorizationData::RotatePrimaryKey(alice.did),
+            AuthorizationData::RotatePrimaryKey,
             None,
         )
     };
@@ -1565,7 +1565,7 @@ fn changing_primary_key_with_cdd_auth_we() {
     let owner_auth_id = Identity::add_auth(
         alice_did,
         Signatory::Account(new_key.clone()),
-        AuthorizationData::RotatePrimaryKey(alice_did),
+        AuthorizationData::RotatePrimaryKey,
         None,
     );
 
@@ -1588,7 +1588,7 @@ fn changing_primary_key_with_cdd_auth_we() {
     let owner_auth_id2 = Identity::add_auth(
         alice_did,
         Signatory::Account(new_key),
-        AuthorizationData::RotatePrimaryKey(alice_did),
+        AuthorizationData::RotatePrimaryKey,
         None,
     );
 

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -685,7 +685,7 @@
     "AuthorizationData": {
       "_enum": {
         "AttestPrimaryKeyRotation": "IdentityId",
-        "RotatePrimaryKey": "IdentityId",
+        "RotatePrimaryKey": "",
         "TransferTicker": "Ticker",
         "TransferPrimaryIssuanceAgent": "Ticker",
         "AddMultiSigSigner": "AccountId",

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -31,7 +31,7 @@ pub enum AuthorizationData<AccountId> {
     /// CDD provider's attestation to change primary key
     AttestPrimaryKeyRotation(IdentityId),
     /// Authorization to change primary key
-    RotatePrimaryKey(IdentityId),
+    RotatePrimaryKey,
     /// Authorization to transfer a ticker
     /// Must be issued by the current owner of the ticker
     TransferTicker(Ticker),
@@ -67,7 +67,7 @@ impl<AccountId> AuthorizationData<AccountId> {
     pub fn auth_type(&self) -> AuthorizationType {
         match self {
             Self::AttestPrimaryKeyRotation(..) => AuthorizationType::AttestPrimaryKeyRotation,
-            Self::RotatePrimaryKey(..) => AuthorizationType::RotatePrimaryKey,
+            Self::RotatePrimaryKey => AuthorizationType::RotatePrimaryKey,
             Self::TransferTicker(..) => AuthorizationType::TransferTicker,
             Self::TransferPrimaryIssuanceAgent(..) => AuthorizationType::NoData,
             Self::TransferCorporateActionAgent(..) => AuthorizationType::NoData,

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -172,5 +172,11 @@ macro_rules! extract_auth {
             $crate::authorization::AuthorizationData::$variant($($f),*) => ($($f),*),
             _ => frame_support::fail!($crate::authorization::AuthorizationError::BadType),
         }
-    }
+    };
+    ($data:expr, $variant:ident ) => {
+        match $data {
+            $crate::authorization::AuthorizationData::$variant => (),
+            _ => frame_support::fail!($crate::authorization::AuthorizationError::BadType),
+        }
+    };
 }


### PR DESCRIPTION

## changelog

### modified API

- Remove the `IdentityId` from `AuthorizationData::RotatePrimaryKey`.  Use the `authorized_by` identity in `Authorization` instead.

### modified logic

- Use the `authorized_by` identity in `Authorization` instead of storing it in the authorization data.  This fixes an issue where anyone could rotate the pirmary key of an identity.
