### PR TITLE
Ensure CA checkpoint balance was greater than zero for distribution.

### DIFF
--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -496,6 +496,7 @@ impl<T: Config> Module<T> {
 
         // Compute `balance * amount / supply`, i.e. DID's benefit.
         let balance = <CA<T>>::balance_at_cp(holder, ca_id, cp_id);
+        ensure!(balance > 0, Error::<T>::NotTargetedByCA);
         let benefit = Self::benefit_of(balance, dist.per_share)?;
 
         // Ensure we have enough remaining.


### PR DESCRIPTION
Note: Recreated from PR #1073 to fix issue with the CI-pipeline.

Minor change to Corporate Action - Distribution pallet to prevent zero value claims and transfers in the case `push_benefit` or `claim` is called for a DID that had a zero balance at the time of the checkpoint.

## changelog

### modified logic

-  if target `balance` at the applicable checkpoint was ZERO when `claim` or `push_benefit` are called functions now return error `NotTargetedByCA`. 

Note: The ITN dashboard currently does not check the balance at the checkpoint when displaying a pending distribution value and allowing a distribution to be accepted, with this change those claims would fail instead of succeeding with a zero value transfer.