### PR TITLE
Small schema fix.

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -650,13 +650,7 @@
         "Proposal": "Vec<u8>"
       }
     },
-    "OffChainSignature": {
-      "_enum": {
-        "Ed25519": "H512",
-        "Sr25519": "H512",
-        "Ecdsa": "H512"
-      }
-    },
+    "OffChainSignature": "MultiSignature",
     "Authorization": {
       "authorization_data": "AuthorizationData",
       "authorized_by": "IdentityId",


### PR DESCRIPTION
Our `OffChainSignature` type in `polymesh_schema.json` was wrong.

In our runtimes we use `sp_runtime::MultiSignature` for `OffChainSignature`.  Our schema had the wrong type for variant `Ecdsa`.  A `H512` is 64 bytes long, but ecdsa signatures have an extra byte (8 bits for recovery ID):
https://github.com/PolymathNetwork/substrate/blob/1fe1f43666016d6c95743c6a81c8e5b57a3058bb/primitives/core/src/ecdsa.rs#L229