### PR TITLE
MESH-1706: Update protocol fees

### DIFF
--- a/pallets/asset/src/checkpoint/mod.rs
+++ b/pallets/asset/src/checkpoint/mod.rs
@@ -521,7 +521,7 @@ impl<T: Config> Module<T> {
         // Charge the fee for checkpoint creation.
         // N.B. this operation bundles verification + a storage change.
         // Thus, it must be last, and only storage changes follow.
-        T::ProtocolFee::charge_fee(ProtocolOp::AssetCreateCheckpointSchedule)?;
+        T::ProtocolFee::charge_fee(ProtocolOp::CheckpointCreateSchedule)?;
 
         // (1) Start is now, so create the checkpoint.
         if let Some(cp_id) = cp_id {

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1776,7 +1776,7 @@ impl<T: Config> Module<T> {
 
         // Charge fee.
         let len = docs.len();
-        T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocument, len)?;
+        T::ProtocolFee::batch_charge_fee(ProtocolOp::AssetAddDocuments, len)?;
 
         // Add the documents & emit events.
         AssetDocumentsIdSequence::mutate(ticker, |DocumentId(ref mut id)| {

--- a/pallets/common/src/protocol_fee.rs
+++ b/pallets/common/src/protocol_fee.rs
@@ -26,21 +26,17 @@ use sp_runtime::{Deserialize, Serialize};
 pub enum ProtocolOp {
     AssetRegisterTicker,
     AssetIssue,
-    AssetAddDocument,
+    AssetAddDocuments,
     AssetCreateAsset,
-    AssetCreateCheckpointSchedule,
-    DividendNew,
+    CheckpointCreateSchedule,
     ComplianceManagerAddComplianceRequirement,
-    IdentityRegisterDid,
     IdentityCddRegisterDid,
     IdentityAddClaim,
-    IdentitySetPrimaryKey,
     IdentityAddSecondaryKeysWithAuthorization,
     PipsPropose,
-    VotingAddBallot,
     ContractsPutCode,
-    BallotAttachBallot,
-    DistributionDistribute,
+    CorporateBallotAttachBallot,
+    CapitalDistributionDistribute,
 }
 
 /// Common interface to protocol fees for runtime modules.

--- a/pallets/corporate-actions/src/ballot/mod.rs
+++ b/pallets/corporate-actions/src/ballot/mod.rs
@@ -339,7 +339,7 @@ decl_module! {
             Self::ensure_meta_lengths_limited(&meta)?;
 
             // Charge protocol fee.
-            T::ProtocolFee::charge_fee(ProtocolOp::BallotAttachBallot)?;
+            T::ProtocolFee::charge_fee(ProtocolOp::CorporateBallotAttachBallot)?;
 
             // Commit to storage.
             MotionNumChoices::insert(ca_id, choices);

--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -251,7 +251,7 @@ decl_module! {
             <Portfolio<T>>::ensure_sufficient_balance(&from, &currency, amount)?;
 
             // Charge the protocol fee. Last check; we are in commit phase after this.
-            T::ProtocolFee::charge_fee(ProtocolOp::DistributionDistribute)?;
+            T::ProtocolFee::charge_fee(ProtocolOp::CapitalDistributionDistribute)?;
 
             // (1) Lock `amount` in `from`.
             <Portfolio<T>>::unchecked_lock_tokens(&from, &currency, amount);

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -48,18 +48,17 @@ impl Default for MockProtocolBaseFees {
         let ops = vec![
             ProtocolOp::AssetRegisterTicker,
             ProtocolOp::AssetIssue,
-            ProtocolOp::AssetAddDocument,
+            ProtocolOp::AssetAddDocuments,
             ProtocolOp::AssetCreateAsset,
-            ProtocolOp::DividendNew,
+            ProtocolOp::CheckpointCreateSchedule,
             ProtocolOp::ComplianceManagerAddComplianceRequirement,
-            ProtocolOp::IdentityRegisterDid,
             ProtocolOp::IdentityCddRegisterDid,
             ProtocolOp::IdentityAddClaim,
-            ProtocolOp::IdentitySetPrimaryKey,
             ProtocolOp::IdentityAddSecondaryKeysWithAuthorization,
             ProtocolOp::PipsPropose,
-            ProtocolOp::VotingAddBallot,
             ProtocolOp::ContractsPutCode,
+            ProtocolOp::CorporateBallotAttachBallot,
+            ProtocolOp::CapitalDistributionDistribute,
         ];
         let fees = ops
             .into_iter()

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1840,7 +1840,7 @@ fn add_investor_uniqueness_claim_v2() {
             assert_ok!(Identity::_register_did(
                 user_no_cdd_id.clone(),
                 vec![],
-                Some(ProtocolOp::IdentityRegisterDid)
+                Some(ProtocolOp::IdentityCddRegisterDid)
             ));
 
             // Load test cases and run them.

--- a/pallets/test-utils/src/lib.rs
+++ b/pallets/test-utils/src/lib.rs
@@ -124,7 +124,7 @@ decl_module! {
             secondary_keys: Vec<SecondaryKey<T::AccountId>>,
         ) {
             let sender = ensure_signed(origin)?;
-            Identity::<T>::_register_did(sender.clone(), secondary_keys, Some(ProtocolOp::IdentityRegisterDid))?;
+            Identity::<T>::_register_did(sender.clone(), secondary_keys, Some(ProtocolOp::IdentityCddRegisterDid))?;
 
             // Add CDD claim
             let did = Identity::<T>::get_identity(&sender).ok_or("DID Self-register failed")?;

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -796,21 +796,17 @@
       "_enum": [
         "AssetRegisterTicker",
         "AssetIssue",
-        "AssetAddDocument",
+        "AssetAddDocuments",
         "AssetCreateAsset",
-        "AssetCreateCheckpointSchedule",
-        "DividendNew",
+        "CheckpointCreateSchedule",
         "ComplianceManagerAddComplianceRequirement",
-        "IdentityRegisterDid",
         "IdentityCddRegisterDid",
         "IdentityAddClaim",
-        "IdentitySetPrimaryKey",
         "IdentityAddSecondaryKeysWithAuthorization",
         "PipsPropose",
-        "VotingAddBallot",
         "ContractsPutCode",
-        "BallotAttachBallot",
-        "DistributionDistribute"
+        "CorporateBallotAttachBallot",
+        "CapitalDistributionDistribute"
       ]
     },
     "CddStatus": {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1107,7 +1107,7 @@ pub mod mainnet {
                 TelemetryEndpoints::new(vec![(STAGING_TELEMETRY_URL.to_string(), 0)])
                     .expect("Mainnet bootstrap telemetry url is valid; qed"),
             ),
-            Some(&*"/polymath/mainnet"),
+            Some(&*"/polymesh/mainnet"),
             Some(polymath_props(12)),
             Default::default(),
         )


### PR DESCRIPTION
## changelog

### modified API

ProtocolOp fees updated to:
```
        "AssetRegisterTicker",
        "AssetIssue",
        "AssetAddDocuments",
        "AssetCreateAsset",
        "CheckpointCreateSchedule",
        "ComplianceManagerAddComplianceRequirement",
        "IdentityCddRegisterDid",
        "IdentityAddClaim",
        "IdentityAddSecondaryKeysWithAuthorization",
        "PipsPropose",
        "ContractsPutCode",
        "CorporateBallotAttachBallot",
        "CapitalDistributionDistribute"
```

Also updates protocol ID from polymath to polymesh