### PR TITLE
MESH-1787 relayer fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["Polymath"]
 build = "build.rs"
 edition = "2018"

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -415,7 +415,11 @@ decl_module! {
         ///
         /// ## Errors
         /// - `BadAdmin` if `origin` is not `Self::admin()` account.
-        #[weight = (500_000_000, DispatchClass::Operational, Pays::Yes)]
+        #[weight =(
+            500_000_000 + 7_000_000 * u64::try_from(exempted.len()).unwrap_or_default(),
+            DispatchClass::Operational,
+            Pays::Yes
+        )]
         pub fn change_bridge_exempted(origin, exempted: Vec<(IdentityId, bool)>) -> DispatchResult {
             Self::base_change_bridge_exempted(origin, exempted)
         }

--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -127,7 +127,7 @@ decl_module! {
         /// - `AuthorizationError::Expired` if `auth_id` the authorization has expired.
         /// - `AuthorizationError::BadType` if `auth_id` was not a `AddRelayerPayingKey` authorization.
         /// - `NotAuthorizedForUserKey` if `origin` is not authorized to accept the authorization for the `user_key`.
-        /// - `NotAuthorizedForPayingKey` if the authorization was created by a signer that isn't authorized by the `paying_key`.
+        /// - `NotAuthorizedForPayingKey` if the authorization was created an identity different from the `paying_key`'s identity.
         /// - `UserKeyCddMissing` if the `user_key` is not attached to a CDD'd identity.
         /// - `PayingKeyCddMissing` if the `paying_key` is not attached to a CDD'd identity.
         /// - `UnauthorizedCaller` if `origin` is not authorized to call this extrinsic.
@@ -238,14 +238,17 @@ impl<T: Config> Module<T> {
     }
 
     fn base_accept_paying_key(origin: T::Origin, auth_id: u64) -> DispatchResult {
-        let user_key = ensure_signed(origin)?;
+        let caller_key = ensure_signed(origin)?;
         let user_did =
-            <Identity<T>>::get_identity(&user_key).ok_or(Error::<T>::UserKeyCddMissing)?;
-        let signer = Signatory::Account(user_key);
+            <Identity<T>>::get_identity(&caller_key).ok_or(Error::<T>::UserKeyCddMissing)?;
+        let signer = Signatory::Account(caller_key.clone());
 
         <Identity<T>>::accept_auth_with(&signer, auth_id, |data, auth_by| -> DispatchResult {
             let (user_key, paying_key, polyx_limit) =
                 extract_auth!(data, AddRelayerPayingKey(user_key, paying_key, polyx_limit));
+
+            // Allow: `origin == user_key`.
+            ensure!(user_key == caller_key, Error::<T>::NotAuthorizedForUserKey);
 
             Self::auth_accept_paying_key(
                 user_did,

--- a/pallets/runtime/ci/src/runtime.rs
+++ b/pallets/runtime/ci/src/runtime.rs
@@ -61,7 +61,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 3002,
+    spec_version: 3010,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 3002,
+    spec_version: 3010,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -57,7 +57,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 3002,
+    spec_version: 3010,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -61,7 +61,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 3002,
+    spec_version: 3010,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
Bump version v4.1.1 and spec: 3010

## changelog

### modified logic

- Add missing check to `relayer.accept_paying_key`.
- Add missing weight to `change_bridge_exempted`.

