### PR TITLE
MESH-1743 Add rotate_primary_key extrinsic

### DIFF
--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -80,7 +80,7 @@ pub trait WeightInfo {
     fn invalidate_cdd_claims() -> Weight;
     fn remove_secondary_keys(i: u32) -> Weight;
     fn accept_primary_key() -> Weight;
-    fn rotate_primary_key() -> Weight;
+    fn rotate_primary_key_to_secondary() -> Weight;
     fn change_cdd_requirement_for_mk_rotation() -> Weight;
     fn join_identity_as_key() -> Weight;
     fn leave_identity_as_key() -> Weight;

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -80,6 +80,7 @@ pub trait WeightInfo {
     fn invalidate_cdd_claims() -> Weight;
     fn remove_secondary_keys(i: u32) -> Weight;
     fn accept_primary_key() -> Weight;
+    fn rotate_primary_key() -> Weight;
     fn change_cdd_requirement_for_mk_rotation() -> Weight;
     fn join_identity_as_key() -> Weight;
     fn leave_identity_as_key() -> Weight;

--- a/pallets/identity/src/auth.rs
+++ b/pallets/identity/src/auth.rs
@@ -36,7 +36,9 @@ impl<T: Config> Module<T> {
         expiry: Option<T::Moment>,
     ) -> Result<u64, DispatchError> {
         let from_did = Self::ensure_perms(origin)?;
-        if let AuthorizationData::JoinIdentity(perms) = &authorization_data {
+        if let AuthorizationData::JoinIdentity(perms)
+        | AuthorizationData::RotatePrimaryKeyToSecondary(perms) = &authorization_data
+        {
             Self::ensure_perms_length_limited(perms)?;
         }
         Ok(Self::add_auth(from_did, target, authorization_data, expiry))

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -199,7 +199,7 @@ benchmarks! {
         );
     }: _(new_key.origin, owner_auth_id, Some(cdd_auth_id))
 
-    rotate_primary_key {
+    rotate_primary_key_to_secondary {
         let cdd = cdd_provider::<T>("cdd", 0);
         let target = user::<T>("target", 0);
         let new_key = UserBuilder::<T>::default().build("key");
@@ -210,17 +210,11 @@ benchmarks! {
             AuthorizationData::AttestPrimaryKeyRotation(target.did()),
             None,
         );
-        let join_auth_id =  Module::<T>::add_auth(
-            cdd.did(), signatory.clone(),
-            AuthorizationData::JoinIdentity(Permissions::default()),
-            None,
-        );
         let rotate_auth_id =  Module::<T>::add_auth(
             cdd.did(), signatory.clone(),
-            AuthorizationData::DirectRotatePrimaryKey(Permissions::default()),
+            AuthorizationData::RotatePrimaryKeyToSecondary(Permissions::default()),
             None,
         );
-        Module::<T>::join_identity_as_key(new_key.clone().origin.into(), join_auth_id).unwrap();
         Module::<T>::change_cdd_requirement_for_mk_rotation(
             RawOrigin::Root.into(),
             true

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -199,6 +199,35 @@ benchmarks! {
         );
     }: _(new_key.origin, owner_auth_id, Some(cdd_auth_id))
 
+    rotate_primary_key {
+        let cdd = cdd_provider::<T>("cdd", 0);
+        let target = user::<T>("target", 0);
+        let new_key = UserBuilder::<T>::default().build("key");
+        let signatory = Signatory::Account(new_key.account());
+
+        let cdd_auth_id =  Module::<T>::add_auth(
+            cdd.did(), signatory.clone(),
+            AuthorizationData::AttestPrimaryKeyRotation(target.did()),
+            None,
+        );
+        let join_auth_id =  Module::<T>::add_auth(
+            cdd.did(), signatory.clone(),
+            AuthorizationData::JoinIdentity(Permissions::default()),
+            None,
+        );
+        let rotate_auth_id =  Module::<T>::add_auth(
+            cdd.did(), signatory.clone(),
+            AuthorizationData::DirectRotatePrimaryKey(Permissions::default()),
+            None,
+        );
+        Module::<T>::join_identity_as_key(new_key.clone().origin.into(), join_auth_id).unwrap();
+        Module::<T>::change_cdd_requirement_for_mk_rotation(
+            RawOrigin::Root.into(),
+            true
+        ).unwrap();
+
+    }: _(target.origin, rotate_auth_id, Some(cdd_auth_id))
+
     change_cdd_requirement_for_mk_rotation {
         assert!(
             !Module::<T>::cdd_auth_for_primary_key_rotation(),

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -211,7 +211,7 @@ benchmarks! {
             None,
         );
         let rotate_auth_id =  Module::<T>::add_auth(
-            cdd.did(), signatory.clone(),
+            target.did(), signatory.clone(),
             AuthorizationData::RotatePrimaryKeyToSecondary(Permissions::default()),
             None,
         );
@@ -220,7 +220,7 @@ benchmarks! {
             true
         ).unwrap();
 
-    }: _(target.origin, rotate_auth_id, Some(cdd_auth_id))
+    }: _(new_key.origin, rotate_auth_id, Some(cdd_auth_id))
 
     change_cdd_requirement_for_mk_rotation {
         assert!(

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -263,7 +263,7 @@ impl<T: Config> Module<T> {
 
     /// Accepts a primary key rotation.
     /// Differs from accept_primary_key_rotation in that it will leave the old primary key as a
-    /// secondary key with the permissions specified in the corresponding DirectRotatePrimaryKey authorization
+    /// secondary key with the permissions specified in the corresponding RotatePrimaryKeyToSecondary authorization
     /// instead of unlinking the primary key.
     crate fn base_rotate_primary_key_to_secondary(
         origin: T::Origin,

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -242,6 +242,8 @@ impl<T: Config> Module<T> {
             let removed_signers = vec![signer];
             record.remove_secondary_keys(&removed_signers);
             Self::deposit_event(RawEvent::SecondaryKeysRemoved(target_did, removed_signers));
+        } else {
+            Self::link_account_key_to_did(&new_primary_key, target_did)
         }
 
         let old_primary_key = record.primary_key.clone();

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -194,8 +194,10 @@ impl<T: Config> Module<T> {
         })
     }
 
-    // Sets the new primariy key, optionally removes it as a secondary key if it is one,
-    // and optionally checks the cdd auth.
+    // Sets the new primary key and optionally removes it as a secondary key if it is one.
+    // Checks the cdd auth if this is required.
+    // Old primary key will be added as a secondary key if `new_permissions` is not None
+    // New primary key must either be unlinked, or linked to the `target_did`
     pub fn common_rotate_primary_key(
         target_did: IdentityId,
         new_primary_key: T::AccountId,

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -304,6 +304,9 @@ decl_module! {
         /// with the new primary key. If a CDD service provider approved this change, primary key of
         /// the DID is updated.
         ///
+        ///  Differs from rotate_primary_key_to_secondary in that it will unlink the old primary key
+        /// instead of leaving it as a secondary key.
+        ///
         /// # Arguments
         /// * `owner_auth_id` Authorization from the owner who initiated the change
         /// * `cdd_auth_id` Authorization from a CDD service provider
@@ -313,15 +316,19 @@ decl_module! {
         }
 
         /// Call this with the new primary key. By invoking this method, caller accepts authorization
-        /// with the new primary key. If the caller is a secondary key and a CDD service provider approved this change,
+        /// with the new primary key. If a CDD service provider approved this change,
         ///  primary key of the DID is updated.
+        ///
+        /// Differs from accept_primary_key in that it will leave the old primary key as a
+        /// secondary key with the permissions specified in the corresponding DirectRotatePrimaryKey authorization
+        /// instead of unlinking the primary key.
         ///
         /// # Arguments
         /// * `owner_auth_id` Authorization from the owner who initiated the change
         /// * `cdd_auth_id` Authorization from a CDD service provider
-        #[weight = <T as Config>::WeightInfo::rotate_primary_key()]
-        pub fn rotate_primary_key(origin, auth_id:u64, optional_cdd_auth_id: Option<u64>) -> DispatchResult {
-            Self::direct_primary_key_rotation(origin, auth_id, optional_cdd_auth_id)
+        #[weight = <T as Config>::WeightInfo::rotate_primary_key_to_secondary()]
+        pub fn rotate_primary_key_to_secondary(origin, auth_id:u64, optional_cdd_auth_id: Option<u64>) -> DispatchResult {
+            Self::base_rotate_primary_key_to_secondary(origin, auth_id, optional_cdd_auth_id)
         }
 
         /// Set if CDD authorization is required for updating primary key of an identity.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -301,8 +301,11 @@ decl_module! {
         }
 
         /// Call this with the new primary key. By invoking this method, caller accepts authorization
-        /// with the new primary key. If a CDD service provider approved this change, primary key of
-        /// the DID is updated.
+        /// to become the new primary key of the issuing identity. If a CDD service provider approved
+        /// this change (or this is not required), primary key of the DID is updated.
+        ///
+        /// The caller (new primary key) must be either a secondary key of the issuing identity, or
+        /// unlinked to any identity.
         ///
         /// Differs from rotate_primary_key_to_secondary in that it will unlink the old primary key
         /// instead of leaving it as a secondary key.
@@ -316,12 +319,15 @@ decl_module! {
         }
 
         /// Call this with the new primary key. By invoking this method, caller accepts authorization
-        /// with the new primary key. If a CDD service provider approved this change,
-        /// primary key of the DID is updated.
+        /// to become the new primary key of the issuing identity. If a CDD service provider approved
+        /// this change, (or this is not required), primary key of the DID is updated.
         ///
-        /// Differs from accept_primary_key in that it will leave the old primary key as a
-        /// secondary key with the permissions specified in the corresponding RotatePrimaryKeyToSecondary authorization
-        /// instead of unlinking the primary key.
+        /// The caller (new primary key) must be either a secondary key of the issuing identity, or
+        /// unlinked to any identity.
+        ///
+        /// Differs from accept_primary_key in that it will leave the old primary key as a secondary
+        /// key with the permissions specified in the corresponding RotatePrimaryKeyToSecondary authorization
+        /// instead of unlinking the old primary key.
         ///
         /// # Arguments
         /// * `owner_auth_id` Authorization from the owner who initiated the change

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -312,6 +312,18 @@ decl_module! {
             Self::accept_primary_key_rotation(origin, rotation_auth_id, optional_cdd_auth_id)
         }
 
+        /// Call this with the new primary key. By invoking this method, caller accepts authorization
+        /// with the new primary key. If the caller is a secondary key and a CDD service provider approved this change,
+        ///  primary key of the DID is updated.
+        ///
+        /// # Arguments
+        /// * `owner_auth_id` Authorization from the owner who initiated the change
+        /// * `cdd_auth_id` Authorization from a CDD service provider
+        #[weight = <T as Config>::WeightInfo::rotate_primary_key()]
+        pub fn rotate_primary_key(origin, auth_id:u64, optional_cdd_auth_id: Option<u64>) -> DispatchResult {
+            Self::direct_primary_key_rotation(origin, auth_id, optional_cdd_auth_id)
+        }
+
         /// Set if CDD authorization is required for updating primary key of an identity.
         /// Callable via root (governance)
         ///

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -304,7 +304,7 @@ decl_module! {
         /// with the new primary key. If a CDD service provider approved this change, primary key of
         /// the DID is updated.
         ///
-        ///  Differs from rotate_primary_key_to_secondary in that it will unlink the old primary key
+        /// Differs from rotate_primary_key_to_secondary in that it will unlink the old primary key
         /// instead of leaving it as a secondary key.
         ///
         /// # Arguments
@@ -317,10 +317,10 @@ decl_module! {
 
         /// Call this with the new primary key. By invoking this method, caller accepts authorization
         /// with the new primary key. If a CDD service provider approved this change,
-        ///  primary key of the DID is updated.
+        /// primary key of the DID is updated.
         ///
         /// Differs from accept_primary_key in that it will leave the old primary key as a
-        /// secondary key with the permissions specified in the corresponding DirectRotatePrimaryKey authorization
+        /// secondary key with the permissions specified in the corresponding RotatePrimaryKeyToSecondary authorization
         /// instead of unlinking the primary key.
         ///
         /// # Arguments

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -556,7 +556,7 @@ decl_module! {
         pub fn make_multisig_primary(origin, multisig: T::AccountId, optional_cdd_auth_id: Option<u64>) -> DispatchResult {
             let did = Self::ensure_ms_creator(origin, &multisig)?;
             Self::ensure_ms(&multisig)?;
-            <Identity<T>>::unsafe_primary_key_rotation(
+            <Identity<T>>::rotate_primary_key_and_remove(
                 multisig,
                 did,
                 optional_cdd_auth_id

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -556,11 +556,7 @@ decl_module! {
         pub fn make_multisig_primary(origin, multisig: T::AccountId, optional_cdd_auth_id: Option<u64>) -> DispatchResult {
             let did = Self::ensure_ms_creator(origin, &multisig)?;
             Self::ensure_ms(&multisig)?;
-            <Identity<T>>::rotate_primary_key_and_remove(
-                multisig,
-                did,
-                optional_cdd_auth_id
-            )
+            <Identity<T>>::common_rotate_primary_key(did, multisig, None, optional_cdd_auth_id)
         }
 
         /// Root callable extrinsic, used as an internal call for executing scheduled multisig proposal.

--- a/pallets/runtime/ci/src/fee_details.rs
+++ b/pallets/runtime/ci/src/fee_details.rs
@@ -79,7 +79,7 @@ where
             Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
                 rotation_auth_id,
                 ..,
-            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::RotatePrimaryToSecondary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -154,7 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
-            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::RotatePrimaryToSecondary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/ci/src/fee_details.rs
+++ b/pallets/runtime/ci/src/fee_details.rs
@@ -74,6 +74,12 @@ where
             Call::Identity(pallet_identity::Call::accept_primary_key(rotation_auth_id, ..)) => {
                 is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary)
             }
+            // Call made by a new Account key to accept invitation to become the primary key
+            // of an existing identity that has a valid CDD. The auth should be valid.
+            Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
+                rotation_auth_id,
+                ..,
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -148,6 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/common/src/fee_details.rs
+++ b/pallets/runtime/common/src/fee_details.rs
@@ -8,6 +8,7 @@ pub enum CallType {
     AcceptRelayerPayingKey,
     AcceptIdentitySecondary,
     AcceptIdentityPrimary,
+    RotatePrimaryToSecondary,
     /// Matches any call to `remove_authorization`,
     /// where the authorization is available for `auth.authorized_by` payer redirection.
     RemoveAuthorization,

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -79,7 +79,7 @@ where
             Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
                 rotation_auth_id,
                 ..,
-            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::RotatePrimaryToSecondary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -154,7 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
-            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::RotatePrimaryToSecondary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/develop/src/fee_details.rs
+++ b/pallets/runtime/develop/src/fee_details.rs
@@ -74,6 +74,12 @@ where
             Call::Identity(pallet_identity::Call::accept_primary_key(rotation_auth_id, ..)) => {
                 is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary)
             }
+            // Call made by a new Account key to accept invitation to become the primary key
+            // of an existing identity that has a valid CDD. The auth should be valid.
+            Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
+                rotation_auth_id,
+                ..,
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -148,6 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/mainnet/src/fee_details.rs
+++ b/pallets/runtime/mainnet/src/fee_details.rs
@@ -76,7 +76,7 @@ where
             Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
                 rotation_auth_id,
                 ..,
-            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::RotatePrimaryToSecondary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -151,7 +151,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
-            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::RotatePrimaryToSecondary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/mainnet/src/fee_details.rs
+++ b/pallets/runtime/mainnet/src/fee_details.rs
@@ -71,6 +71,12 @@ where
             Call::Identity(pallet_identity::Call::accept_primary_key(rotation_auth_id, ..)) => {
                 is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary)
             }
+            // Call made by a new Account key to accept invitation to become the primary key
+            // of an existing identity that has a valid CDD. The auth should be valid.
+            Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
+                rotation_auth_id,
+                ..,
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -145,6 +151,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/testnet/src/fee_details.rs
+++ b/pallets/runtime/testnet/src/fee_details.rs
@@ -79,7 +79,7 @@ where
             Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
                 rotation_auth_id,
                 ..,
-            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::RotatePrimaryToSecondary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -154,7 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
-            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::RotatePrimaryToSecondary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/testnet/src/fee_details.rs
+++ b/pallets/runtime/testnet/src/fee_details.rs
@@ -74,6 +74,12 @@ where
             Call::Identity(pallet_identity::Call::accept_primary_key(rotation_auth_id, ..)) => {
                 is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary)
             }
+            // Call made by a new Account key to accept invitation to become the primary key
+            // of an existing identity that has a valid CDD. The auth should be valid.
+            Call::Identity(pallet_identity::Call::rotate_primary_key_to_secondary(
+                rotation_auth_id,
+                ..,
+            )) => is_auth_valid(caller, rotation_auth_id, CallType::AcceptIdentityPrimary),
             // Call made by a new Account key to remove invitation for certain authorizations
             // in an existing identity that has a valid CDD. The auth should be valid.
             Call::Identity(pallet_identity::Call::remove_authorization(_, auth_id, true)) => {
@@ -148,6 +154,7 @@ fn is_auth_valid(acc: &AccountId, auth_id: &u64, call_type: CallType) -> ValidPa
             (AuthorizationData::AddMultiSigSigner(_), CallType::AcceptMultiSigSigner)
             | (AuthorizationData::JoinIdentity(_), CallType::AcceptIdentitySecondary)
             | (AuthorizationData::RotatePrimaryKey, CallType::AcceptIdentityPrimary)
+            | (AuthorizationData::RotatePrimaryKeyToSecondary(_), CallType::AcceptIdentityPrimary)
             | (AuthorizationData::AddRelayerPayingKey(..), CallType::AcceptRelayerPayingKey)
             | (_, CallType::RemoveAuthorization),
         )) => check_cdd(&by),

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1267,7 +1267,7 @@ fn changing_primary_key_we() {
     assert_ok!(accept(charlie, add(charlie)));
     assert_eq!(alice_pk(), charlie.to_account_id());
 
-    // Do it again but now making a secondary key the new primary key.
+    // Add Alice's old primary key as a secondary key to the identity..
     let join_auth = Identity::add_auth(
         alice.did,
         Signatory::Account(alice.acc()),
@@ -1276,6 +1276,7 @@ fn changing_primary_key_we() {
     );
     assert_ok!(Identity::join_identity(alice.origin(), join_auth));
 
+    // Do it again but now making the secondary key the new primary key.
     assert_ok!(accept(alice.ring, add(alice.ring)));
     assert_eq!(alice_pk(), alice.acc());
 }

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1266,6 +1266,7 @@ fn changing_primary_key_we() {
     let charlie = AccountKeyring::Charlie;
     assert_ok!(accept(charlie, add(charlie)));
     assert_eq!(alice_pk(), charlie.to_account_id());
+    assert_ok!(Identity::ensure_key_did_unlinked(&alice.acc()));
 
     // Add Alice's old primary key as a secondary key to the identity..
     let join_auth = Identity::add_auth(
@@ -1279,6 +1280,7 @@ fn changing_primary_key_we() {
     // Do it again but now making the secondary key the new primary key.
     assert_ok!(accept(alice.ring, add(alice.ring)));
     assert_eq!(alice_pk(), alice.acc());
+    assert_ok!(Identity::ensure_key_did_unlinked(&charlie.to_account_id()));
 }
 
 #[test]
@@ -1379,6 +1381,7 @@ fn rotating_primary_key_to_secondary_we() {
     );
     assert_ok!(rotate(charlie_origin.clone(), charlie_rotate_auth));
     assert_eq!(alice_pk(), charlie.to_account_id());
+    assert!(Identity::is_signer(alice.did, &alice.signatory_acc()));
 
     let alice_rotate_auth = Identity::add_auth(
         alice.did,
@@ -1388,6 +1391,10 @@ fn rotating_primary_key_to_secondary_we() {
     );
     assert_ok!(rotate(alice.origin(), alice_rotate_auth));
     assert_eq!(alice_pk(), alice.acc());
+    assert!(Identity::is_signer(
+        alice.did,
+        &Signatory::Account(charlie.to_account_id())
+    ));
 }
 
 #[test]

--- a/pallets/weights/src/pallet_identity.rs
+++ b/pallets/weights/src/pallet_identity.rs
@@ -80,6 +80,11 @@ impl pallet_identity::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(9 as Weight))
             .saturating_add(DbWeight::get().writes(7 as Weight))
     }
+    fn rotate_primary_key() -> Weight {
+        (141_907_000 as Weight)
+            .saturating_add(DbWeight::get().reads(9 as Weight))
+            .saturating_add(DbWeight::get().writes(7 as Weight))
+    }
     fn change_cdd_requirement_for_mk_rotation() -> Weight {
         (19_537_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }

--- a/pallets/weights/src/pallet_identity.rs
+++ b/pallets/weights/src/pallet_identity.rs
@@ -80,7 +80,7 @@ impl pallet_identity::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(9 as Weight))
             .saturating_add(DbWeight::get().writes(7 as Weight))
     }
-    fn rotate_primary_key() -> Weight {
+    fn rotate_primary_key_to_secondary() -> Weight {
         (141_907_000 as Weight)
             .saturating_add(DbWeight::get().reads(9 as Weight))
             .saturating_add(DbWeight::get().writes(7 as Weight))

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -673,7 +673,8 @@
         "JoinIdentity": "Permissions",
         "PortfolioCustody": "PortfolioId",
         "BecomeAgent": "(Ticker, AgentGroup)",
-        "AddRelayerPayingKey": "(AccountId, AccountId, Balance)"
+        "AddRelayerPayingKey": "(AccountId, AccountId, Balance)",
+        "RotatePrimaryKeyToSecondary": "Permissions"
       }
     },
     "SmartExtensionType": {
@@ -846,7 +847,8 @@
         "JoinIdentity": "",
         "PortfolioCustody": "",
         "BecomeAgent": "",
-        "AddRelayerPayingKey": ""
+        "AddRelayerPayingKey": "",
+        "RotatePrimaryKeyToSecondary": ""
       }
     },
     "ProposalDetails": {

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -51,8 +51,9 @@ pub enum AuthorizationData<AccountId> {
     /// Must be issued by the paying key.
     /// `AddRelayerPayingKey(user_key, paying_key, polyx_limit)`
     AddRelayerPayingKey(AccountId, AccountId, Balance),
-    /// Authorization to change primary key with an existing secondary key
-    DirectRotatePrimaryKey(Permissions),
+    /// Authorization to change primary key and leave it as a secondary key
+    /// with the given permissions.
+    RotatePrimaryKeyToSecondary(Permissions),
 }
 
 impl<AccountId> AuthorizationData<AccountId> {
@@ -68,7 +69,7 @@ impl<AccountId> AuthorizationData<AccountId> {
             Self::JoinIdentity(..) => AuthorizationType::JoinIdentity,
             Self::PortfolioCustody(..) => AuthorizationType::PortfolioCustody,
             Self::AddRelayerPayingKey(..) => AuthorizationType::AddRelayerPayingKey,
-            Self::DirectRotatePrimaryKey(..) => AuthorizationType::DirectRotatePrimaryKey,
+            Self::RotatePrimaryKeyToSecondary(..) => AuthorizationType::RotatePrimaryKeyToSecondary,
         }
     }
 }
@@ -96,7 +97,7 @@ pub enum AuthorizationType {
     /// Authorization to add a Relayer paying key.
     AddRelayerPayingKey,
     /// Authorization to change primary key with an existing secondary key
-    DirectRotatePrimaryKey,
+    RotatePrimaryKeyToSecondary,
 }
 
 /// Status of an Authorization after consume is called on it.

--- a/primitives/src/authorization.rs
+++ b/primitives/src/authorization.rs
@@ -51,6 +51,8 @@ pub enum AuthorizationData<AccountId> {
     /// Must be issued by the paying key.
     /// `AddRelayerPayingKey(user_key, paying_key, polyx_limit)`
     AddRelayerPayingKey(AccountId, AccountId, Balance),
+    /// Authorization to change primary key with an existing secondary key
+    DirectRotatePrimaryKey(Permissions),
 }
 
 impl<AccountId> AuthorizationData<AccountId> {
@@ -66,6 +68,7 @@ impl<AccountId> AuthorizationData<AccountId> {
             Self::JoinIdentity(..) => AuthorizationType::JoinIdentity,
             Self::PortfolioCustody(..) => AuthorizationType::PortfolioCustody,
             Self::AddRelayerPayingKey(..) => AuthorizationType::AddRelayerPayingKey,
+            Self::DirectRotatePrimaryKey(..) => AuthorizationType::DirectRotatePrimaryKey,
         }
     }
 }
@@ -92,6 +95,8 @@ pub enum AuthorizationType {
     BecomeAgent,
     /// Authorization to add a Relayer paying key.
     AddRelayerPayingKey,
+    /// Authorization to change primary key with an existing secondary key
+    DirectRotatePrimaryKey,
 }
 
 /// Status of an Authorization after consume is called on it.


### PR DESCRIPTION
## changelog

### new features

- Added new extrinsic `rotate_primary_key_to_secondary`.

### modified API

- Added new extrinsic `rotate_primary_key_to_secondary`.
- Added new Item to enum `AuthorizationData::RotatePrimaryKeyToSecondary(Permissions)`.
- Added new Item to enum `AuthorizationType::RotatePrimaryKeyToSecondary`.

### modified logic

- `accept_primary_key` now accepts secondary keys as the new primary key.

