### PR TITLE
MESH-1767 - Add secondary key and permissions length checks to `cdd_register_did`

### DIFF
--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{Claim1stKey, Claim2ndKey, Claims, DidRecords, Error, Module};
+use crate::{Claim1stKey, Claim2ndKey, Claims, DidRecord, DidRecords, Error, Module};
 use core::convert::From;
 use frame_support::{
     dispatch::{DispatchError, DispatchResult},
@@ -481,17 +481,21 @@ impl<T: Config> Module<T> {
         // Sender has to be part of CDDProviders
         Self::ensure_authorized_cdd_provider(cdd_did)?;
 
-        let record = <DidRecords<T>>::get(cdd_did);
-        let cost = secondary_keys.iter().try_fold(
-            0usize,
-            |cost, auth| -> Result<usize, DispatchError> {
-                //Check permissions limits
-                Self::ensure_perms_length_limited(&auth.permissions)?;
-                Ok(cost.saturating_add(auth.permissions.complexity()))
-            },
-        )?;
+        let record = DidRecord {
+            ..Default::default()
+        };
 
-        // Check secondary keys limits
+        // Calculates the cost complexity of the SK's permissions.
+        let cost =
+            secondary_keys
+                .iter()
+                .try_fold(0, |cost, auth| -> Result<usize, DispatchError> {
+                    // Check limit for this SK's permissions.
+                    Self::ensure_perms_length_limited(&auth.permissions)?;
+                    Ok(cost.saturating_add(auth.permissions.complexity()))
+                })?;
+
+        // Check secondary key limits.
         Self::ensure_secondary_keys_limited(&record, secondary_keys.len(), cost)?;
 
         // Register Identity

--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -482,17 +482,17 @@ impl<T: Config> Module<T> {
         Self::ensure_authorized_cdd_provider(cdd_did)?;
 
         let record = <DidRecords<T>>::get(cdd_did);
-        let cost =
-            secondary_keys
-                .iter()
-                .try_fold(0usize, |cost, auth| -> Result<usize, DispatchError> {
-                    //Check permissions limits
-                    Self::ensure_perms_length_limited(&auth.permissions)?;
-                    Ok(cost.saturating_add(auth.permissions.complexity()))
-                });
+        let cost = secondary_keys.iter().try_fold(
+            0usize,
+            |cost, auth| -> Result<usize, DispatchError> {
+                //Check permissions limits
+                Self::ensure_perms_length_limited(&auth.permissions)?;
+                Ok(cost.saturating_add(auth.permissions.complexity()))
+            },
+        )?;
 
         // Check secondary keys limits
-        Self::ensure_secondary_keys_limited(&record, secondary_keys.len(), cost.unwrap())?;
+        Self::ensure_secondary_keys_limited(&record, secondary_keys.len(), cost)?;
 
         // Register Identity
         let target_did = Self::_register_did(

--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -484,7 +484,7 @@ impl<T: Config> Module<T> {
         let record = <DidRecords<T>>::get(cdd_did);
         let cost = secondary_keys.iter().fold(0usize, |cost, auth| {
             //Check permissions limits
-            Self::ensure_perms_length_limited(&auth.permissions);
+            Self::ensure_perms_length_limited(&auth.permissions).unwrap();
             cost.saturating_add(auth.permissions.complexity())
         });
 

--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -482,14 +482,17 @@ impl<T: Config> Module<T> {
         Self::ensure_authorized_cdd_provider(cdd_did)?;
 
         let record = <DidRecords<T>>::get(cdd_did);
-        let cost = secondary_keys.iter().fold(0usize, |cost, auth| {
-            //Check permissions limits
-            Self::ensure_perms_length_limited(&auth.permissions).unwrap();
-            cost.saturating_add(auth.permissions.complexity())
-        });
+        let cost =
+            secondary_keys
+                .iter()
+                .try_fold(0usize, |cost, auth| -> Result<usize, DispatchError> {
+                    //Check permissions limits
+                    Self::ensure_perms_length_limited(&auth.permissions)?;
+                    Ok(cost.saturating_add(auth.permissions.complexity()))
+                });
 
         // Check secondary keys limits
-        Self::ensure_secondary_keys_limited(&record, secondary_keys.len(), cost)?;
+        Self::ensure_secondary_keys_limited(&record, secondary_keys.len(), cost.unwrap())?;
 
         // Register Identity
         let target_did = Self::_register_did(


### PR DESCRIPTION

## changelog

### modified logic

- Adding secondary key and permissions length checks to `cdd_register_did`



