### PR TITLE
Revert RPC schema changes

### DIFF
--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -224,7 +224,7 @@ decl_storage! {
             double_map hasher(identity) T::AccountId, hasher(blake2_128_concat) T::Proposal => Option<u64>;
         /// Individual multisig signer votes. (multi sig, signer, proposal) => vote.
         pub Votes get(fn votes): map hasher(twox_64_concat) (T::AccountId, Signatory<T::AccountId>, u64) => bool;
-        /// Maps a multisig secondary key to a multisig address.
+        /// Maps a multisig signer key to a multisig address.
         pub KeyToMultiSig get(fn key_to_ms): map hasher(twox_64_concat) T::AccountId => T::AccountId;
         /// Maps a multisig account to its identity.
         pub MultiSigToIdentity get(fn ms_to_identity): map hasher(identity) T::AccountId => IdentityId;

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2258,7 +2258,7 @@ decl_module! {
             Self::deposit_event(RawEvent::CommissionCapUpdated(GC_DID, old_cap, new_cap));
         }
 
-        /// Changes min bond value to be used in bond(). Only Governance
+        /// Changes min bond value to be used in validate(). Only Governance
         /// committee is allowed to change this value.
         ///
         /// # Arguments

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1144,13 +1144,13 @@
           },
           {
             "name": "from_did",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "to_did",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "blockHash",
@@ -1366,8 +1366,8 @@
           },
           {
             "name": "from_custodian",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "from_portfolio",
@@ -1376,8 +1376,8 @@
           },
           {
             "name": "to_custodian",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "to_portfolio",
@@ -1407,8 +1407,8 @@
         "params": [
           {
             "name": "from_custodian",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "from_portfolio",
@@ -1417,8 +1417,8 @@
           },
           {
             "name": "to_custodian",
-            "type": "IdentityId",
-            "isOptional": true
+            "type": "Option<IdentityId>",
+            "isOptional": false
           },
           {
             "name": "to_portfolio",

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -282,6 +282,7 @@ fn genesis_processed_data(
 
     // Identity_05
     // Primary Key: polymath_5
+    // Secondary Keys: bridge multisig (controller)
 
     let mut identities = Vec::with_capacity(5);
     let mut keys = Vec::with_capacity(5 + 2 * initial_authorities.len()); //11


### PR DESCRIPTION
Revert RPC changes from https://github.com/PolymathNetwork/Polymesh/pull/1136 as they cause issues with the SDK.

We will revisit these, and leave these changes in our forks of polkadot.js for now.