### PR TITLE
MESH-1693 - Fix reject_instruction permissions.

### DIFF
--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -2621,6 +2621,20 @@ fn multiple_portfolio_settlement() {
             amount
         );
 
+        // Alice tries to withdraw affirmation from multiple portfolios where only one has been affirmed.
+        assert_noop!(
+            Settlement::withdraw_affirmation(
+                alice.origin(),
+                instruction_counter,
+                vec![
+                    PortfolioId::default_portfolio(alice.did),
+                    PortfolioId::user_portfolio(alice.did, alice_num)
+                ],
+                2
+            ),
+            Error::UnexpectedAffirmationStatus
+        );
+
         // Alice fails to approve the instruction from her user specified portfolio due to lack of funds
         assert_noop!(
             Settlement::affirm_instruction(

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -2934,6 +2934,7 @@ fn reject_instruction() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = User::new(AccountKeyring::Alice);
         let bob = User::new(AccountKeyring::Bob);
+        let charlie = User::new(AccountKeyring::Charlie);
 
         let (ticker, venue_counter) = ticker_init(alice, b"ACME");
         let amount = 100u128;
@@ -2960,6 +2961,12 @@ fn reject_instruction() {
             instruction_counter,
             AffirmationStatus::Affirmed,
             AffirmationStatus::Pending,
+        );
+        next_block();
+        // Try rejecting the instruction from a non-party account.
+        assert_noop!(
+            Settlement::reject_instruction(charlie.origin(), instruction_counter),
+            Error::UnauthorizedSigner
         );
         next_block();
         assert_ok!(Settlement::reject_instruction(

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -705,8 +705,10 @@ benchmarks! {
 
 
     reject_instruction {
+        // Use worse-case, since we don't have a leg count.
+        let l = MAX_LEGS_IN_INSTRUCTION;
         // Emulate the add instruction and get all the necessary arguments.
-        let (legs, venue_id, origin, did , portfolios, _, account_id) = emulate_add_instruction::<T>(MAX_LEGS_IN_INSTRUCTION, true).unwrap();
+        let (legs, venue_id, origin, did , portfolios, _, account_id) = emulate_add_instruction::<T>(l, true).unwrap();
         // Add and affirm instruction.
         Module::<T>::add_and_affirm_instruction((origin.clone()).into(), venue_id, SettlementType::SettleOnAffirmation, None, None, legs, portfolios.clone()).expect("Unable to add and affirm the instruction");
         let instruction_id: u64 = 1;
@@ -836,8 +838,8 @@ benchmarks! {
     }
 
     reschedule_instruction {
-
         let l = MAX_LEGS_IN_INSTRUCTION;
+
         let (portfolios_to, from, to, tickers, _) = setup_affirm_instruction::<T>(l);
         let instruction_id = 1; // It will always be `1` as we know there is no other instruction in the storage yet.
         let to_portfolios = portfolios_to.clone();

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -697,15 +697,7 @@ decl_module! {
             let legs = InstructionLegs::iter_prefix(instruction_id).collect::<Vec<_>>();
 
             // Ensure that the sender is a party of this instruction.
-            let mut is_party = false;
-            for (_, leg) in &legs {
-                if Self::is_leg_party(leg, primary_did, secondary_key.as_ref()) {
-                    is_party = true;
-                    // Only need to find one leg that the sender is a part of.
-                    break;
-                }
-            }
-            ensure!(is_party, Error::<T>::UnauthorizedSigner);
+            ensure!(legs.iter().any(|(_, leg)| Self::is_leg_party(leg, primary_did, secondary_key.as_ref())), Error::<T>::UnauthorizedSigner);
 
             Self::unsafe_unclaim_receipts(instruction_id, &legs);
             Self::unchecked_release_locks(instruction_id, &legs);

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -957,6 +957,7 @@ impl<T: Config> Module<T> {
 
         // Check if the venue has required permissions from token owners.
         for ticker in &tickers {
+            // TODO: Merge with above for loop.
             if Self::venue_filtering(ticker) {
                 ensure!(
                     Self::venue_allow_list(ticker, venue_id),
@@ -1049,7 +1050,7 @@ impl<T: Config> Module<T> {
                     ));
                 }
                 LegStatus::ExecutionPending => {
-                    // Tokens are unlocked, need to be unlocked
+                    // Tokens are locked, need to be unlocked.
                     Self::unlock_via_leg(&leg_details)?;
                 }
                 LegStatus::PendingTokenLock => {
@@ -1059,7 +1060,7 @@ impl<T: Config> Module<T> {
             <InstructionLegStatus<T>>::insert(instruction_id, leg_id, LegStatus::PendingTokenLock);
         }
 
-        // Updates storage
+        // Updates storage.
         for portfolio in &portfolios {
             UserAffirmations::insert(portfolio, instruction_id, AffirmationStatus::Pending);
             AffirmsReceived::remove(instruction_id, portfolio);
@@ -1201,6 +1202,7 @@ impl<T: Config> Module<T> {
         AffirmsReceived::remove_prefix(instruction_id);
 
         // We remove duplicates in memory before triggering storage actions
+        // TODO: Use BTreeSet instead to avoid sort/dedup.
         let mut counter_parties = Vec::with_capacity(legs.len() * 2);
         for (_, leg) in &legs {
             counter_parties.push(leg.from);

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -1196,7 +1196,8 @@ impl<T: Config> Module<T> {
 
     fn prune_instruction(instruction_id: u64) {
         let legs = InstructionLegs::drain_prefix(instruction_id).collect::<Vec<_>>();
-        <InstructionDetails<T>>::remove(instruction_id);
+        let details = <InstructionDetails<T>>::take(instruction_id);
+        VenueInstructions::remove(details.venue_id, instruction_id);
         <InstructionLegStatus<T>>::remove_prefix(instruction_id);
         InstructionAffirmsPending::remove(instruction_id);
         AffirmsReceived::remove_prefix(instruction_id);

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -944,10 +944,12 @@ impl<T: Config> Module<T> {
 
         // Create a list of unique counter parties involved in the instruction.
         let mut counter_parties = BTreeSet::new();
+        let mut tickers = BTreeSet::new();
         for leg in &legs {
             ensure!(leg.from != leg.to, Error::<T>::SameSenderReceiver);
             // Check if the venue has required permissions from token owners.
-            if Self::venue_filtering(leg.asset) {
+            // Only check each ticker once.
+            if tickers.insert(leg.asset) && Self::venue_filtering(leg.asset) {
                 ensure!(
                     Self::venue_allow_list(leg.asset, venue_id),
                     Error::<T>::UnauthorizedVenue
@@ -1211,7 +1213,7 @@ impl<T: Config> Module<T> {
         max_legs_count: u32,
         secondary_key: Option<&SecondaryKey<T::AccountId>>,
     ) -> Result<u32, DispatchError> {
-        // checks portfolio's custodian and if it is a counter party with a pending or rejected affirmation
+        // Checks portfolio's custodian and if it is a counter party with a pending affirmation.
         Self::ensure_portfolios_and_affirmation_status(
             instruction_id,
             &portfolios,
@@ -1410,7 +1412,7 @@ impl<T: Config> Module<T> {
             Error::<T>::ReceiptAlreadyClaimed
         );
 
-        // verify portfolio custodianship and check if it is a counter party with a pending or rejected affirmation
+        // Verify portfolio custodianship and check if it is a counter party with a pending affirmation.
         Self::ensure_portfolios_and_affirmation_status(
             instruction_id,
             &portfolios_set,

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -178,6 +178,7 @@ pub enum AffirmationStatus {
     /// Affirmed by the user
     Affirmed,
     /// Rejected by the user
+    /// TODO: Unused, remove.
     Rejected,
 }
 

--- a/pallets/weights/src/pallet_settlement.rs
+++ b/pallets/weights/src/pallet_settlement.rs
@@ -90,9 +90,9 @@ impl pallet_settlement::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn reject_instruction() -> Weight {
-        (207_786_000 as Weight)
-            .saturating_add(DbWeight::get().reads(11 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+        (59_452_483_000 as Weight)
+            .saturating_add(DbWeight::get().reads(85 as Weight))
+            .saturating_add(DbWeight::get().writes(152 as Weight))
     }
     fn affirm_instruction(l: u32) -> Weight {
         (161_962_000 as Weight)


### PR DESCRIPTION
## changelog

### modified logic

- `reject_instruction` now checks that the caller is a party of at least one of the legs.  If the caller is not a party of the instruction, then `UnauthorizedSigner` error is returned.

### modified agent functionality

- `reject_instruction` requires that the sender is the owner/custodian of a portfolio from at least one leg.
