### PR TITLE
Include permmisions complexity in extrinsic weight.

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -397,7 +397,7 @@ decl_module! {
         /// Sets permissions for an specific `target_key` key.
         ///
         /// Only the primary key of an identity is able to set secondary key permissions.
-        #[weight = <T as Config>::WeightInfo::set_permission_to_signer()]
+        #[weight = <T as Config>::WeightInfo::set_permission_to_signer_full(&perms)]
         pub fn set_permission_to_signer(origin, signer: Signatory<T::AccountId>, perms: Permissions) {
             Self::base_set_permission_to_signer(origin, signer, perms)?;
         }
@@ -405,7 +405,7 @@ decl_module! {
         /// This function is a workaround for https://github.com/polkadot-js/apps/issues/3632
         /// It sets permissions for an specific `target_key` key.
         /// Only the primary key of an identity is able to set secondary key permissions.
-        #[weight = <T as Config>::WeightInfo::set_permission_to_signer()]
+        #[weight = <T as Config>::WeightInfo::legacy_set_permission_to_signer_full(&permissions)]
         pub fn legacy_set_permission_to_signer(
             origin,
             signer: Signatory<T::AccountId>,
@@ -431,7 +431,7 @@ decl_module! {
 
         // Manage generic authorizations
         /// Adds an authorization.
-        #[weight = <T as Config>::WeightInfo::add_authorization()]
+        #[weight = <T as Config>::WeightInfo::add_authorization_full::<T::AccountId>(&data)]
         pub fn add_authorization(
             origin,
             target: Signatory<T::AccountId>,
@@ -465,7 +465,7 @@ decl_module! {
         /// Failure
         ///     - It can only called by primary key owner.
         ///     - Keys should be able to linked to any identity.
-        #[weight = <T as Config>::WeightInfo::add_secondary_keys_with_authorization(additional_keys.len() as u32)]
+        #[weight = <T as Config>::WeightInfo::add_secondary_keys_full::<T::AccountId>(&additional_keys)]
         pub fn add_secondary_keys_with_authorization(
             origin,
             additional_keys: Vec<SecondaryKeyWithAuth<T::AccountId>>,

--- a/pallets/weights/src/pallet_identity.rs
+++ b/pallets/weights/src/pallet_identity.rs
@@ -118,6 +118,17 @@ impl pallet_identity::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
+    fn permissions_cost(a: u32, p: u32, l: u32, e: u32) -> Weight {
+        (0 as Weight)
+            // Standard Error: 200_000
+            .saturating_add((1_254_000 as Weight).saturating_mul(a as Weight))
+            // Standard Error: 200_000
+            .saturating_add((1_027_000 as Weight).saturating_mul(p as Weight))
+            // Standard Error: 200_000
+            .saturating_add((75_415_000 as Weight).saturating_mul(l as Weight))
+            // Standard Error: 200_000
+            .saturating_add((72_009_000 as Weight).saturating_mul(e as Weight))
+    }
     fn freeze_secondary_keys() -> Weight {
         (56_201_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))


### PR DESCRIPTION
## changelog

### modified logic

- Add permission complexity to the weights of extrinsics: `identity.add_authorization`, `identity.set_permission_to_signer`, `identity.legacy_set_permission_to_signer`, and `identity.add_secondary_keys_with_authorization`
