### PR TITLE
MESH-1746 fix scope with disabled investor uniqueness

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -815,6 +815,8 @@ decl_error! {
         FundingRoundNameMaxLengthExceeded,
         /// Some `AssetIdentifier` was invalid.
         InvalidAssetIdentifier,
+        /// Investor Uniqueness claims are not allowed for this asset.
+        InvestorUniquenessClaimNotAllowed,
     }
 }
 
@@ -915,6 +917,15 @@ impl<T: Config> AssetSubTrait for Module<T> {
         } else {
             Self::scope_id_of(ticker, did)
         }
+    }
+
+    /// Ensure that Investor Uniqueness is allowed for the ticker.
+    fn ensure_investor_uniqueness_claims_allowed(ticker: &Ticker) -> DispatchResult {
+        ensure!(
+            !DisableInvestorUniqueness::get(ticker),
+            Error::<T>::InvestorUniquenessClaimNotAllowed
+        );
+        Ok(())
     }
 }
 
@@ -1283,7 +1294,7 @@ impl<T: Config> Module<T> {
         let current_to_balance = Self::balance_of(ticker, to_did);
         // No check since the total balance is always <= the total supply. The
         // total supply is already checked above.
-        let updated_to_balance = current_to_balance + value;
+        let mut updated_to_balance = current_to_balance + value;
         // No check since the default portfolio balance is always <= the total
         // supply. The total supply is already checked above.
         let updated_to_def_balance = Portfolio::<T>::portfolio_asset_balances(
@@ -1302,18 +1313,25 @@ impl<T: Config> Module<T> {
             <Checkpoint<T>>::advance_update_balances(ticker, &[(to_did, current_to_balance)])
         })?;
 
-        // Increase total supply
+        // Increase total supply.
         token.total_supply = updated_total_supply;
         BalanceOf::insert(ticker, &to_did, updated_to_balance);
         Portfolio::<T>::set_default_portfolio_balance(to_did, ticker, updated_to_def_balance);
         Tokens::insert(ticker, token);
 
-        // Update scope balances
+        // If investor uniqueness is disabled for the ticker,
+        // the `scope_id` will always equal `to_did`.
         let scope_id = Self::scope_id(ticker, &to_did);
-        Self::update_scope_balance(&ticker, value, scope_id, to_did, updated_to_balance, false);
+        if scope_id != ScopeId::default() {
+            // scope_id can only be default if investor uniqueness
+            // is enabled and the issuer doesn't have a claim yet.
 
-        // Using the aggregate balance to update the unique investor count.
-        let updated_to_balance = Self::aggregate_balance_of(ticker, &scope_id);
+            // Update scope balances.
+            Self::update_scope_balance(&ticker, value, scope_id, to_did, updated_to_balance, false);
+
+            // Using the aggregate balance to update the unique investor count.
+            updated_to_balance = Self::aggregate_balance_of(ticker, &scope_id);
+        }
         Statistics::<T>::update_transfer_stats(&ticker, None, Some(updated_to_balance), value);
 
         let round = Self::funding_round(ticker);

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1308,15 +1308,12 @@ impl<T: Config> Module<T> {
         Portfolio::<T>::set_default_portfolio_balance(to_did, ticker, updated_to_def_balance);
         Tokens::insert(ticker, token);
 
-        let updated_to_balance = if ScopeIdOf::contains_key(ticker, &to_did) {
-            let scope_id = Self::scope_id(ticker, &to_did);
-            Self::update_scope_balance(&ticker, value, scope_id, to_did, updated_to_balance, false);
-            // Using the aggregate balance to update the unique investor count.
-            Self::aggregate_balance_of(ticker, &scope_id)
-        } else {
-            // Since the caller does not have a scope claim yet, we assume this is their only identity
-            value
-        };
+        // Update scope balances
+        let scope_id = Self::scope_id(ticker, &to_did);
+        Self::update_scope_balance(&ticker, value, scope_id, to_did, updated_to_balance, false);
+
+        // Using the aggregate balance to update the unique investor count.
+        let updated_to_balance = Self::aggregate_balance_of(ticker, &scope_id);
         Statistics::<T>::update_transfer_stats(&ticker, None, Some(updated_to_balance), value);
 
         let round = Self::funding_round(ticker);

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -45,6 +45,9 @@ pub trait AssetSubTrait {
 
     /// Returns the `ScopeId` for a given `ticker` and `did`.
     fn scope_id(ticker: &Ticker, did: &IdentityId) -> ScopeId;
+
+    /// Ensure that Investor Uniqueness is allowed for the ticker.
+    fn ensure_investor_uniqueness_claims_allowed(ticker: &Ticker) -> DispatchResult;
 }
 
 pub trait AssetFnTrait<Account, Origin> {

--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -358,6 +358,9 @@ impl<T: Config> Module<T> {
         );
 
         if let Scope::Ticker(ticker) = scope {
+            // Ensure uniqueness claims are allowed.
+            T::AssetSubTraitTarget::ensure_investor_uniqueness_claims_allowed(ticker)?;
+
             // Update the balance of the IdentityId under the ScopeId provided in claim data.
             T::AssetSubTraitTarget::update_balance_of_scope_id(scope_id, target, *ticker);
         }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -460,6 +460,9 @@ impl AssetSubTrait for Test {
     fn scope_id(_: &Ticker, _: &IdentityId) -> ScopeId {
         ScopeId::from(0u128)
     }
+    fn ensure_investor_uniqueness_claims_allowed(_: &Ticker) -> DispatchResult {
+        Ok(())
+    }
 }
 
 impl MultiSigSubTrait<AccountId> for Test {

--- a/pallets/runtime/tests/src/statistics_test.rs
+++ b/pallets/runtime/tests/src/statistics_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    storage::{make_account, make_account_with_scope, TestStorage, User},
+    storage::{TestStorage, User},
     ExtBuilder,
 };
 use frame_support::{assert_noop, assert_ok};
@@ -9,7 +9,7 @@ use pallet_statistics::{self as statistics};
 use polymesh_primitives::{
     asset::AssetType,
     statistics::{HashablePermill, TransferManager},
-    AccountId, IdentityId, PortfolioId, Ticker,
+    PortfolioId, Ticker,
 };
 use sp_arithmetic::Permill;
 use sp_std::convert::TryFrom;
@@ -22,47 +22,45 @@ type ComplianceManager = compliance_manager::Module<TestStorage>;
 type Error = statistics::Error<TestStorage>;
 type AssetError = asset::Error<TestStorage>;
 
-pub fn allow_all_transfers(origin: Origin, ticker: Ticker) {
-    assert_ok!(ComplianceManager::add_compliance_requirement(
-        origin,
-        ticker,
-        vec![],
-        vec![]
-    ));
-}
-
-fn create_token(token_name: &[u8], ticker: Ticker, keyring: AccountId) {
-    let origin = Origin::signed(keyring);
+fn create_token(owner: User, disable_iu: bool) -> Ticker {
+    let token_name = b"ACME";
+    let ticker = Ticker::try_from(&token_name[..]).unwrap();
     assert_ok!(Asset::create_asset(
-        origin.clone(),
+        owner.origin(),
         token_name.into(),
         ticker,
         true,
         AssetType::default(),
         vec![],
         None,
-        false,
+        disable_iu,
     ));
-    assert_ok!(Asset::issue(origin.clone(), ticker, 1_000_000));
-    allow_all_transfers(origin, ticker);
+    assert_ok!(Asset::issue(owner.origin(), ticker, 1_000_000));
+    assert_ok!(ComplianceManager::add_compliance_requirement(
+        owner.origin(),
+        ticker,
+        vec![],
+        vec![]
+    ));
+    ticker
 }
 
 #[track_caller]
-fn do_valid_transfer(ticker: Ticker, from: IdentityId, to: IdentityId, amount: u128) {
+fn do_valid_transfer(ticker: Ticker, from: User, to: User, amount: u128) {
     assert_ok!(Asset::base_transfer(
-        PortfolioId::default_portfolio(from),
-        PortfolioId::default_portfolio(to),
+        PortfolioId::default_portfolio(from.did),
+        PortfolioId::default_portfolio(to.did),
         &ticker,
         amount
     ));
 }
 
 #[track_caller]
-fn ensure_invalid_transfer(ticker: Ticker, from: IdentityId, to: IdentityId, amount: u128) {
+fn ensure_invalid_transfer(ticker: Ticker, from: User, to: User, amount: u128) {
     assert_noop!(
         Asset::base_transfer(
-            PortfolioId::default_portfolio(from),
-            PortfolioId::default_portfolio(to),
+            PortfolioId::default_portfolio(from.did),
+            PortfolioId::default_portfolio(to.did),
             &ticker,
             amount
         ),
@@ -84,50 +82,24 @@ fn investor_count_with_ext() {
     let bob = User::new(AccountKeyring::Bob);
     let charlie = User::new(AccountKeyring::Charlie);
 
-    // 1. Alice create an asset.
-    let name = b"ACME";
-    let identifiers = Vec::new();
-    let ticker = Ticker::try_from(&name[..]).unwrap();
-    assert_ok!(Asset::create_asset(
-        alice.origin(),
-        name.into(),
-        ticker,
-        true,
-        AssetType::default(),
-        identifiers.clone(),
-        None,
-        false,
-    ));
-    // Total supply over the limit.
-    assert_ok!(Asset::issue(alice.origin(), ticker, 1_000_000));
+    // 1. Create an asset with investor uniqueness.
+    let ticker = create_token(alice, false);
 
     // Each user needs an investor uniqueness claim.
-    alice.provide_scope_claim(ticker, &cdd_provider);
-    bob.provide_scope_claim(ticker, &cdd_provider);
-    charlie.provide_scope_claim(ticker, &cdd_provider);
-
-    let ticker = Ticker::try_from(name.as_ref()).unwrap();
-    allow_all_transfers(alice.origin(), ticker);
-
-    let base_transfer = |from, to, value| {
-        assert_ok!(Asset::base_transfer(
-            PortfolioId::default_portfolio(from),
-            PortfolioId::default_portfolio(to),
-            &ticker,
-            value,
-        ));
-    };
+    alice.make_scope_claim(ticker, &cdd_provider);
+    bob.make_scope_claim(ticker, &cdd_provider);
+    charlie.make_scope_claim(ticker, &cdd_provider);
 
     // Alice sends some tokens to Bob. Token has only one investor.
-    base_transfer(alice.did, bob.did, 500);
+    do_valid_transfer(ticker, alice, bob, 500);
     assert_eq!(Statistic::investor_count(&ticker), 2);
 
     // Alice sends some tokens to Charlie. Token has now two investors.
-    base_transfer(alice.did, charlie.did, 5000);
+    do_valid_transfer(ticker, alice, charlie, 5000);
     assert_eq!(Statistic::investor_count(&ticker), 3);
 
     // Bob sends all his tokens to Charlie, so now we have one investor again.
-    base_transfer(bob.did, charlie.did, 500);
+    do_valid_transfer(ticker, bob, charlie, 500);
     assert_eq!(Statistic::investor_count(&ticker), 2);
 }
 
@@ -143,63 +115,34 @@ fn investor_count_disable_iu_with_ext() {
     let bob = User::new(AccountKeyring::Bob);
     let charlie = User::new(AccountKeyring::Charlie);
 
-    // 1. Alice create an asset.
-    let name = b"ACME";
-    let identifiers = Vec::new();
-    let ticker = Ticker::try_from(&name[..]).unwrap();
-    assert_ok!(Asset::create_asset(
-        alice.origin(),
-        name.into(),
-        ticker,
-        true,
-        AssetType::default(),
-        identifiers.clone(),
-        None,
-        true, // Disable investor uniqueness.
-    ));
-    // Total supply over the limit.
-    assert_ok!(Asset::issue(alice.origin(), ticker, 1_000_000));
-
-    let ticker = Ticker::try_from(name.as_ref()).unwrap();
-    allow_all_transfers(alice.origin(), ticker);
-
-    let base_transfer = |from, to, value| {
-        assert_ok!(Asset::base_transfer(
-            PortfolioId::default_portfolio(from),
-            PortfolioId::default_portfolio(to),
-            &ticker,
-            value,
-        ));
-    };
+    // 1. Create an asset with disabled investor uniqueness.
+    let ticker = create_token(alice, true);
 
     // Alice sends some tokens to Bob. Token has only one investor.
-    base_transfer(alice.did, bob.did, 500);
+    do_valid_transfer(ticker, alice, bob, 500);
     assert_eq!(Statistic::investor_count(&ticker), 2);
 
     // Alice sends some tokens to Charlie. Token has now two investors.
-    base_transfer(alice.did, charlie.did, 5000);
+    do_valid_transfer(ticker, alice, charlie, 5000);
     assert_eq!(Statistic::investor_count(&ticker), 3);
 
     // Bob sends all his tokens to Charlie, so now we have one investor again.
-    base_transfer(bob.did, charlie.did, 500);
+    do_valid_transfer(ticker, bob, charlie, 500);
     assert_eq!(Statistic::investor_count(&ticker), 2);
 }
 
 #[test]
 fn should_add_tm() {
     ExtBuilder::default().build().execute_with(|| {
-        let (token_owner_signed, _token_owner_did) =
-            make_account(AccountKeyring::Alice.to_account_id()).unwrap();
+        let alice = User::new(AccountKeyring::Alice);
 
-        let token_name = b"ACME";
-        let ticker = Ticker::try_from(&token_name[..]).unwrap();
-        create_token(token_name, ticker, AccountKeyring::Alice.to_account_id());
+        let ticker = create_token(alice, false);
 
         let tms = (0..3u64)
             .map(TransferManager::CountTransferManager)
             .collect::<Vec<_>>();
 
-        let add_tm = |tm| Statistic::add_transfer_manager(token_owner_signed.clone(), ticker, tm);
+        let add_tm = |tm| Statistic::add_transfer_manager(alice.origin(), ticker, tm);
         assert_ok!(add_tm(tms[0].clone()));
         assert_eq!(Statistic::transfer_managers(ticker), [tms[0].clone()]);
 
@@ -221,19 +164,16 @@ fn should_add_tm() {
 #[test]
 fn should_remove_tm() {
     ExtBuilder::default().build().execute_with(|| {
-        let (token_owner_signed, _token_owner_did) =
-            make_account(AccountKeyring::Alice.to_account_id()).unwrap();
+        let alice = User::new(AccountKeyring::Alice);
 
-        let token_name = b"ACME";
-        let ticker = Ticker::try_from(&token_name[..]).unwrap();
-        create_token(token_name, ticker, AccountKeyring::Alice.to_account_id());
+        let ticker = create_token(alice, false);
 
         let mut tms = Vec::new();
 
         for i in 0..3u64 {
             tms.push(TransferManager::CountTransferManager(i));
             assert_ok!(Statistic::add_transfer_manager(
-                token_owner_signed.clone(),
+                alice.origin(),
                 ticker,
                 tms[i as usize].clone()
             ));
@@ -243,7 +183,7 @@ fn should_remove_tm() {
         for _ in 0..3u64 {
             let tm = tms.pop().unwrap();
             assert_ok!(Statistic::remove_transfer_manager(
-                token_owner_signed.clone(),
+                alice.origin(),
                 ticker,
                 tm
             ));
@@ -255,33 +195,30 @@ fn should_remove_tm() {
 #[test]
 fn should_add_remove_exempted_entities() {
     ExtBuilder::default().build().execute_with(|| {
-        let (token_owner_signed, token_owner_did) =
-            make_account(AccountKeyring::Alice.to_account_id()).unwrap();
+        let alice = User::new(AccountKeyring::Alice);
 
-        let token_name = b"ACME";
-        let ticker = Ticker::try_from(&token_name[..]).unwrap();
-        create_token(token_name, ticker, AccountKeyring::Alice.to_account_id());
+        let ticker = create_token(alice, false);
 
         let tm = TransferManager::CountTransferManager(1000000);
         let assert_exemption = |boolean| {
             assert_eq!(
-                Statistic::entity_exempt((ticker, tm.clone()), token_owner_did),
+                Statistic::entity_exempt((ticker, tm.clone()), alice.did),
                 boolean
             )
         };
         assert_exemption(false);
         assert_ok!(Statistic::add_exempted_entities(
-            token_owner_signed.clone(),
+            alice.origin(),
             ticker,
             tm.clone(),
-            vec![token_owner_did]
+            vec![alice.did]
         ));
         assert_exemption(true);
         assert_ok!(Statistic::remove_exempted_entities(
-            token_owner_signed.clone(),
+            alice.origin(),
             ticker,
             tm.clone(),
-            vec![token_owner_did]
+            vec![alice.did]
         ));
         assert_exemption(false);
     });
@@ -293,40 +230,39 @@ fn should_verify_tms() {
         .cdd_providers(vec![AccountKeyring::Eve.to_account_id()])
         .build()
         .execute_with(|| {
-            let token_name = b"ACME";
-            let ticker = Ticker::try_from(&token_name[..]).unwrap();
+            let cdd_provider = AccountKeyring::Eve.to_account_id();
+            let ticker = Ticker::try_from(&b"ACME"[..]).unwrap();
             let setup_account = |keyring: AccountKeyring| {
-                make_account_with_scope(
-                    keyring.to_account_id(),
-                    ticker,
-                    AccountKeyring::Eve.to_account_id(),
-                )
-                .unwrap()
+                let user = User::new(keyring);
+                let (scope, _) = user.make_scope_claim(ticker, &cdd_provider);
+                (user, scope)
             };
-            let (alice_signed, alice_did, alice_scope) = setup_account(AccountKeyring::Alice);
-            let (_, bob_did, _) = setup_account(AccountKeyring::Bob);
-            let (_, char_did, char_scope) = setup_account(AccountKeyring::Charlie);
-            let (_, dave_did, dave_scope) = setup_account(AccountKeyring::Dave);
-            create_token(token_name, ticker, AccountKeyring::Alice.to_account_id());
+            let (alice, alice_scope) = setup_account(AccountKeyring::Alice);
+            let (bob, _) = setup_account(AccountKeyring::Bob);
+            let (charlie, charlie_scope) = setup_account(AccountKeyring::Charlie);
+            let (dave, dave_scope) = setup_account(AccountKeyring::Dave);
+
+            let ticker = create_token(alice, false);
+
             assert_eq!(Statistic::investor_count(&ticker), 1);
 
             // No TM attached, transfer should be valid
-            do_valid_transfer(ticker, alice_did, bob_did, 10);
+            do_valid_transfer(ticker, alice, bob, 10);
             assert_eq!(Statistic::investor_count(&ticker), 2);
-            let add_tm = |tm| Statistic::add_transfer_manager(alice_signed.clone(), ticker, tm);
+            let add_tm = |tm| Statistic::add_transfer_manager(alice.origin(), ticker, tm);
             let add_ctm = |limit| {
                 add_tm(TransferManager::CountTransferManager(limit)).expect("Failed to add CTM")
             };
             // Count TM attached with max investors limit reached already
             add_ctm(2);
             // Transfer that increases the investor count beyond the limit should fail
-            ensure_invalid_transfer(ticker, bob_did, char_did, 5);
+            ensure_invalid_transfer(ticker, bob, charlie, 5);
             // Transfer that keeps the investor count the same should succeed
-            do_valid_transfer(ticker, bob_did, alice_did, 1);
+            do_valid_transfer(ticker, bob, alice, 1);
 
             let add_exemption = |tm, scopes| {
                 assert_ok!(Statistic::add_exempted_entities(
-                    alice_signed.clone(),
+                    alice.origin(),
                     ticker,
                     tm,
                     scopes
@@ -339,13 +275,13 @@ fn should_verify_tms() {
                 vec![alice_scope, dave_scope],
             );
             // Transfer should fail when receiver is exempted but not sender for CTM
-            ensure_invalid_transfer(ticker, bob_did, dave_did, 5);
+            ensure_invalid_transfer(ticker, bob, dave, 5);
             // Transfer should succeed since sender is exempted
-            do_valid_transfer(ticker, alice_did, char_did, 5);
+            do_valid_transfer(ticker, alice, charlie, 5);
 
             // Bump CTM to 10
             assert_ok!(Statistic::remove_transfer_manager(
-                alice_signed.clone(),
+                alice.origin(),
                 ticker,
                 TransferManager::CountTransferManager(2)
             ));
@@ -357,26 +293,26 @@ fn should_verify_tms() {
             // Add ptm with max ownership limit of 50%
             assert_ok!(add_tm(ptm25.clone()));
             // Transfer should fail when receiver is breaching the limit
-            ensure_invalid_transfer(ticker, alice_did, dave_did, 250_001);
+            ensure_invalid_transfer(ticker, alice, dave, 250_001);
             // Transfer should succeed when under limit
-            do_valid_transfer(ticker, alice_did, dave_did, 250_000);
+            do_valid_transfer(ticker, alice, dave, 250_000);
             // Transfer should fail when receiver is breaching the limit
-            ensure_invalid_transfer(ticker, alice_did, dave_did, 1);
+            ensure_invalid_transfer(ticker, alice, dave, 1);
 
             // Add charlie to exemption list
-            add_exemption(ptm25, vec![char_scope]);
+            add_exemption(ptm25, vec![charlie_scope]);
             // Transfer should succeed since receiver is exempted
-            do_valid_transfer(ticker, alice_did, char_did, 250_001);
+            do_valid_transfer(ticker, alice, charlie, 250_001);
 
             // Advanced scenario where charlie is limited at 30% but others at 25%
             assert_ok!(add_tm(TransferManager::PercentageTransferManager(
                 HashablePermill(Permill::from_rational_approximation(3u32, 10u32))
             )));
             // Transfer should fail when dave is breaching the default limit
-            ensure_invalid_transfer(ticker, alice_did, dave_did, 1);
+            ensure_invalid_transfer(ticker, alice, dave, 1);
             // Transfer should fail when charlie is breaching the advanced limit
-            ensure_invalid_transfer(ticker, alice_did, char_did, 50_000);
+            ensure_invalid_transfer(ticker, alice, charlie, 50_000);
             // Transfer should succeed when charlie under advanced limit
-            do_valid_transfer(ticker, alice_did, char_did, 25_000);
+            do_valid_transfer(ticker, alice, charlie, 25_000);
         });
 }

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -298,6 +298,14 @@ impl User {
         create_investor_uid(self.acc())
     }
 
+    pub fn provide_scope_claim(
+        &self,
+        ticker: Ticker,
+        cdd_provider: &AccountId,
+    ) -> (ScopeId, CddId) {
+        provide_scope_claim(self.did, ticker, self.uid(), cdd_provider.clone(), None)
+    }
+
     /// Create a `Scope::Identity` from a User
     pub fn scope(&self) -> Scope {
         Scope::Identity(self.did)

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -298,11 +298,7 @@ impl User {
         create_investor_uid(self.acc())
     }
 
-    pub fn provide_scope_claim(
-        &self,
-        ticker: Ticker,
-        cdd_provider: &AccountId,
-    ) -> (ScopeId, CddId) {
+    pub fn make_scope_claim(&self, ticker: Ticker, cdd_provider: &AccountId) -> (ScopeId, CddId) {
         provide_scope_claim(self.did, ticker, self.uid(), cdd_provider.clone(), None)
     }
 
@@ -609,7 +605,7 @@ pub type CorporateActions = corporate_actions::Module<TestStorage>;
 pub fn make_account(
     id: AccountId,
 ) -> Result<(<TestStorage as frame_system::Config>::Origin, IdentityId), &'static str> {
-    let uid = InvestorUid::from(format!("{}", id).as_str());
+    let uid = create_investor_uid(id.clone());
     make_account_with_uid(id, uid)
 }
 


### PR DESCRIPTION
Minting of new tokens wasn't updating the scope balance for the issuer if Investor Uniqueness was disabled.

## changelog

### modified API

- New event `asset.InvestorUniquenessClaimNotAllowed` - This is thrown if an issuer tries to add an investor uniqueness claim for a ticker that has uniqueness disabled.
- `identity.add_investor_uniqueness_claim` and `identity.add_investor_uniqueness_claim_v2` will throw error `InvestorUniquenessClaimNotAllowed` if the ticker has IU disabled.

### modified logic

- `asset.issue` - Now correctly updates the scope balance.
- An InvestorUniqueness claim (both v1 and v2) is not allowed for tickers with Investor Uniqueness disabled.
