### PR TITLE
MESH-1752 check custom asset type id

### DIFF
--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -2400,20 +2400,12 @@ fn invalid_custom_asset_type_check() {
         let owner = User::new(AccountKeyring::Dave);
 
         // Create ticker.
-        let (ticker, _) = a_token(owner.did);
+        let (ticker, mut token) = a_token(owner.did);
 
         let invalid_id = CustomAssetTypeId(1_000_000);
+        token.asset_type = AssetType::Custom(invalid_id);
         assert_noop!(
-            Asset::create_asset(
-                owner.origin(),
-                ticker.as_ref().into(),
-                ticker,
-                true,
-                AssetType::Custom(invalid_id),
-                vec![],
-                None,
-                false,
-            ),
+            basic_asset(owner, ticker, &token),
             AssetError::InvalidCustomAssetTypeId
         );
     });

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -2395,6 +2395,31 @@ fn asset_type_custom_works() {
 }
 
 #[test]
+fn invalid_custom_asset_type_check() {
+    ExtBuilder::default().build().execute_with(|| {
+        let owner = User::new(AccountKeyring::Dave);
+
+        // Create ticker.
+        let (ticker, _) = a_token(owner.did);
+
+        let invalid_id = CustomAssetTypeId(1_000_000);
+        assert_noop!(
+            Asset::create_asset(
+                owner.origin(),
+                ticker.as_ref().into(),
+                ticker,
+                true,
+                AssetType::Custom(invalid_id),
+                vec![],
+                None,
+                false,
+            ),
+            AssetError::InvalidCustomAssetTypeId
+        );
+    });
+}
+
+#[test]
 fn asset_doc_field_too_long() {
     ExtBuilder::default().build().execute_with(|| {
         let owner = User::new(AccountKeyring::Alice);


### PR DESCRIPTION
## changelog

### modified logic

- `asset.create_asset` - Now checks if `AssetType::Custom` is valid.  Will throw error `InvalidCustomAssetTypeId` if a custom asset hasn't been registered for that type id.
