### PR TITLE
MESH-1670/make_mulisig_signer_fix

### DIFF
--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -113,6 +113,8 @@ use sp_std::{convert::TryFrom, iter, prelude::*};
 
 type Identity<T> = identity::Module<T>;
 
+pub const NAME: &[u8] = b"MultiSig";
+
 /// Either the ID of a successfully created multisig account or an error.
 pub type CreateMultisigAccountResult<T> =
     sp_std::result::Result<<T as frame_system::Config>::AccountId, DispatchError>;
@@ -248,7 +250,7 @@ decl_module! {
             if last_version < current_version {
                 TransactionVersion::set(current_version);
                 for item in &["Proposals", "ProposalIds", "ProposalDetail", "Votes"] {
-                    kill_item(b"MultiSig", item.as_bytes())
+                    kill_item(NAME, item.as_bytes())
                 }
             }
 
@@ -539,9 +541,7 @@ decl_module! {
             <Identity<T>>::unsafe_join_identity(
                 did,
                 Permissions::from_pallet_permissions(
-                    // TODO: Check if there is a variable for the pallet name and, if there is, use
-                    // it instead of b"_".
-                    iter::once(PalletPermissions::entire_pallet(b"multisig".as_ref().into()))
+                    iter::once(PalletPermissions::entire_pallet(NAME.into()))
                 ),
                 &Signatory::Account(multisig),
             );

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -513,7 +513,7 @@ fn make_multisig_signer() {
         ));
         let permissions =
             Permissions::from_pallet_permissions(vec![PalletPermissions::entire_pallet(
-                b"multisig".as_ref().into(),
+                multisig::NAME.into(),
             )]);
         // The desired secondary key record.
         let musig_secondary = SecondaryKey::new(Signatory::Account(multisig.clone()), permissions);


### PR DESCRIPTION
Extrinsic `make_multisig_singer` was using the wrong case ("multisig" instead of "MultiSig") for the pallet name in the permissions.

There is no simple way to get the pallet name that is used in the call metadata.