### PR TITLE
MESH-1675: Don't check perms in `Identity::leave_identity_as_key` + Remove some extrinsics

### DIFF
--- a/pallets/bridge/src/genesis.rs
+++ b/pallets/bridge/src/genesis.rs
@@ -2,7 +2,7 @@ use crate::{BridgeTxDetail, BridgeTxStatus, Config, GenesisConfig};
 
 use frame_support::{debug, storage::StorageDoubleMap};
 use polymesh_common_utilities::{balances::CheckCdd, constants::currency::POLY, Context};
-use polymesh_primitives::{Permissions, Signatory};
+use polymesh_primitives::Permissions;
 use sp_runtime::traits::Zero;
 use sp_std::convert::TryFrom;
 
@@ -39,11 +39,7 @@ pub(crate) fn controller<T: Config>(config: &GenesisConfig<T>) -> T::AccountId {
     let creator_did = Context::current_identity_or::<Identity<T>>(&config.creator)
         .expect("bridge creator account has no identity");
 
-    Identity::<T>::unsafe_join_identity(
-        creator_did,
-        Permissions::default(),
-        &Signatory::Account(multisig_id.clone()),
-    );
+    Identity::<T>::unsafe_join_identity(creator_did, Permissions::default(), multisig_id.clone());
     debug::info!("Joined identity {} as signer {}", creator_did, multisig_id);
 
     multisig_id

--- a/pallets/common/src/benchs/mod.rs
+++ b/pallets/common/src/benchs/mod.rs
@@ -34,6 +34,13 @@ pub fn user<T: Config + TestUtilsFn<<T as SysTrait>::AccountId>>(
         .build(prefix)
 }
 
+pub fn user_without_did<T: Config + TestUtilsFn<<T as SysTrait>::AccountId>>(
+    prefix: &'static str,
+    u: u32,
+) -> User<T> {
+    UserBuilder::<T>::default().seed(u).build(prefix)
+}
+
 pub fn cdd_provider<T: Config + TestUtilsFn<<T as SysTrait>::AccountId>>(
     prefix: &'static str,
     u: u32,

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -82,9 +82,7 @@ pub trait WeightInfo {
     fn accept_primary_key() -> Weight;
     fn change_cdd_requirement_for_mk_rotation() -> Weight;
     fn join_identity_as_key() -> Weight;
-    fn join_identity_as_identity() -> Weight;
     fn leave_identity_as_key() -> Weight;
-    fn leave_identity_as_identity() -> Weight;
     fn add_claim() -> Weight;
     fn revoke_claim() -> Weight;
     fn set_permission_to_signer() -> Weight;
@@ -93,7 +91,6 @@ pub trait WeightInfo {
     fn add_authorization() -> Weight;
     fn remove_authorization() -> Weight;
     fn add_secondary_keys_with_authorization(n: u32) -> Weight;
-    fn revoke_offchain_authorization() -> Weight;
     fn add_investor_uniqueness_claim() -> Weight;
     fn add_investor_uniqueness_claim_v2() -> Weight;
     fn revoke_claim_by_index() -> Weight;

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -33,8 +33,8 @@ use frame_support::{
     Parameter,
 };
 use polymesh_primitives::{
-    secondary_key::api::SecondaryKey, AuthorizationData, DispatchableName, IdentityClaim,
-    IdentityId, InvestorUid, PalletName, Permissions, Signatory, Ticker,
+    secondary_key::api::SecondaryKey, AuthorizationData, IdentityClaim, IdentityId, InvestorUid,
+    Permissions, Signatory, Ticker,
 };
 use sp_core::H512;
 use sp_runtime::traits::{Dispatchable, IdentifyAccount, Member, Verify};
@@ -222,9 +222,6 @@ decl_event!(
 
         /// Mocked InvestorUid created.
         MockInvestorUIDCreated(IdentityId, InvestorUid),
-
-        /// Forwarded Call - (calling DID, target DID, pallet name, function name)
-        ForwardedCall(IdentityId, IdentityId, PalletName, DispatchableName),
     }
 );
 

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -232,7 +232,7 @@ pub trait IdentityFnTrait<AccountId> {
     fn current_payer() -> Option<AccountId>;
     fn set_current_payer(payer: Option<AccountId>);
 
-    fn is_signer_authorized(did: IdentityId, signer: &Signatory<AccountId>) -> bool;
+    fn is_key_authorized(did: IdentityId, key: &AccountId) -> bool;
     fn is_primary_key(did: &IdentityId, key: &AccountId) -> bool;
 
     /// It adds a systematic CDD claim for each `target` identity.

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -91,7 +91,6 @@ use frame_support::{
     traits::{ChangeMembers, EnsureOrigin},
     StorageValue,
 };
-use frame_system::ensure_signed;
 use sp_std::prelude::*;
 
 pub type Event<T, I> = polymesh_common_utilities::group::Event<T, I>;
@@ -259,8 +258,7 @@ decl_module! {
         /// * Last member of a group cannot abdicate.
         #[weight = <T as Config<I>>::WeightInfo::abdicate_membership()]
         pub fn abdicate_membership(origin) {
-            let who = ensure_signed(origin)?;
-            let remove_id = Context::current_identity_or::<Identity<T>>(&who)?;
+            let (who, remove_id) = Identity::<T>::ensure_did(origin)?;
 
             ensure!(
                 <Identity<T>>::is_primary_key(&remove_id, &who),

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -20,7 +20,7 @@ use confidential_identity_v1::mocked::make_investor_uid as make_investor_uid_v1;
 use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
 use polymesh_common_utilities::{
-    benchs::{cdd_provider, user, AccountIdOf, User, UserBuilder},
+    benchs::{cdd_provider, user, user_without_did, AccountIdOf, User, UserBuilder},
     traits::{identity::TargetIdAuthorization, TestUtilsFn},
 };
 use polymesh_primitives::{
@@ -313,9 +313,9 @@ benchmarks! {
         let auth_encoded = authorization.encode();
 
         let secondary_keys_with_auth = (0..i).map(|x| {
-            let user = user::<T>("key", x);
+            let user = user_without_did::<T>("key", x);
             SecondaryKeyWithAuth {
-                secondary_key: SecondaryKey::from(user.did()).into(),
+                secondary_key: SecondaryKey::from_account_id(user.account()).into(),
                 auth_signature: H512::from(user.sign(&auth_encoded).unwrap()),
             }
         }).collect::<Vec<_>>();

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -224,18 +224,6 @@ benchmarks! {
         );
     }: _(new_key.origin, auth_id)
 
-    join_identity_as_identity {
-        let target = user::<T>("target", 0);
-        let new_user = user::<T>("key", 0);
-
-        let auth_id =  Module::<T>::add_auth(
-            target.did(),
-            Signatory::Identity(new_user.did()),
-            AuthorizationData::JoinIdentity(Permissions::default()),
-            None,
-        );
-    }: _(new_user.origin, auth_id)
-
     leave_identity_as_key {
         let target = user::<T>("target", 0);
         let key = UserBuilder::<T>::default().build("key");
@@ -257,15 +245,6 @@ benchmarks! {
             "Key was not removed from its identity"
         );
     }
-
-    leave_identity_as_identity {
-        let target = user::<T>("target", 0);
-        let new_user = user::<T>("key", 0);
-        let signatory = Signatory::Identity(new_user.did());
-
-        Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), &signatory);
-
-    }: _(new_user.origin, target.did())
 
     add_claim {
         let caller = user::<T>("caller", 0);
@@ -341,17 +320,6 @@ benchmarks! {
             }
         }).collect::<Vec<_>>();
     }: _(caller.origin, secondary_keys_with_auth, expires_at)
-
-    revoke_offchain_authorization {
-        let caller = user::<T>("caller", 0);
-        let nonce = Module::<T>::offchain_authorization_nonce(caller.did());
-
-        let authorization = TargetIdAuthorization::<T::Moment> {
-            target_id: caller.did(),
-            nonce,
-            expires_at: 600u32.into(),
-        };
-    }: _(caller.origin, Signatory::Identity(caller.did()), authorization)
 
     add_investor_uniqueness_claim {
         let (caller, _, claim, proof) = setup_investor_uniqueness_claim_v1::<T>("caller");

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -170,9 +170,9 @@ benchmarks! {
 
         let mut signatories = Vec::with_capacity(i as usize);
         for x in 0..i {
-            let signer = Signatory::Account(account("key", x, SEED));
-            signatories.push(signer.clone());
-            Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), &signer);
+            let key: T::AccountId = account("key", x, SEED);
+            signatories.push(Signatory::Account(key.clone()));
+            Module::<T>::unsafe_join_identity(target.did(), Permissions::default(), key);
         }
     }: _(target.origin, signatories.clone())
 
@@ -267,9 +267,9 @@ benchmarks! {
     set_permission_to_signer {
         let target = user::<T>("target", 0);
         let key = UserBuilder::<T>::default().build("key");
-        let signatory = Signatory::Account(key.account);
+        let signatory = Signatory::Account(key.account());
 
-        Module::<T>::unsafe_join_identity(target.did(), Permissions::empty(), &signatory);
+        Module::<T>::unsafe_join_identity(target.did(), Permissions::empty(), key.account());
     }: _(target.origin, signatory, Permissions::default().into())
 
     freeze_secondary_keys {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -809,8 +809,6 @@ decl_error! {
         CDDIdNotUniqueForIdentity,
         /// Non systematic CDD providers can not create default cdd_id claims.
         InvalidCDDId,
-        /// Do not allow forwarded call to be called recursively
-        RecursionNotAllowed,
         /// Claim and Proof versions are different.
         ClaimAndProofVersionsDoNotMatch,
         /// The account key is being used, it can't be unlinked.
@@ -2121,6 +2119,7 @@ impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Module<T> {
 
         // NB: Doing this check here since `get_sk_data` moves `target_did_record`
         let is_direct_call = target_did == key_did;
+        assert!(is_direct_call);
         if is_direct_call && who == &target_did_record.primary_key {
             // It is a direct call and `who` is the primary key.
             return Some(AccountCallPermissionsData {

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1857,26 +1857,6 @@ impl<T: Config> Module<T> {
         Self::deposit_event(RawEvent::DidCreated(id, primary_key, vec![]));
     }
 
-    /// It returns the list of flatten identities of the given identity.
-    /// It runs recursively over all secondary items.
-    pub fn flatten_identities(id: IdentityId, max_depth: u8) -> Vec<IdentityId> {
-        Self::identity_record_of(id)
-            .map(|identity| {
-                identity
-                    .secondary_keys
-                    .into_iter()
-                    .flat_map(|si| match si.signer {
-                        Signatory::Identity(sub_id) if max_depth > 0 => {
-                            Self::flatten_identities(sub_id, max_depth - 1)
-                        }
-                        _ => vec![],
-                    })
-                    .chain(core::iter::once(id))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
-    }
-
     /// Ensures that `origin`'s key is linked to a DID and returns both.
     pub fn ensure_did(origin: T::Origin) -> Result<(T::AccountId, IdentityId), DispatchError> {
         let sender = ensure_signed(origin)?;

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1308,20 +1308,12 @@ impl<T: Config> Module<T> {
         Ok(record)
     }
 
-    /// It checks if `key` is the primary key or secondary key of any IdentityId.
-    /// Please note that _frozen secondary keys_ are not lined to the frozen identity temporary.
-    ///
-    /// # Return
-    ///
-    /// An Option object containing the `IdentityId` that belongs to the key.
+    /// Returns the DID associated with `key`, if any,
+    /// assuming it is either the primary key or isn't frozen.
     pub fn get_identity(key: &T::AccountId) -> Option<IdentityId> {
-        if <KeyToIdentityIds<T>>::contains_key(key) {
-            let did = <KeyToIdentityIds<T>>::get(key);
-            if !Self::is_did_frozen(did) || Self::is_primary_key(&did, key) {
-                return Some(did);
-            }
-        }
-        None
+        <KeyToIdentityIds<T>>::try_get(key)
+            .ok()
+            .filter(|did| !Self::is_did_frozen(did) || Self::is_primary_key(&did, key))
     }
 
     /// It freezes/unfreezes the target `did` identity.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1655,14 +1655,6 @@ impl<T: Config> Module<T> {
         })
     }
 
-    /// Returns identity of a signatory
-    pub fn get_identity_of_signatory(signer: &Signatory<T::AccountId>) -> Option<IdentityId> {
-        match signer {
-            Signatory::Account(key) => Self::get_identity(&key),
-            Signatory::Identity(did) => Some(*did),
-        }
-    }
-
     fn leave_identity(origin: T::Origin) -> DispatchResult {
         let (key, did) = Self::ensure_did(origin)?;
         let signer = Signatory::Account(key.clone());

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -65,7 +65,6 @@
 //! - `accept_primary_key` - Accept authorization to become the new primary key of an identity.
 //! - `change_cdd_requirement_for_mk_rotation` - Sets if CDD authorization is required for updating primary key of an identity.
 //! - `join_identity_as_key` - Join an identity as a secondary key.
-//! - `join_identity_as_identity` - Join an identity as a secondary identity.
 //! - `add_claim` - Adds a new claim record or edits an existing one.
 //! - `revoke_claim` - Marks the specified claim as revoked.
 //! - `revoke_claim_by_index` - Revoke a claim identified by its index.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -427,7 +427,10 @@ decl_module! {
         /// Leave an identity as a secondary identity.
         #[weight = <T as Config>::WeightInfo::leave_identity_as_identity()]
         pub fn leave_identity_as_identity(origin, did: IdentityId) -> DispatchResult {
-            let (_, sender_did) = Self::ensure_did(origin)?;
+            let (sender, sender_did) = Self::ensure_did(origin)?;
+            if sender != DidRecords::<T>::get(sender_did).primary_key {
+                CallPermissions::<T>::ensure_call_permissions(&sender)?;
+            }
             Self::leave_identity(Signatory::from(sender_did), did)
         }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -859,7 +859,7 @@ impl<T: Config> Module<T> {
 
             Self::link_account_key_to_did(&key, target_did);
 
-            Self::unsafe_join_identity(target_did, permissions, &signer);
+            Self::unsafe_join_identity(target_did, permissions, key);
             Ok(())
         })
     }
@@ -873,14 +873,14 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    /// Joins an identity as signer
+    /// Joins a DID as an account based secondary key.
     pub fn unsafe_join_identity(
         target_did: IdentityId,
         permissions: Permissions,
-        signer: &Signatory<T::AccountId>,
+        key: T::AccountId,
     ) {
         // Link the secondary key.
-        let sk = SecondaryKey::new(signer.clone(), permissions);
+        let sk = SecondaryKey::new(Signatory::Account(key), permissions);
         <DidRecords<T>>::mutate(target_did, |identity| {
             identity.add_secondary_keys(iter::once(sk.clone()));
         });

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -75,7 +75,6 @@
 //! - `add_authorization` - Adds an authorization.
 //! - `remove_authorization` - Removes an authorization.
 //! - `add_secondary_keys_with_authorization` - Adds secondary keys to target identity `id`.
-//! - `revoke_offchain_authorization` - Revokes the `auth` off-chain authorization of `signer`.
 //! - `add_investor_uniqueness_claim` - Adds InvestorUniqueness claim for a given target identity.
 //! - `add_investor_uniqueness_claim_v2` - Adds InvestorUniqueness claim V2 for a given target identity.
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -410,28 +410,11 @@ decl_module! {
             Self::join_identity(Signatory::Account(sender), auth_id)
         }
 
-        /// Join an identity as a secondary identity.
-        #[weight = <T as Config>::WeightInfo::join_identity_as_identity()]
-        pub fn join_identity_as_identity(origin, auth_id: u64) -> DispatchResult {
-            let sender_did = Self::ensure_perms(origin)?;
-            Self::join_identity(Signatory::from(sender_did), auth_id)
-        }
-
         /// Leave the secondary key's identity.
         #[weight = <T as Config>::WeightInfo::leave_identity_as_key()]
         pub fn leave_identity_as_key(origin) -> DispatchResult {
             let (sender, did) = Self::ensure_did(origin)?;
             Self::leave_identity(Signatory::Account(sender), did)
-        }
-
-        /// Leave an identity as a secondary identity.
-        #[weight = <T as Config>::WeightInfo::leave_identity_as_identity()]
-        pub fn leave_identity_as_identity(origin, did: IdentityId) -> DispatchResult {
-            let (sender, sender_did) = Self::ensure_did(origin)?;
-            if sender != DidRecords::<T>::get(sender_did).primary_key {
-                CallPermissions::<T>::ensure_call_permissions(&sender)?;
-            }
-            Self::leave_identity(Signatory::from(sender_did), did)
         }
 
         /// Adds a new claim record or edits an existing one. Only called by did_issuer's secondary key.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -805,8 +805,6 @@ impl<T: Config> Module<T> {
             // join another identity, and then do something as the new identity.
             T::CddHandler::set_current_identity(&target_did);
 
-            Self::link_account_key_to_did(&key, target_did);
-
             Self::unsafe_join_identity(target_did, permissions, key);
             Ok(())
         })
@@ -827,6 +825,8 @@ impl<T: Config> Module<T> {
         permissions: Permissions,
         key: T::AccountId,
     ) {
+        Self::link_account_key_to_did(&key, target_did);
+
         // Link the secondary key.
         let sk = SecondaryKey::new(Signatory::Account(key), permissions);
         <DidRecords<T>>::mutate(target_did, |identity| {

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -539,13 +539,10 @@ decl_module! {
             <Identity<T>>::ensure_key_did_unlinked(&multisig)?;
 
             <Identity<T>>::link_account_key_to_did(&multisig, did);
-            <Identity<T>>::unsafe_join_identity(
-                did,
-                Permissions::from_pallet_permissions(
-                    iter::once(PalletPermissions::entire_pallet(NAME.into()))
-                ),
-                &Signatory::Account(multisig),
+            let perms = Permissions::from_pallet_permissions(
+                iter::once(PalletPermissions::entire_pallet(NAME.into()))
             );
+            <Identity<T>>::unsafe_join_identity(did, perms, multisig);
         }
 
         /// Adds a multisig as the primary key of the current did if the current DID is the creator

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -686,8 +686,7 @@ impl<T: Config> Module<T> {
     }
 
     fn ensure_signed_did(origin: T::Origin) -> Result<Signatory<T::AccountId>, DispatchError> {
-        let sender = ensure_signed(origin)?;
-        Context::current_identity_or::<Identity<T>>(&sender).map(Signatory::from)
+        Identity::<T>::ensure_did(origin).map(|(_, d)| d.into())
     }
 
     fn ensure_primary_key(did: &IdentityId, sender: &T::AccountId) -> DispatchResult {
@@ -702,8 +701,7 @@ impl<T: Config> Module<T> {
         origin: T::Origin,
         multisig: &T::AccountId,
     ) -> Result<IdentityId, DispatchError> {
-        let sender = ensure_signed(origin)?;
-        let did = Context::current_identity_or::<Identity<T>>(&sender)?;
+        let (sender, did) = Identity::<T>::ensure_did(origin)?;
         Self::verify_sender_is_creator(did, multisig)?;
         Self::ensure_primary_key(&did, &sender)?;
         Ok(did)

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -538,7 +538,6 @@ decl_module! {
             Self::verify_sender_is_creator(did, &multisig)?;
             <Identity<T>>::ensure_key_did_unlinked(&multisig)?;
 
-            <Identity<T>>::link_account_key_to_did(&multisig, did);
             let perms = Permissions::from_pallet_permissions(
                 iter::once(PalletPermissions::entire_pallet(NAME.into()))
             );

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -62,7 +62,6 @@ decl_error! {
     pub enum Error for Module<T: Config> {
         /// The caller is not authorized to call the current extrinsic.
         UnauthorizedCaller,
-        RecursionNotAllowed,
     }
 }
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -700,21 +700,21 @@ pub fn register_keyring_account_without_cdd(
 
 pub fn add_secondary_key_with_perms(
     did: IdentityId,
-    signer: Signatory<AccountId>,
+    acc: AccountId,
     perms: AuthPermissions,
 ) {
     let _primary_key = Identity::did_records(&did).primary_key;
     let auth_id = Identity::add_auth(
         did.clone(),
-        signer.clone(),
+        Signatory::Account(acc.clone()),
         AuthorizationData::JoinIdentity(perms),
         None,
     );
-    assert_ok!(Identity::join_identity(signer, auth_id));
+    assert_ok!(Identity::join_identity(Origin::signed(acc), auth_id));
 }
 
-pub fn add_secondary_key(did: IdentityId, signer: Signatory<AccountId>) {
-    add_secondary_key_with_perms(did, signer, <_>::default())
+pub fn add_secondary_key(did: IdentityId, acc: AccountId) {
+    add_secondary_key_with_perms(did, acc, <_>::default())
 }
 
 pub fn account_from(id: u64) -> AccountId {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -239,31 +239,56 @@ polymesh_runtime_common::runtime_apis! {}
 
 #[derive(Copy, Clone)]
 pub struct User {
+    /// The `ring` of the `User` used to derive account related data,
+    /// e.g., origins, keys, and balances.
     pub ring: AccountKeyring,
+    /// The DID of the `User`.
+    /// The `ring` need not be the primary key of this DID.
     pub did: IdentityId,
 }
 
 impl User {
-    pub fn new(ring: AccountKeyring) -> Self {
-        let did = register_keyring_account(ring).unwrap();
-        Self { ring, did }
-    }
-
-    pub fn existing(ring: AccountKeyring) -> Self {
-        let did = get_identity_id(ring).unwrap();
+    /// Creates a `User` provided a `did` and a `ring`.
+    ///
+    /// The function is useful when `ring` refers to a secondary key.
+    /// At the time of calling, nothing is asserted about `did`'s registration.
+    pub const fn new_with(did: IdentityId, ring: AccountKeyring) -> Self {
         User { ring, did }
     }
 
+    /// Creates and registers a `User` for the given `ring` which will act as the primary key.
+    pub fn new(ring: AccountKeyring) -> Self {
+        Self::new_with(register_keyring_account(ring).unwrap(), ring)
+    }
+
+    /// Creates a `User` for an already registered DID with `ring` as its primary key.
+    pub fn existing(ring: AccountKeyring) -> Self {
+        Self::new_with(get_identity_id(ring).unwrap(), ring)
+    }
+
+    /// Returns the current balance of `self`'s account.
     pub fn balance(self, balance: u128) -> Self {
         use frame_support::traits::Currency as _;
         Balances::make_free_balance_be(&self.acc(), balance);
         self
     }
 
+    /// Returns `self`'s `AccountId`. This is based on the `ring`.
     pub fn acc(&self) -> AccountId {
         self.ring.to_account_id()
     }
 
+    /// Returns an account based signatory for `self`.
+    pub fn signatory_acc(&self) -> Signatory<AccountId> {
+        Signatory::Account(self.acc())
+    }
+
+    /// Returns an account based signatory for `self`.
+    pub const fn signatory_did(&self) -> Signatory<AccountId> {
+        Signatory::Identity(self.did)
+    }
+
+    /// Returns an `Origin` that can be used to execute extrinsics.
     pub fn origin(&self) -> Origin {
         Origin::signed(self.acc())
     }
@@ -673,15 +698,23 @@ pub fn register_keyring_account_without_cdd(
     make_account_without_cdd(acc.to_account_id()).map(|(_, id)| id)
 }
 
-pub fn add_secondary_key(did: IdentityId, signer: Signatory<AccountId>) {
+pub fn add_secondary_key_with_perms(
+    did: IdentityId,
+    signer: Signatory<AccountId>,
+    perms: AuthPermissions,
+) {
     let _primary_key = Identity::did_records(&did).primary_key;
     let auth_id = Identity::add_auth(
         did.clone(),
         signer.clone(),
-        AuthorizationData::JoinIdentity(AuthPermissions::default()),
+        AuthorizationData::JoinIdentity(perms),
         None,
     );
     assert_ok!(Identity::join_identity(signer, auth_id));
+}
+
+pub fn add_secondary_key(did: IdentityId, signer: Signatory<AccountId>) {
+    add_secondary_key_with_perms(did, signer, <_>::default())
 }
 
 pub fn account_from(id: u64) -> AccountId {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -698,11 +698,7 @@ pub fn register_keyring_account_without_cdd(
     make_account_without_cdd(acc.to_account_id()).map(|(_, id)| id)
 }
 
-pub fn add_secondary_key_with_perms(
-    did: IdentityId,
-    acc: AccountId,
-    perms: AuthPermissions,
-) {
+pub fn add_secondary_key_with_perms(did: IdentityId, acc: AccountId, perms: AuthPermissions) {
     let _primary_key = Identity::did_records(&did).primary_key;
     let auth_id = Identity::add_auth(
         did.clone(),

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2204,8 +2204,7 @@ decl_module! {
         /// #</weight>
         #[weight = 1_000_000_000]
         pub fn validate_cdd_expiry_nominators(origin, targets: Vec<T::AccountId>) {
-            let caller = ensure_signed(origin)?;
-            let caller_id = Context::current_identity_or::<T::IdentityFn>(&caller)?;
+            let (caller, caller_id) = Identity::<T>::ensure_did(origin)?;
 
             let mut expired_nominators = Vec::new();
             ensure!(!targets.is_empty(), "targets cannot be empty");

--- a/pallets/weights/src/pallet_identity.rs
+++ b/pallets/weights/src/pallet_identity.rs
@@ -40,20 +40,10 @@ impl pallet_identity::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(11 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
-    fn join_identity_as_identity() -> Weight {
-        (198_296_000 as Weight)
-            .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
     fn leave_identity_as_key() -> Weight {
         (163_285_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
-    }
-    fn leave_identity_as_identity() -> Weight {
-        (112_937_000 as Weight)
-            .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_claim() -> Weight {
         (171_882_000 as Weight)
@@ -101,11 +91,6 @@ impl pallet_identity::WeightInfo for WeightInfo {
             .saturating_add((108_801_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(12 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
-    }
-    fn revoke_offchain_authorization() -> Weight {
-        (119_376_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_investor_uniqueness_claim() -> Weight {
         (2_301_277_000 as Weight)

--- a/scripts/cli/src/interfaces/augment-api-errors.ts
+++ b/scripts/cli/src/interfaces/augment-api-errors.ts
@@ -761,10 +761,6 @@ declare module '@polkadot/api/types/errors' {
        **/
       NotPrimaryKey: AugmentedError<ApiType>;
       /**
-       * Do not allow forwarded call to be called recursively
-       **/
-      RecursionNotAllowed: AugmentedError<ApiType>;
-      /**
        * The secondary keys contain the primary key.
        **/
       SecondaryKeysContainPrimaryKey: AugmentedError<ApiType>;
@@ -902,7 +898,6 @@ declare module '@polkadot/api/types/errors' {
       [key: string]: AugmentedError<ApiType>;
     };
     permissions: {
-      RecursionNotAllowed: AugmentedError<ApiType>;
       /**
        * The caller is not authorized to call the current extrinsic.
        **/
@@ -1550,7 +1545,7 @@ declare module '@polkadot/api/types/errors' {
     system: {
       /**
        * Failed to extract the runtime version from the new runtime.
-       * 
+       *
        * Either calling `Core_version` or decoding `RuntimeVersion` failed.
        **/
       FailedToExtractRuntimeVersion: AugmentedError<ApiType>;

--- a/scripts/cli/src/interfaces/augment-api-events.ts
+++ b/scripts/cli/src/interfaces/augment-api-events.ts
@@ -629,10 +629,6 @@ declare module '@polkadot/api/types/events' {
        **/
       DidCreated: AugmentedEvent<ApiType, [IdentityId, AccountId, Vec<SecondaryKey>]>;
       /**
-       * Forwarded Call - (calling DID, target DID, pallet name, function name)
-       **/
-      ForwardedCall: AugmentedEvent<ApiType, [IdentityId, IdentityId, PalletName, DispatchableName]>;
-      /**
        * Mocked InvestorUid created.
        **/
       MockInvestorUIDCreated: AugmentedEvent<ApiType, [IdentityId, InvestorUid]>;


### PR DESCRIPTION
## changelog

### modified logic

- Do not check permissions in `Identity::leave_identity_as_key`.

### modified api

- Removed extrinsics `Identity::{join, leave}_identity_as_identity` and `Identity::revoke_offchain_authorization`.
- Removed event `Identity.ForwardedCall`.
- Removed errors `{Permissions, Identity}.RecursionNotAllowed`