### PR TITLE
MESH-1748 improve default mutisig permissions

### DIFF
--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -297,7 +297,7 @@ decl_module! {
             expiry: Option<T::Moment>,
             auto_close: bool
         ) {
-            let signer = Self::ensure_signed_did(origin)?;
+            let signer = Self::ensure_perms_signed_did(origin)?;
             Self::create_or_approve_proposal(multisig, signer, proposal, expiry, auto_close)?;
         }
 
@@ -337,7 +337,7 @@ decl_module! {
             expiry: Option<T::Moment>,
             auto_close: bool
         ) {
-            let signer = Self::ensure_signed_did(origin)?;
+            let signer = Self::ensure_perms_signed_did(origin)?;
             Self::create_proposal(multisig, signer, proposal, expiry, auto_close)?;
         }
 
@@ -369,7 +369,7 @@ decl_module! {
         /// If quorum is reached, the proposal will be immediately executed.
         #[weight = <T as Config>::WeightInfo::approve_as_identity()]
         pub fn approve_as_identity(origin, multisig: T::AccountId, proposal_id: u64) -> DispatchResult {
-            let signer = Self::ensure_signed_did(origin)?;
+            let signer = Self::ensure_perms_signed_did(origin)?;
             Self::unsafe_approve(multisig, signer, proposal_id)
         }
 
@@ -393,7 +393,7 @@ decl_module! {
         /// If quorum is reached, the proposal will be immediately executed.
         #[weight = <T as Config>::WeightInfo::reject_as_identity()]
         pub fn reject_as_identity(origin, multisig: T::AccountId, proposal_id: u64) -> DispatchResult {
-            let signer = Self::ensure_signed_did(origin)?;
+            let signer = Self::ensure_perms_signed_did(origin)?;
             Self::unsafe_reject(multisig, signer, proposal_id)
         }
 
@@ -415,7 +415,7 @@ decl_module! {
         /// * `auth_id` - Auth id of the authorization.
         #[weight = <T as Config>::WeightInfo::accept_multisig_signer_as_identity()]
         pub fn accept_multisig_signer_as_identity(origin, auth_id: u64) -> DispatchResult {
-            let signer = Self::ensure_signed_did(origin)?;
+            let signer = Self::ensure_perms_signed_did(origin)?;
             Self::unsafe_accept_multisig_signer(signer, auth_id)
         }
 
@@ -681,8 +681,10 @@ impl<T: Config> Module<T> {
         Ok(Signatory::Account(sender))
     }
 
-    fn ensure_signed_did(origin: T::Origin) -> Result<Signatory<T::AccountId>, DispatchError> {
-        Identity::<T>::ensure_did(origin).map(|(_, d)| d.into())
+    fn ensure_perms_signed_did(
+        origin: T::Origin,
+    ) -> Result<Signatory<T::AccountId>, DispatchError> {
+        <Identity<T>>::ensure_perms(origin).map(|d| d.into())
     }
 
     fn ensure_primary_key(did: &IdentityId, sender: &T::AccountId) -> DispatchResult {

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -104,11 +104,9 @@ use polymesh_common_utilities::{
     identity::Config as IdentityConfig, multisig::MultiSigSubTrait,
     transaction_payment::CddAndFeeDetails, Context,
 };
-use polymesh_primitives::{
-    extract_auth, AuthorizationData, IdentityId, PalletPermissions, Permissions, Signatory,
-};
+use polymesh_primitives::{extract_auth, AuthorizationData, IdentityId, Permissions, Signatory};
 use sp_runtime::traits::{Dispatchable, Hash, One};
-use sp_std::{convert::TryFrom, iter, prelude::*};
+use sp_std::{convert::TryFrom, prelude::*};
 
 type Identity<T> = identity::Module<T>;
 
@@ -542,12 +540,8 @@ decl_module! {
 
             <Identity<T>>::ensure_secondary_key_can_be_added(&did, &multisig)?;
 
-            let perms = Permissions::from_pallet_permissions(
-                iter::once(PalletPermissions::entire_pallet(NAME.into()))
-            );
-
-
-            <Identity<T>>::unsafe_join_identity(did, perms, multisig);
+            // Add the multisig as a secondary key with no permissions.
+            <Identity<T>>::unsafe_join_identity(did, Permissions::empty(), multisig);
         }
 
         /// Adds a multisig as the primary key of the current did if the current DID is the creator

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use frame_support::{assert_noop, assert_ok};
 use pallet_multisig as multisig;
-use polymesh_primitives::{AccountId, PalletPermissions, Permissions, SecondaryKey, Signatory};
+use polymesh_primitives::{AccountId, Permissions, SecondaryKey, Signatory};
 use test_client::AccountKeyring;
 
 type Balances = pallet_balances::Module<TestStorage>;
@@ -511,12 +511,9 @@ fn make_multisig_signer() {
             vec![Signatory::from(alice.did)],
             1,
         ));
-        let permissions =
-            Permissions::from_pallet_permissions(vec![PalletPermissions::entire_pallet(
-                multisig::NAME.into(),
-            )]);
         // The desired secondary key record.
-        let musig_secondary = SecondaryKey::new(Signatory::Account(multisig.clone()), permissions);
+        let musig_secondary =
+            SecondaryKey::new(Signatory::Account(multisig.clone()), Permissions::empty());
 
         let has_ms_sk = || {
             Identity::did_records(alice.did)


### PR DESCRIPTION
## changelog

### modified logic

- `make_multisig_signer` - Use empty permissions when adding a multisig as a secondary key.
- `create_or_approve_proposal_as_identity`, `create_proposal_as_identity`, `approve_as_identity`, `reject_as_identity`, `accept_multisig_signer_as_identity` - Add call permissions checks to make sure that secondary keys for the identity have the right permissions.
