### PR TITLE
Fix is_root check.

### DIFF
--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -173,7 +173,7 @@ decl_module! {
         /// - The sum of the weights of the `calls`.
         /// - One event.
         ///
-        /// This will return `Ok` in all circumstances. To determine the success of the batch, an
+        /// This will return `Ok` in all circumstances except an unsigned origin. To determine the success of the batch, an
         /// event is deposited. If a call failed and the batch was interrupted, then the
         /// `BatchInterrupted` event is deposited, along with the number of successful calls made
         /// and the error of the failed call. If all were successful, then the `BatchCompleted`
@@ -201,7 +201,7 @@ decl_module! {
         /// - The sum of the weights of the `calls`.
         /// - One event.
         ///
-        /// This will return `Ok` in all circumstances.
+        /// This will return `Ok` in all circumstances except an unsigned origin.
         /// To determine the success of the batch, an event is deposited.
         /// If any call failed, then `BatchInterrupted` is deposited.
         /// If all were successful, then the `BatchCompleted` event is deposited.
@@ -240,7 +240,7 @@ decl_module! {
         /// - The sum of the weights of the `calls`.
         /// - One event.
         ///
-        /// This will return `Ok` in all circumstances.
+        /// This will return `Ok` in all circumstances except an unsigned origin.
         /// To determine the success of the batch, an event is deposited.
         /// If any call failed, then `BatchOptimisticFailed` is deposited,
         /// with a vector of event counts for each call as well as a vector

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -164,7 +164,7 @@ decl_module! {
         ///
         /// This will execute until the first one fails and then stop.
         ///
-        /// May be called from any origin.
+        /// May be called from root or a signed origin.
         ///
         ///# Parameters
         /// - `calls`: The calls to be dispatched from the same origin.
@@ -192,7 +192,7 @@ decl_module! {
         /// in which case the state changes are rolled back.
         /// On failure, an event `BatchInterrupted(failure_idx, error)` is deposited.
         ///
-        /// May be called from any origin.
+        /// May be called from root or a signed origin.
         ///
         ///# Parameters
         /// - `calls`: The calls to be dispatched from the same origin.
@@ -230,7 +230,7 @@ decl_module! {
         /// This will execute all calls, in order, irrespective of failures.
         /// Any failures will be available in a `BatchOptimisticFailed` event.
         ///
-        /// May be called from any origin.
+        /// May be called from root or a signed origin.
         ///
         ///# Parameters
         /// - `calls`: The calls to be dispatched from the same origin.

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -180,7 +180,7 @@ decl_module! {
         /// event is deposited.
         #[weight = <T as Config>::WeightInfo::batch(&calls)]
         pub fn batch(origin, calls: Vec<<T as Config>::Call>) {
-            let is_root = Self::ensure_root_or_signed(origin.clone()).is_ok();
+            let is_root = Self::ensure_root_or_signed(origin.clone())?;
 
             // Run batch
             Self::deposit_event(Self::run_batch(origin.clone(), is_root, calls, true));


### PR DESCRIPTION
Fix the `is_root` check in `utility.batch` extrinsic.

We are not using a `BaseCallFilter` right now, so I don't think this bug has any security issues.