### PR TITLE
Bring in some substrate 3.0 changes to staking

### DIFF
--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -219,9 +219,7 @@ macro_rules! misc_pallet_impls {
             type UnsignedPriority = StakingUnsignedPriority;
             type RequiredAddOrigin = Self::SlashCancelOrigin;
             type RequiredRemoveOrigin = Self::SlashCancelOrigin;
-            type RequiredComplianceOrigin = Self::SlashCancelOrigin;
             type RequiredCommissionOrigin = Self::SlashCancelOrigin;
-            type RequiredChangeHistoryDepthOrigin = Self::SlashCancelOrigin;
             type RewardScheduler = Scheduler;
             type MaxValidatorPerIdentity = MaxValidatorPerIdentity;
             type MaxVariableInflationTotalIssuance = MaxVariableInflationTotalIssuance;
@@ -734,7 +732,7 @@ macro_rules! runtime_apis {
 
             impl pallet_staking_rpc_runtime_api::StakingApi<Block> for Runtime {
                 fn get_curve() -> Vec<(Perbill, Perbill)> {
-                    Staking::get_curve()
+                    RewardCurve::get().points.to_vec()
                 }
             }
 

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -609,9 +609,7 @@ impl Config for Test {
     type WeightInfo = polymesh_weights::pallet_staking::WeightInfo;
     type RequiredAddOrigin = frame_system::EnsureRoot<AccountId>;
     type RequiredRemoveOrigin = EnsureSignedBy<TwoThousand, Self::AccountId>;
-    type RequiredComplianceOrigin = frame_system::EnsureRoot<AccountId>;
     type RequiredCommissionOrigin = frame_system::EnsureRoot<AccountId>;
-    type RequiredChangeHistoryDepthOrigin = frame_system::EnsureRoot<AccountId>;
     type RewardScheduler = Scheduler;
     type PalletsOrigin = OriginCaller;
     type MaxValidatorPerIdentity = MaxValidatorPerIdentity;

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -2791,10 +2791,7 @@ fn garbage_collection_after_slashing() {
 
             assert_eq!(Balances::free_balance(11), 256_000 - 25_600);
             assert!(SlashingSpans::<Test>::get(&11).is_some());
-            assert_eq!(
-                SpanSlash::<Test>::get(&(11, 0)).amount_slashed(),
-                &25_600
-            );
+            assert_eq!(SpanSlash::<Test>::get(&(11, 0)).amount_slashed(), &25_600);
 
             on_offence_now(
                 &[OffenceDetails {

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -204,7 +204,7 @@ fn basic_setup_works() {
 
         // ValidatorPrefs are default
         assert_eq_uvec!(
-            mock::Staking::get_all_validators(),
+            Validators::<Test>::iter().collect::<Vec<_>>(),
             vec![
                 (31, ValidatorPrefs::default()),
                 (21, ValidatorPrefs::default()),
@@ -554,10 +554,10 @@ fn no_candidate_emergency_condition() {
                 commission: Perbill::one(),
                 ..Default::default()
             };
-            mock::Staking::insert_validators(11, prefs.clone());
+            Validators::<Test>::insert(11, prefs.clone());
 
             // set the minimum validator count.
-            mock::Staking::set_minimum_validator_count(10);
+            MinimumValidatorCount::put(10);
 
             // try to chill
             let _ = Staking::chill(Origin::signed(10));
@@ -2790,9 +2790,9 @@ fn garbage_collection_after_slashing() {
             );
 
             assert_eq!(Balances::free_balance(11), 256_000 - 25_600);
-            assert!(mock::Staking::get_slashing_spans(&11).is_some());
+            assert!(SlashingSpans::<Test>::get(&11).is_some());
             assert_eq!(
-                mock::Staking::get_span_slash(&(11, 0)).amount_slashed(),
+                SpanSlash::<Test>::get(&(11, 0)).amount_slashed(),
                 &25_600
             );
 
@@ -2813,7 +2813,7 @@ fn garbage_collection_after_slashing() {
             assert_eq!(Balances::free_balance(11), 0);
             assert_eq!(Balances::total_balance(&11), 0);
 
-            let slashing_spans = mock::Staking::get_slashing_spans(&11).unwrap();
+            let slashing_spans = SlashingSpans::<Test>::get(&11).unwrap();
             assert_eq!(slashing_spans.iter().count(), 2);
 
             // reap_stash respects num_slashing_spans so that weight is accurate
@@ -2823,8 +2823,8 @@ fn garbage_collection_after_slashing() {
             );
             assert_ok!(Staking::reap_stash(Origin::none(), 11, 2));
 
-            assert!(mock::Staking::get_slashing_spans(&11).is_none());
-            assert_eq!(mock::Staking::get_span_slash(&(11, 0)).amount_slashed(), &0);
+            assert!(SlashingSpans::<Test>::get(&11).is_none());
+            assert_eq!(SpanSlash::<Test>::get(&(11, 0)).amount_slashed(), &0);
         })
 }
 
@@ -2855,20 +2855,20 @@ fn garbage_collection_on_window_pruning() {
         // assert_eq!(Balances::free_balance(101), 2000 - (nominated_value / 10));
         assert_eq!(Balances::free_balance(101), 2000);
 
-        assert!(mock::Staking::get_validator_slash_in_era(&now, &11).is_some());
+        assert!(ValidatorSlashInEra::<Test>::get(&now, &11).is_some());
         // Storage will not be updates as nominator didn't get slashed so it will be none.
-        assert!(mock::Staking::get_nominators_slash_in_era(&now, &101).is_none());
+        assert!(NominatorSlashInEra::<Test>::get(&now, &101).is_none());
 
         // + 1 because we have to exit the bonding window.
         for era in (0..(BondingDuration::get() + 1)).map(|offset| offset + now + 1) {
-            assert!(mock::Staking::get_validator_slash_in_era(&now, &11).is_some());
-            assert!(mock::Staking::get_nominators_slash_in_era(&now, &101).is_none());
+            assert!(ValidatorSlashInEra::<Test>::get(&now, &11).is_some());
+            assert!(NominatorSlashInEra::<Test>::get(&now, &101).is_none());
 
             mock::start_active_era(era);
         }
 
-        assert!(mock::Staking::get_validator_slash_in_era(&now, &11).is_none());
-        assert!(mock::Staking::get_nominators_slash_in_era(&now, &101).is_none());
+        assert!(ValidatorSlashInEra::<Test>::get(&now, &11).is_none());
+        assert!(NominatorSlashInEra::<Test>::get(&now, &101).is_none());
     })
 }
 
@@ -2932,7 +2932,7 @@ fn slashing_nominators_by_span_max() {
             },
         ];
 
-        let get_span = |account| mock::Staking::get_slashing_spans(&account).unwrap();
+        let get_span = |account| SlashingSpans::<Test>::get(&account).unwrap();
 
         assert_eq!(get_span(11).iter().collect::<Vec<_>>(), expected_spans,);
 
@@ -3002,7 +3002,7 @@ fn slashes_are_summed_across_spans() {
         assert_eq!(Balances::free_balance(21), 2000);
         assert_eq!(Staking::slashable_balance_of(&21), 1000);
 
-        let get_span = |account| mock::Staking::get_slashing_spans(&account).unwrap();
+        let get_span = |account| SlashingSpans::<Test>::get(&account).unwrap();
 
         on_offence_now(
             &[OffenceDetails {
@@ -3251,7 +3251,7 @@ fn remove_multi_deferred() {
                 &[Perbill::from_percent(25)],
             );
 
-            assert_eq!(mock::Staking::get_unapplied_slashed(&1).len(), 5);
+            assert_eq!(UnappliedSlashes::<Test>::get(&1).len(), 5);
 
             // fails if list is not sorted
             assert_noop!(
@@ -3275,7 +3275,7 @@ fn remove_multi_deferred() {
                 vec![0, 2, 4]
             ));
 
-            let slashes = mock::Staking::get_unapplied_slashed(&1);
+            let slashes = UnappliedSlashes::<Test>::get(&1);
             assert_eq!(slashes.len(), 2);
             assert_eq!(slashes[0].validator, 21);
             assert_eq!(slashes[1].validator, 42);
@@ -4437,15 +4437,15 @@ fn slash_kicks_validators_not_nominators_and_disables_nominator_for_kicked_valid
 
         // This is the best way to check that the validator was chilled; `get` will
         // return default value.
-        for (stash, _) in mock::Staking::get_all_validators().iter() {
-            assert!(*stash != 11);
+        for (stash, _) in Validators::<Test>::iter() {
+            assert!(stash != 11);
         }
 
         let nominations = mock::Staking::nominators(&101).unwrap();
 
         // and make sure that the vote will be ignored even if the validator
         // re-registers.
-        let last_slash = mock::Staking::get_slashing_spans(&11)
+        let last_slash = SlashingSpans::<Test>::get(&11)
             .unwrap()
             .last_nonzero_slash();
         assert!(nominations.submitted_in < last_slash);
@@ -4571,15 +4571,15 @@ fn zero_slash_keeps_nominators() {
 
         // This is the best way to check that the validator was chilled; `get` will
         // return default value.
-        for (stash, _) in mock::Staking::get_all_validators().iter() {
-            assert!(*stash != 11);
+        for (stash, _) in Validators::<Test>::iter() {
+            assert!(stash != 11);
         }
 
         let nominations = mock::Staking::nominators(&101).unwrap();
 
         // and make sure that the vote will not be ignored, because the slash was
         // zero.
-        let last_slash = mock::Staking::get_slashing_spans(&11)
+        let last_slash = SlashingSpans::<Test>::get(&11)
             .unwrap()
             .last_nonzero_slash();
         assert!(nominations.submitted_in >= last_slash);
@@ -4980,7 +4980,7 @@ fn on_initialize_weight_is_correct() {
     ExtBuilder::default()
         .has_stakers(false)
         .build_and_execute(|| {
-            assert_eq!(mock::Staking::get_all_validators().iter().count(), 0);
+            assert_eq!(Validators::<Test>::iter().count(), 0);
             assert_eq!(Nominators::<Test>::iter().count(), 0);
             // When this pallet has nothing, we do 4 reads each block
             let base_weight = <Test as frame_system::Config>::DbWeight::get().reads(4);
@@ -5000,7 +5000,7 @@ fn on_initialize_weight_is_correct() {
             Timestamp::set_timestamp(System::block_number() * 1000 + INIT_TIMESTAMP);
             Session::on_initialize(System::block_number());
 
-            assert_eq!(mock::Staking::get_all_validators().iter().count(), 4);
+            assert_eq!(Validators::<Test>::iter().count(), 4);
             assert_eq!(Nominators::<Test>::iter().count(), 5);
             // With 4 validators and 5 nominator, we should increase weight by:
             // - (4 + 5) reads

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -811,7 +811,13 @@ fn double_staking_should_fail() {
             Staking::nominate(Origin::signed(1), vec![1]),
             Error::<Test>::NotController
         );
+
         // 2 = controller  => nominating should work.
+        assert_noop!(
+            Staking::nominate(Origin::signed(2), vec![1]),
+            Error::<Test>::StashIdentityDoesNotExist,
+        );
+        provide_did_to_user(1);
         assert_ok!(Staking::nominate(Origin::signed(2), vec![1]));
     });
 }
@@ -4835,6 +4841,7 @@ fn payout_stakers_handles_basic_errors() {
 
             // Create nominators, targeting stash
             for i in 0..100 {
+                provide_did_to_user(1000 + i);
                 bond_nominator(1000 + i, 100 + i, balance + i as Balance, vec![11]);
             }
 
@@ -5038,7 +5045,10 @@ fn add_nominator_with_invalid_expiry() {
             let now = Utc::now();
             Timestamp::set_timestamp(now.timestamp() as u64);
             let validators = vec![10, 20, 30];
-            assert_ok!(Staking::nominate(controller_signed.clone(), validators));
+            assert_noop!(
+                Staking::nominate(controller_signed.clone(), validators),
+                Error::<Test>::StashIdentityNotCDDed,
+            );
             assert!(Staking::nominators(&account_alice).is_none());
         });
 }

--- a/pallets/staking/src/inflation.rs
+++ b/pallets/staking/src/inflation.rs
@@ -51,16 +51,18 @@ where
         return (payout.clone(), payout);
     }
 
-    let payout = portion
-        * yearly_inflation
-            .calculate_for_fraction_times_denominator(npos_token_staked, total_tokens.clone());
+    let payout = portion * yearly_inflation.calculate_for_fraction_times_denominator(
+        npos_token_staked,
+        total_tokens.clone(),
+    );
     let maximum = portion * (yearly_inflation.maximum * total_tokens);
     (payout, maximum)
 }
 
 #[cfg(test)]
 mod test {
-    use sp_runtime::{curve::PiecewiseLinear, Perbill};
+    use sp_runtime::curve::PiecewiseLinear;
+    use sp_runtime::Perbill;
 
     pallet_staking_reward_curve::build! {
         const I_NPOS: PiecewiseLinear<'static> = curve!(
@@ -76,9 +78,6 @@ mod test {
     #[test]
     fn npos_curve_is_sensible() {
         const YEAR: u64 = 365 * 24 * 60 * 60 * 1000;
-        const DAY: u64 = 24 * 60 * 60 * 1000;
-        const SIX_HOURS: u64 = 6 * 60 * 60 * 1000;
-        const HOUR: u64 = 60 * 60 * 1000;
         const MAX_VARIABLE_INFLATION_TOTAL_ISSUANCE: u64 = 1_000_000_000;
         const FIXED_YEARLY_REWARD: u64 = 1_000_000;
 
@@ -121,13 +120,16 @@ mod test {
         assert_payout(75_000, YEAR, 2_733);
         assert_payout(95_000, YEAR, 2_513);
         assert_payout(100_000, YEAR, 2_505);
+        const DAY: u64 = 24 * 60 * 60 * 1000;
         assert_payout(25_000, DAY, 17);
         assert_payout(50_000, DAY, 27);
         assert_payout(75_000, DAY, 7);
+        const SIX_HOURS: u64 = 6 * 60 * 60 * 1000;
         assert_payout(25_000, SIX_HOURS, 4);
         assert_payout(50_000, SIX_HOURS, 7);
         assert_payout(75_000, SIX_HOURS, 2);
 
+        const HOUR: u64 = 60 * 60 * 1000;
         assert_eq!(
             super::compute_total_payout(
                 &I_NPOS,

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2137,13 +2137,14 @@ decl_module! {
             ensure!(Self::permissioned_identity(&identity).is_none(), Error::<T>::AlreadyExists);
             // Validate the cdd status of the identity.
             ensure!(<Identity<T>>::has_valid_cdd(identity), Error::<T>::InvalidValidatorIdentity);
-            let pref = intended_count
-                .map(|count| {
+            let pref = match intended_count {
+                Some(count) => {
                     // Maximum allowed validator count is always less than the `MaxValidatorPerIdentity of validator_count()`.
                     ensure!(count < Self::get_allowed_validator_count(), Error::<T>::IntendedCountIsExceedingConsensusLimit);
                     PermissionedIdentityPrefs::new(count)
-                })
-                .unwrap_or_default();
+                }
+                None => PermissionedIdentityPrefs::default(),
+            };
 
             // Change identity status to be Permissioned
             PermissionedIdentity::insert(&identity, pref);

--- a/pallets/staking/src/offchain_election.rs
+++ b/pallets/staking/src/offchain_election.rs
@@ -134,8 +134,13 @@ pub(crate) fn compute_offchain_election<T: Config>() -> Result<(), OffchainElect
     let current_era = <Module<T>>::current_era().unwrap_or_default();
 
     // send it.
-    let call =
-        Call::submit_election_solution_unsigned(winners, compact, score, current_era, size).into();
+    let call = Call::submit_election_solution_unsigned(
+            winners,
+            compact,
+            score,
+            current_era,
+            size,
+    ).into();
 
     SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call)
         .map_err(|_| OffchainElectionError::PoolSubmissionFailed)
@@ -150,8 +155,7 @@ pub fn get_balancing_iters<T: Config>() -> usize {
         max @ _ => {
             let seed = sp_io::offchain::random_seed();
             let random = <u32>::decode(&mut TrailingZeroInput::new(seed.as_ref()))
-                .expect("input is padded with zeroes; qed")
-                % max.saturating_add(1);
+                .expect("input is padded with zeroes; qed") % max.saturating_add(1);
             random as usize
         }
     }
@@ -192,7 +196,7 @@ pub fn maximum_compact_len<W: crate::WeightInfo>(
                     Some(voters) if voters < max_voters => Ok(voters),
                     _ => Err(()),
                 }
-            }
+            },
             Ordering::Greater => voters.checked_sub(step).ok_or(()),
             Ordering::Equal => Ok(voters),
         }
@@ -206,17 +210,18 @@ pub fn maximum_compact_len<W: crate::WeightInfo>(
             // proceed with the binary search
             Ok(next) if next != voters => {
                 voters = next;
-            }
+            },
             // we are out of bounds, break out of the loop.
             Err(()) => {
                 break;
-            }
+            },
             // we found the right value - early exit the function.
-            Ok(next) => return next,
+            Ok(next) => return next
         }
         step = step / 2;
         current_weight = weight_with(voters);
     }
+
 
     // Time to finish.
     // We might have reduced less than expected due to rounding error. Increase one last time if we
@@ -230,9 +235,7 @@ pub fn maximum_compact_len<W: crate::WeightInfo>(
 
     debug_assert!(
         weight_with(voters.min(size.nominators)) <= max_weight,
-        "weight_with({}) <= {}",
-        voters.min(size.nominators),
-        max_weight,
+        "weight_with({}) <= {}", voters.min(size.nominators), max_weight,
     );
     voters.min(size.nominators)
 }
@@ -260,10 +263,7 @@ pub fn trim_to_weight<T: Config, FN>(
 where
     for<'r> FN: Fn(&'r T::AccountId) -> Option<NominatorIndex>,
 {
-    match compact
-        .voter_count()
-        .checked_sub(maximum_allowed_voters as usize)
-    {
+    match compact.voter_count().checked_sub(maximum_allowed_voters as usize) {
         Some(to_remove) if to_remove > 0 => {
             // grab all voters and sort them by least stake.
             let balance_of = <Module<T>>::slashable_balance_of_fn();
@@ -322,12 +322,7 @@ pub fn prepare_submission<T: Config>(
     do_reduce: bool,
     _maximum_weight: Weight,
 ) -> Result<
-    (
-        Vec<ValidatorIndex>,
-        CompactAssignments,
-        ElectionScore,
-        ElectionSize,
-    ),
+    (Vec<ValidatorIndex>, CompactAssignments, ElectionScore, ElectionSize),
     OffchainElectionError,
 > {
     // make sure that the snapshot is available.
@@ -451,48 +446,106 @@ mod test {
 
     struct Staking;
 
-    macro_rules! unimplemented_weight_fn {
-        ($name:ident $(,$arg_type:tt)*) => {
-            fn $name( $(_:$arg_type,)*) -> Weight {
-                unimplemented!()
-            }
-        };
-    }
-
     impl crate::WeightInfo for Staking {
-        unimplemented_weight_fn!(bond);
-        unimplemented_weight_fn!(bond_extra);
-        unimplemented_weight_fn!(unbond);
-        unimplemented_weight_fn!(validate);
-        unimplemented_weight_fn!(chill);
-        unimplemented_weight_fn!(set_payee);
-        unimplemented_weight_fn!(set_controller);
-        unimplemented_weight_fn!(set_validator_count);
-        unimplemented_weight_fn!(force_no_eras);
-        unimplemented_weight_fn!(force_new_era);
-        unimplemented_weight_fn!(force_new_era_always);
-        unimplemented_weight_fn!(set_min_bond_threshold);
-        unimplemented_weight_fn!(add_permissioned_validator);
-        unimplemented_weight_fn!(remove_permissioned_validator);
-        unimplemented_weight_fn!(set_commission_cap, u32);
-        unimplemented_weight_fn!(do_slash, u32);
-        unimplemented_weight_fn!(withdraw_unbonded_update, u32);
-        unimplemented_weight_fn!(withdraw_unbonded_kill, u32);
-        unimplemented_weight_fn!(nominate, u32);
-        unimplemented_weight_fn!(set_invulnerables, u32);
-        unimplemented_weight_fn!(force_unstake, u32);
-        unimplemented_weight_fn!(cancel_deferred_slash, u32);
-        unimplemented_weight_fn!(rebond, u32);
-        unimplemented_weight_fn!(set_history_depth, u32);
-        unimplemented_weight_fn!(reap_stash, u32);
-        unimplemented_weight_fn!(payout_stakers, u32);
-        unimplemented_weight_fn!(payout_stakers_alive_controller, u32);
-        unimplemented_weight_fn!(payout_all, u32, u32);
-        unimplemented_weight_fn!(new_era, u32, u32);
-        unimplemented_weight_fn!(change_slashing_allowed_for);
-        unimplemented_weight_fn!(update_permissioned_validator_intended_count);
-        unimplemented_weight_fn!(scale_validator_count);
-        unimplemented_weight_fn!(increase_validator_count);
+        fn bond() -> Weight {
+            unimplemented!()
+        }
+        fn bond_extra() -> Weight {
+            unimplemented!()
+        }
+        fn unbond() -> Weight {
+            unimplemented!()
+        }
+		fn withdraw_unbonded_update(s: u32) -> Weight {
+			unimplemented!()
+		}
+		fn withdraw_unbonded_kill(s: u32) -> Weight {
+			unimplemented!()
+		}
+        fn validate() -> Weight {
+            unimplemented!()
+        }
+		fn nominate(n: u32) -> Weight {
+			unimplemented!()
+		}
+        fn chill() -> Weight {
+            unimplemented!()
+        }
+        fn set_payee() -> Weight {
+            unimplemented!()
+        }
+        fn set_controller() -> Weight {
+            unimplemented!()
+        }
+        fn set_validator_count() -> Weight {
+            unimplemented!()
+        }
+        fn force_no_eras() -> Weight {
+            unimplemented!()
+        }
+        fn force_new_era() -> Weight {
+            unimplemented!()
+        }
+        fn force_new_era_always() -> Weight {
+            unimplemented!()
+        }
+		fn set_invulnerables(v: u32) -> Weight {
+			unimplemented!()
+		}
+		fn force_unstake(s: u32) -> Weight {
+			unimplemented!()
+		}
+		fn cancel_deferred_slash(s: u32) -> Weight {
+			unimplemented!()
+		}
+        fn payout_all(_: u32, _: u32) -> Weight {
+            unimplemented!()
+        }
+		fn payout_stakers(n: u32) -> Weight {
+			unimplemented!()
+		}
+		fn payout_stakers_alive_controller(n: u32) -> Weight {
+			unimplemented!()
+		}
+        fn set_min_bond_threshold() -> Weight {
+            unimplemented!()
+        }
+        fn add_permissioned_validator() -> Weight {
+            unimplemented!()
+        }
+        fn remove_permissioned_validator() -> Weight {
+            unimplemented!()
+        }
+        fn set_commission_cap(_: u32) -> Weight {
+            unimplemented!()
+        }
+        fn do_slash(_: u32) -> Weight {
+            unimplemented!()
+        }
+		fn rebond(l: u32) -> Weight {
+			unimplemented!()
+		}
+		fn set_history_depth(e: u32) -> Weight {
+			unimplemented!()
+		}
+		fn reap_stash(s: u32) -> Weight {
+			unimplemented!()
+		}
+        fn new_era(v: u32, n: u32) -> Weight {
+            unimplemented!()
+        }
+        fn change_slashing_allowed_for() -> Weight {
+            unimplemented!()
+        }
+        fn update_permissioned_validator_intended_count() -> Weight {
+            unimplemented!()
+        }
+        fn scale_validator_count() -> Weight {
+            unimplemented!()
+        }
+        fn increase_validator_count() -> Weight {
+            unimplemented!()
+        }
 
         fn submit_solution_better(v: u32, n: u32, a: u32, w: u32) -> Weight {
             (0 * v + 0 * n + 1000 * a + 0 * w) as Weight

--- a/pallets/staking/src/rustfmt.toml
+++ b/pallets/staking/src/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/pallets/staking/src/slashing.rs
+++ b/pallets/staking/src/slashing.rs
@@ -50,20 +50,17 @@
 //! Based on research at <https://research.web3.foundation/en/latest/polkadot/slashing/npos/>
 
 use super::{
-    BalanceOf, Config, EraIndex, Error, Exposure, Module, NegativeImbalanceOf, Perbill,
-    SessionInterface, SlashingSwitch, Store, UnappliedSlash,
+    EraIndex, Config, Module, Store, BalanceOf, Exposure, Perbill, SessionInterface,
+    NegativeImbalanceOf, UnappliedSlash, Error,
+    SlashingSwitch,
 };
-use codec::{Decode, Encode};
+use sp_runtime::{traits::{Zero, Saturating}, RuntimeDebug, DispatchResult};
 use frame_support::{
-    ensure,
-    traits::{Currency, Imbalance, OnUnbalanced},
-    StorageDoubleMap, StorageMap,
-};
-use sp_runtime::{
-    traits::{Saturating, Zero},
-    DispatchResult, RuntimeDebug,
+    StorageMap, StorageDoubleMap, ensure,
+    traits::{Currency, OnUnbalanced, Imbalance},
 };
 use sp_std::vec::Vec;
+use codec::{Encode, Decode};
 
 /// The proportion of the slashing reward to be paid out on the first slashing detection.
 /// This is f_1 in the paper.
@@ -122,9 +119,7 @@ impl SlashingSpans {
     // that internal state is unchanged.
     pub(crate) fn end_span(&mut self, now: EraIndex) -> bool {
         let next_start = now + 1;
-        if next_start <= self.last_start {
-            return false;
-        }
+        if next_start <= self.last_start { return false }
 
         let last_length = next_start - self.last_start;
         self.prior.insert(0, last_length);
@@ -137,21 +132,13 @@ impl SlashingSpans {
     pub fn iter(&'_ self) -> impl Iterator<Item = SlashingSpan> + '_ {
         let mut last_start = self.last_start;
         let mut index = self.span_index;
-        let last = SlashingSpan {
-            index,
-            start: last_start,
-            length: None,
-        };
+        let last = SlashingSpan { index, start: last_start, length: None };
         let prior = self.prior.iter().cloned().map(move |length| {
             let start = last_start - length;
             last_start = start;
             index -= 1;
 
-            SlashingSpan {
-                index,
-                start,
-                length: Some(length),
-            }
+            SlashingSpan { index, start, length: Some(length) }
         });
 
         sp_std::iter::once(last).chain(prior)
@@ -167,13 +154,9 @@ impl SlashingSpans {
     // If this returns `Some`, then it includes a range start..end of all the span
     // indices which were pruned.
     fn prune(&mut self, window_start: EraIndex) -> Option<(SpanIndex, SpanIndex)> {
-        let old_idx = self
-            .iter()
+        let old_idx = self.iter()
             .skip(1) // skip ongoing span.
-            .position(|span| {
-                span.length
-                    .map_or(false, |len| span.start + len <= window_start)
-            });
+            .position(|span| span.length.map_or(false, |len| span.start + len <= window_start));
 
         let earliest_span_index = self.span_index - self.prior.len() as SpanIndex;
         let pruned = match old_idx {
@@ -233,9 +216,9 @@ pub(crate) struct SlashParams<'a, T: 'a + Config> {
 ///
 /// The pending slash record returned does not have initialized reporters. Those have
 /// to be set at a higher level, if any.
-pub(crate) fn compute_slash<T: Config>(
-    params: SlashParams<T>,
-) -> Option<UnappliedSlash<T::AccountId, BalanceOf<T>>> {
+pub(crate) fn compute_slash<T: Config>(params: SlashParams<T>)
+    -> Option<UnappliedSlash<T::AccountId, BalanceOf<T>>>
+{
     let SlashParams {
         stash,
         slash,
@@ -258,14 +241,19 @@ pub(crate) fn compute_slash<T: Config>(
         return None;
     }
 
-    let (prior_slash_p, _era_slash) =
-        <Module<T> as Store>::ValidatorSlashInEra::get(&slash_era, stash)
-            .unwrap_or((Perbill::zero(), Zero::zero()));
+    let (prior_slash_p, _era_slash) = <Module<T> as Store>::ValidatorSlashInEra::get(
+        &slash_era,
+        stash,
+    ).unwrap_or((Perbill::zero(), Zero::zero()));
 
     // compare slash proportions rather than slash values to avoid issues due to rounding
     // error.
     if slash.deconstruct() > prior_slash_p.deconstruct() {
-        <Module<T> as Store>::ValidatorSlashInEra::insert(&slash_era, stash, &(slash, own_slash));
+        <Module<T> as Store>::ValidatorSlashInEra::insert(
+            &slash_era,
+            stash,
+            &(slash, own_slash),
+        );
     } else {
         // we slash based on the max in era - this new event is not the max,
         // so neither the validator or any nominators will need an update.
@@ -287,7 +275,10 @@ pub(crate) fn compute_slash<T: Config>(
             reward_proportion,
         );
 
-        let target_span = spans.compare_and_update_span_slash(slash_era, own_slash);
+        let target_span = spans.compare_and_update_span_slash(
+            slash_era,
+            own_slash,
+        );
 
         if target_span == Some(spans.span_index()) {
             // misbehavior occurred within the current slashing span - take appropriate
@@ -324,7 +315,9 @@ pub(crate) fn compute_slash<T: Config>(
 
 // doesn't apply any slash, but kicks out the validator if the misbehavior is from
 // the most recent slashing span.
-fn kick_out_if_recent<T: Config>(params: SlashParams<T>) {
+fn kick_out_if_recent<T: Config>(
+    params: SlashParams<T>,
+) {
     // these are not updated by era-span or end-span.
     let mut reward_payout = Zero::zero();
     let mut val_slashed = Zero::zero();
@@ -380,12 +373,18 @@ fn slash_nominators<T: Config>(
             let own_slash_by_validator = slash * nominator.value;
             let own_slash_difference = own_slash_by_validator.saturating_sub(own_slash_prior);
 
-            let mut era_slash = <Module<T> as Store>::NominatorSlashInEra::get(&slash_era, stash)
-                .unwrap_or_else(|| Zero::zero());
+            let mut era_slash = <Module<T> as Store>::NominatorSlashInEra::get(
+                &slash_era,
+                stash,
+            ).unwrap_or_else(|| Zero::zero());
 
             era_slash += own_slash_difference;
 
-            <Module<T> as Store>::NominatorSlashInEra::insert(&slash_era, stash, &era_slash);
+            <Module<T> as Store>::NominatorSlashInEra::insert(
+                &slash_era,
+                stash,
+                &era_slash,
+            );
 
             era_slash
         };
@@ -400,7 +399,10 @@ fn slash_nominators<T: Config>(
                 reward_proportion,
             );
 
-            let target_span = spans.compare_and_update_span_slash(slash_era, era_slash);
+            let target_span = spans.compare_and_update_span_slash(
+                slash_era,
+                era_slash,
+            );
 
             if target_span == Some(spans.span_index()) {
                 // End the span, but don't chill the nominator. its nomination
@@ -501,8 +503,8 @@ impl<'a, T: 'a + Config> InspectingSpans<'a, T> {
             span_record.slashed = slash;
 
             // compute reward.
-            let reward =
-                REWARD_F1 * (self.reward_proportion * slash).saturating_sub(span_record.paid_out);
+            let reward = REWARD_F1
+                * (self.reward_proportion * slash).saturating_sub(span_record.paid_out);
 
             self.add_slash(difference, slash_era);
             changed = true;
@@ -533,9 +535,7 @@ impl<'a, T: 'a + Config> InspectingSpans<'a, T> {
 impl<'a, T: 'a + Config> Drop for InspectingSpans<'a, T> {
     fn drop(&mut self) {
         // only update on disk if we slashed this account.
-        if !self.dirty {
-            return;
-        }
+        if !self.dirty { return }
 
         if let Some((start, end)) = self.spans.prune(self.window_start) {
             for span_index in start..end {
@@ -563,10 +563,7 @@ pub(crate) fn clear_stash_metadata<T: Config>(
         Some(s) => s,
     };
 
-    ensure!(
-        num_slashing_spans as usize >= spans.iter().count(),
-        Error::<T>::IncorrectSlashingSpans
-    );
+    ensure!(num_slashing_spans as usize >= spans.iter().count(), Error::<T>::IncorrectSlashingSpans);
 
     <Module<T> as Store>::SlashingSpans::remove(stash);
 
@@ -615,7 +612,9 @@ pub fn do_slash<T: Config>(
         <Module<T>>::update_ledger(&controller, &ledger);
 
         // trigger the event
-        <Module<T>>::deposit_event(super::RawEvent::Slash(stash.clone(), value));
+        <Module<T>>::deposit_event(
+            super::RawEvent::Slash(stash.clone(), value)
+        );
     }
 }
 
@@ -646,6 +645,7 @@ pub(crate) fn apply_slash<T: Config>(unapplied_slash: UnappliedSlash<T::AccountI
     pay_reporters::<T>(reward_payout, slashed_imbalance, &unapplied_slash.reporters);
 }
 
+
 /// Apply a reward payout to some reporters, paying the rewards out of the slashed imbalance.
 fn pay_reporters<T: Config>(
     reward_payout: BalanceOf<T>,
@@ -656,7 +656,7 @@ fn pay_reporters<T: Config>(
         // nobody to pay out to or nothing to pay;
         // just treat the whole value as slashed.
         T::Slash::on_unbalanced(slashed_imbalance);
-        return;
+        return
     }
 
     // take rewards out of the slashed imbalance.
@@ -685,11 +685,7 @@ mod tests {
     #[test]
     fn span_contains_era() {
         // unbounded end
-        let span = SlashingSpan {
-            index: 0,
-            start: 1000,
-            length: None,
-        };
+        let span = SlashingSpan { index: 0, start: 1000, length: None };
         assert!(!span.contains_era(0));
         assert!(!span.contains_era(999));
 
@@ -698,11 +694,7 @@ mod tests {
         assert!(span.contains_era(10000));
 
         // bounded end - non-inclusive range.
-        let span = SlashingSpan {
-            index: 0,
-            start: 1000,
-            length: Some(10),
-        };
+        let span = SlashingSpan { index: 0, start: 1000, length: Some(10) };
         assert!(!span.contains_era(0));
         assert!(!span.contains_era(999));
 
@@ -724,11 +716,7 @@ mod tests {
 
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
-            vec![SlashingSpan {
-                index: 0,
-                start: 1000,
-                length: None
-            }],
+            vec![SlashingSpan { index: 0, start: 1000, length: None }],
         );
     }
 
@@ -744,31 +732,11 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 10,
-                    start: 1000,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 9,
-                    start: 990,
-                    length: Some(10)
-                },
-                SlashingSpan {
-                    index: 8,
-                    start: 981,
-                    length: Some(9)
-                },
-                SlashingSpan {
-                    index: 7,
-                    start: 973,
-                    length: Some(8)
-                },
-                SlashingSpan {
-                    index: 6,
-                    start: 963,
-                    length: Some(10)
-                },
+                SlashingSpan { index: 10, start: 1000, length: None },
+                SlashingSpan { index: 9, start: 990, length: Some(10) },
+                SlashingSpan { index: 8, start: 981, length: Some(9) },
+                SlashingSpan { index: 7, start: 973, length: Some(8) },
+                SlashingSpan { index: 6, start: 963, length: Some(10) },
             ],
         )
     }
@@ -786,21 +754,9 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 10,
-                    start: 1000,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 9,
-                    start: 990,
-                    length: Some(10)
-                },
-                SlashingSpan {
-                    index: 8,
-                    start: 981,
-                    length: Some(9)
-                },
+                SlashingSpan { index: 10, start: 1000, length: None },
+                SlashingSpan { index: 9, start: 990, length: Some(10) },
+                SlashingSpan { index: 8, start: 981, length: Some(9) },
             ],
         );
 
@@ -808,21 +764,9 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 10,
-                    start: 1000,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 9,
-                    start: 990,
-                    length: Some(10)
-                },
-                SlashingSpan {
-                    index: 8,
-                    start: 981,
-                    length: Some(9)
-                },
+                SlashingSpan { index: 10, start: 1000, length: None },
+                SlashingSpan { index: 9, start: 990, length: Some(10) },
+                SlashingSpan { index: 8, start: 981, length: Some(9) },
             ],
         );
 
@@ -830,42 +774,26 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 10,
-                    start: 1000,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 9,
-                    start: 990,
-                    length: Some(10)
-                },
-                SlashingSpan {
-                    index: 8,
-                    start: 981,
-                    length: Some(9)
-                },
+                SlashingSpan { index: 10, start: 1000, length: None },
+                SlashingSpan { index: 9, start: 990, length: Some(10) },
+                SlashingSpan { index: 8, start: 981, length: Some(9) },
             ],
         );
 
         assert_eq!(spans.prune(1000), Some((8, 10)));
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
-            vec![SlashingSpan {
-                index: 10,
-                start: 1000,
-                length: None
-            },],
+            vec![
+                SlashingSpan { index: 10, start: 1000, length: None },
+            ],
         );
 
         assert_eq!(spans.prune(2000), None);
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
-            vec![SlashingSpan {
-                index: 10,
-                start: 2000,
-                length: None
-            },],
+            vec![
+                SlashingSpan { index: 10, start: 2000, length: None },
+            ],
         );
 
         // now all in one shot.
@@ -878,11 +806,9 @@ mod tests {
         assert_eq!(spans.prune(2000), Some((6, 10)));
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
-            vec![SlashingSpan {
-                index: 10,
-                start: 2000,
-                length: None
-            },],
+            vec![
+                SlashingSpan { index: 10, start: 2000, length: None },
+            ],
         );
     }
 
@@ -900,16 +826,8 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 2,
-                    start: 11,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 1,
-                    start: 10,
-                    length: Some(1)
-                },
+                SlashingSpan { index: 2, start: 11, length: None },
+                SlashingSpan { index: 1, start: 10, length: Some(1) },
             ],
         );
 
@@ -917,21 +835,9 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 3,
-                    start: 16,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 2,
-                    start: 11,
-                    length: Some(5)
-                },
-                SlashingSpan {
-                    index: 1,
-                    start: 10,
-                    length: Some(1)
-                },
+                SlashingSpan { index: 3, start: 16, length: None },
+                SlashingSpan { index: 2, start: 11, length: Some(5) },
+                SlashingSpan { index: 1, start: 10, length: Some(1) },
             ],
         );
 
@@ -940,21 +846,9 @@ mod tests {
         assert_eq!(
             spans.iter().collect::<Vec<_>>(),
             vec![
-                SlashingSpan {
-                    index: 3,
-                    start: 16,
-                    length: None
-                },
-                SlashingSpan {
-                    index: 2,
-                    start: 11,
-                    length: Some(5)
-                },
-                SlashingSpan {
-                    index: 1,
-                    start: 10,
-                    length: Some(1)
-                },
+                SlashingSpan { index: 3, start: 16, length: None },
+                SlashingSpan { index: 2, start: 11, length: Some(5) },
+                SlashingSpan { index: 1, start: 10, length: Some(1) },
             ],
         );
     }

--- a/pallets/staking/src/weights.rs
+++ b/pallets/staking/src/weights.rs
@@ -1,0 +1,38 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn bond() -> Weight;
+    fn bond_extra() -> Weight;
+    fn unbond() -> Weight;
+    fn withdraw_unbonded_update(s: u32) -> Weight;
+    fn withdraw_unbonded_kill(s: u32) -> Weight;
+    fn set_min_bond_threshold() -> Weight;
+    fn add_permissioned_validator() -> Weight;
+    fn remove_permissioned_validator() -> Weight;
+    fn set_commission_cap(m: u32) -> Weight;
+    fn validate() -> Weight;
+    fn nominate(n: u32) -> Weight;
+    fn chill() -> Weight;
+    fn set_payee() -> Weight;
+    fn set_controller() -> Weight;
+    fn set_validator_count() -> Weight;
+    fn force_no_eras() -> Weight;
+    fn force_new_era() -> Weight;
+    fn force_new_era_always() -> Weight;
+    fn set_invulnerables(v: u32) -> Weight;
+    fn force_unstake(s: u32) -> Weight;
+    fn cancel_deferred_slash(s: u32) -> Weight;
+    fn payout_stakers(n: u32) -> Weight;
+    fn payout_stakers_alive_controller(n: u32) -> Weight;
+    fn rebond(l: u32) -> Weight;
+    fn set_history_depth(e: u32) -> Weight;
+    fn reap_stash(s: u32) -> Weight;
+    fn new_era(v: u32, n: u32) -> Weight;
+    fn do_slash(l: u32) -> Weight;
+    fn payout_all(v: u32, n: u32) -> Weight;
+    fn submit_solution_better(v: u32, n: u32, a: u32, w: u32) -> Weight;
+    fn change_slashing_allowed_for() -> Weight;
+    fn update_permissioned_validator_intended_count() -> Weight;
+    fn increase_validator_count() -> Weight;
+    fn scale_validator_count() -> Weight;
+}


### PR DESCRIPTION
## Reviewing notes

- Make sure to review with whitespace changes hidden and focus on the perf/semantic changes.
- Many changes here are aimed at minimizing the diff to the [tag `v3.0.0` in substrate](https://github.com/paritytech/substrate/blob/v3.0.0/frame/staking/src/lib.rs) which is really the ultimate goal of this PR.

## changelog

### modified logic

- `Staking.{bond_extra, rebond}` check that the new active amount >= the `minimum_balance`.
- `Staking.withdraw_unbonded` is also updated to use `minimum_balance` instead of zero.
- `Staking.reap_stash` now considers `minimum_balance` also.
- `Staking.validate` can now throw errors `StashIdentityDoesNotExist` and `StashIdentityNotPermissioned`.
- `Staking.nominate` now throws `TooManyTargets` on `targets.len() <= MAX_NOMINATIONS`. It also considers blocked validators.