### PR TITLE
Add a `waitBocks` utility function for the integration tests.

### DIFF
--- a/scripts/cli/src/tests/11_A_settlement.ts
+++ b/scripts/cli/src/tests/11_A_settlement.ts
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
   await settlement.affirmInstruction(bob, intructionCounterAB, bobDid, 0);
 
   // Wait for settlement to be executed - happens in the next block
-  await init.sleep(1500);
+  await init.waitBlocks(2);
 
   //await rejectInstruction(bob, intructionCounter);
   //await unathorizeInstruction(alice, instructionCounter);

--- a/scripts/cli/src/tests/11_B_settlement.ts
+++ b/scripts/cli/src/tests/11_B_settlement.ts
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
   await settlement.affirmInstruction(eve, instructionCounter, eveDid, 0);
 
   // Wait for settlement to be executed - happens in the next block
-  await init.sleep(1500);
+  await init.waitBlocks(2);
 
   aliceBalance = await assetBalance(ticker, aliceDid);
   bobBalance = await assetBalance(ticker, bobDid);

--- a/scripts/cli/src/util/init.ts
+++ b/scripts/cli/src/util/init.ts
@@ -15,7 +15,7 @@ import BN from "bn.js";
 import fs from "fs";
 import path from "path";
 import cryptoRandomString from "crypto-random-string";
-import type { AccountId } from "@polkadot/types/interfaces/runtime";
+import type { AccountId, BlockNumber } from "@polkadot/types/interfaces/runtime";
 import type { SubmittableExtrinsic } from "@polkadot/api/types";
 import type { KeyringPair } from "@polkadot/keyring/types";
 import type { DispatchError } from "@polkadot/types/interfaces";
@@ -72,6 +72,22 @@ export class ApiSingleton {
 
 export async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function currentBlock() {
+  const api = await ApiSingleton.getInstance();
+  return (await api.query.system.number()).toNumber();
+}
+
+export async function waitBlocks(blocks: number) {
+  let end_block = (await currentBlock()) + blocks;
+  while ((await currentBlock()) < end_block) {
+    await sleep(100);
+  }
+}
+
+export async function waitNextBlock() {
+  await waitBlocks(1);
 }
 
 interface TestEntities {


### PR DESCRIPTION
Instead of used a fixed sleep time, wait for x blocks to be produced.