### PR TITLE
Use nightly 2021-05-19 for building the docs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Use rust nightly 2021-05-19 for building docs.
+      run: echo "nightly-2021-05-19" > ./rust-toolchain
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
This adds a step to the `docs` github job to build the docs using Rust `nightly-2021-05-19`.  Which fixes an issue with the list of crates in the sidebar.