### PR TITLE
MESH-1793 multisig primary/secondary key with balance.

### DIFF
--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -187,6 +187,10 @@ pub trait Config: CommonConfig + pallet_timestamp::Config + crate::traits::base:
 
     /// POLYX given to primary keys of all new Identities
     type InitialPOLYX: Get<<Self::Balances as Currency<Self::AccountId>>::Balance>;
+
+    /// Only allow MultiSig primary/secondary keys to be removed from an identity
+    /// if it's POLYX balance is below this limit.
+    type MultiSigBalanceLimit: Get<<Self::Balances as Currency<Self::AccountId>>::Balance>;
 }
 
 decl_event!(

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -189,7 +189,7 @@ pub trait Config: CommonConfig + pallet_timestamp::Config + crate::traits::base:
     type InitialPOLYX: Get<<Self::Balances as Currency<Self::AccountId>>::Balance>;
 
     /// Only allow MultiSig primary/secondary keys to be removed from an identity
-    /// if it's POLYX balance is below this limit.
+    /// if its POLYX balance is below this limit.
     type MultiSigBalanceLimit: Get<<Self::Balances as Currency<Self::AccountId>>::Balance>;
 }
 

--- a/pallets/common/src/traits/multisig.rs
+++ b/pallets/common/src/traits/multisig.rs
@@ -18,8 +18,6 @@
 //! The interface allows to process addition of a multisig signer from modules other than the
 //! multisig module itself.
 
-use sp_std::vec::Vec;
-
 /// This trait is used to add a signer to a multisig and enable unlinking multisig from an identity
 pub trait MultiSigSubTrait<AccountId> {
     /// Checks if the account is a multisig

--- a/pallets/common/src/traits/multisig.rs
+++ b/pallets/common/src/traits/multisig.rs
@@ -22,12 +22,6 @@ use sp_std::vec::Vec;
 
 /// This trait is used to add a signer to a multisig and enable unlinking multisig from an identity
 pub trait MultiSigSubTrait<AccountId> {
-    /// Fetches signers of a multisig
-    ///
-    /// # Arguments
-    /// * `multisig` - multisig AccountId
-    fn get_key_signers(multisig: &AccountId) -> Vec<AccountId>;
-
     /// Checks if the account is a multisig
     ///
     /// # Arguments

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -40,7 +40,7 @@ use polymesh_primitives::{
 };
 use sp_core::sr25519::Signature;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{AccountIdConversion as _, IdentifyAccount, Verify, Zero as _};
+use sp_runtime::traits::{AccountIdConversion as _, IdentifyAccount, Verify};
 use sp_runtime::{AnySignature, DispatchError};
 use sp_std::{vec, vec::Vec};
 
@@ -154,10 +154,10 @@ impl<T: Config> Module<T> {
             <AccountKeyRefCount<T>>::get(key) == 0,
             Error::<T>::AccountKeyIsBeingUsed
         );
-        // Do not allow unlinking MultiSig keys with balance.
+        // Do not allow unlinking MultiSig keys with balance >= 1 POLYX.
         if T::MultiSig::is_multisig(key) {
             ensure!(
-                T::Balances::total_balance(key).is_zero(),
+                T::Balances::total_balance(key) < T::MultiSigBalanceLimit::get().into(),
                 Error::<T>::MultiSigHasBalance
             );
         }

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -374,11 +374,6 @@ impl<T: Config> Module<T> {
                         if !T::Balances::total_balance(key).is_zero() {
                             return Left(iter::empty());
                         }
-                        // Unlink multisig signers from the identity.
-                        Self::unlink_multisig_signers_from_did(
-                            T::MultiSig::get_key_signers(key),
-                            did,
-                        );
                     }
                     // Unlink the secondary account key.
                     Self::unlink_account_key_from_did(key, did);
@@ -561,8 +556,6 @@ impl<T: Config> Module<T> {
                 T::Balances::total_balance(&key).is_zero(),
                 Error::<T>::MultiSigHasBalance
             );
-            // Unlink multisig signers from the identity.
-            Self::unlink_multisig_signers_from_did(T::MultiSig::get_key_signers(&key), did);
         }
         Self::unlink_account_key_from_did(&key, did);
 
@@ -572,12 +565,6 @@ impl<T: Config> Module<T> {
         });
         Self::deposit_event(RawEvent::SignerLeft(did, signer));
         Ok(())
-    }
-
-    fn unlink_multisig_signers_from_did(signers: Vec<T::AccountId>, did: IdentityId) {
-        for signer in signers {
-            Self::unlink_account_key_from_did(&signer, did)
-        }
     }
 
     /// Freezes/unfreezes the target `did` identity.

--- a/pallets/multisig/src/benchmarking.rs
+++ b/pallets/multisig/src/benchmarking.rs
@@ -342,7 +342,7 @@ benchmarks! {
         assert!(<MultiSigSignsRequired<T>>::get(&multisig) == 1);
     }
 
-    make_multisig_signer {
+    make_multisig_secondary {
         let (alice, multisig, _, _, _) = generate_multisig_for_alice::<T>(1, 1).unwrap();
         let ephemeral_multisig = multisig.clone();
         let ms_signer = Signatory::Account(multisig);

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -59,7 +59,7 @@
 //! - `remove_multisig_signers_via_creator` - Removes a signer from the multisig when called by the
 //! creator of the multisig.
 //! - `change_sigs_required` - Changes the number of signatures required to execute a transaction.
-//! - `make_multisig_signer` - Adds a multisig as a signer of the current DID if the current DID is
+//! - `make_multisig_secondary` - Adds a multisig as a secondary key of the current DID if the current DID is
 //! the creator of the multisig.
 //! - `make_multisig_primary` - Adds a multisig as the primary key of the current DID if the current DID
 //! is the creator of the multisig.
@@ -202,7 +202,7 @@ pub trait WeightInfo {
     fn add_multisig_signers_via_creator(signers: u32) -> Weight;
     fn remove_multisig_signers_via_creator(signers: u32) -> Weight;
     fn change_sigs_required() -> Weight;
-    fn make_multisig_signer() -> Weight;
+    fn make_multisig_secondary() -> Weight;
     fn make_multisig_primary() -> Weight;
     fn execute_scheduled_proposal() -> Weight;
 }
@@ -528,13 +528,13 @@ decl_module! {
             Self::unsafe_change_sigs_required(sender, sigs_required);
         }
 
-        /// Adds a multisig as a signer of current did if the current did is the creator of the
+        /// Adds a multisig as a secondary key of current did if the current did is the creator of the
         /// multisig.
         ///
         /// # Arguments
         /// * `multisig` - multi sig address
-        #[weight = <T as Config>::WeightInfo::make_multisig_signer()]
-        pub fn make_multisig_signer(origin, multisig: T::AccountId) {
+        #[weight = <T as Config>::WeightInfo::make_multisig_secondary()]
+        pub fn make_multisig_secondary(origin, multisig: T::AccountId) {
             let did = <Identity<T>>::ensure_perms(origin)?;
             Self::ensure_ms(&multisig)?;
             Self::verify_sender_is_creator(did, &multisig)?;

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1121,18 +1121,6 @@ impl<T: Config> Module<T> {
 }
 
 impl<T: Config> MultiSigSubTrait<T::AccountId> for Module<T> {
-    fn get_key_signers(multisig: &T::AccountId) -> Vec<T::AccountId> {
-        <MultiSigSigners<T>>::iter_prefix_values(multisig)
-            .filter_map(|signer| {
-                if let Signatory::Account(key) = signer {
-                    Some(key)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     fn is_multisig(account: &T::AccountId) -> bool {
         <MultiSigToIdentity<T>>::contains_key(account)
     }

--- a/pallets/runtime/ci/src/runtime.rs
+++ b/pallets/runtime/ci/src/runtime.rs
@@ -223,6 +223,7 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/common/src/lib.rs
+++ b/pallets/runtime/common/src/lib.rs
@@ -87,6 +87,8 @@ parameter_types! {
     pub const TransactionByteFee: Balance = 10 * MILLICENTS;
     /// We want the noop transaction to cost 0.03 POLYX
     pub const PolyXBaseFee: Balance = 3 * CENTS;
+    /// MultiSig balance limit: 1 POLYX
+    pub const MultiSigBalanceLimit: Balance = POLY;
     /// The maximum weight of the pips extrinsic `enact_snapshot_results` which equals to
     /// `MaximumBlockWeight * AvailableBlockRatio`.
     pub const PipsEnactSnapshotMaximumWeight: Weight = MAXIMUM_BLOCK_WEIGHT * 75 / 100;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -219,6 +219,7 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -212,6 +212,7 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -223,6 +223,7 @@ impl polymesh_common_utilities::traits::identity::Config for Runtime {
     type IdentityFn = pallet_identity::Module<Runtime>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -717,7 +717,7 @@ fn do_remove_secondary_keys_test_with_externalities() {
     let charlie = User::new(AccountKeyring::Charlie);
     let dave_key = AccountKeyring::Dave.to_account_id();
 
-    let musig_address = MultiSig::get_next_multisig_address(alice.acc());
+    let ms_address = MultiSig::get_next_multisig_address(alice.acc());
 
     assert_ok!(MultiSig::create_multisig(
         alice.origin(),
@@ -735,18 +735,18 @@ fn do_remove_secondary_keys_test_with_externalities() {
 
     add_secondary_key(alice.did, bob.acc());
 
-    add_secondary_key(alice.did, musig_address.clone());
+    add_secondary_key(alice.did, ms_address.clone());
 
     // Fund the multisig
     assert_ok!(Balances::transfer(
         alice.origin(),
-        musig_address.clone().into(),
+        ms_address.clone().into(),
         1
     ));
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), Some(alice.did));
+    assert_eq!(Identity::get_identity(&ms_address), Some(alice.did));
     assert_eq!(Identity::get_identity(&bob_key), Some(alice.did));
 
     // Try removing bob using charlie
@@ -758,7 +758,7 @@ fn do_remove_secondary_keys_test_with_externalities() {
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), Some(alice.did));
+    assert_eq!(Identity::get_identity(&ms_address), Some(alice.did));
     assert_eq!(Identity::get_identity(&bob_key), Some(alice.did));
 
     // Try remove bob using alice
@@ -770,32 +770,32 @@ fn do_remove_secondary_keys_test_with_externalities() {
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), Some(alice.did));
+    assert_eq!(Identity::get_identity(&ms_address), Some(alice.did));
     assert_eq!(Identity::get_identity(&bob_key), None);
 
     // Try removing multisig while it has funds
     assert_noop!(
         Identity::remove_secondary_keys(
             alice.origin(),
-            vec![Signatory::Account(musig_address.clone())]
+            vec![Signatory::Account(ms_address.clone())]
         ),
         Error::MultiSigHasBalance
     );
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), Some(alice.did));
+    assert_eq!(Identity::get_identity(&ms_address), Some(alice.did));
     assert_eq!(Identity::get_identity(&bob_key), None);
 
     // Check multisig's signer
     assert_eq!(
-        MultiSig::ms_signers(musig_address.clone(), Signatory::Account(dave_key.clone())),
+        MultiSig::ms_signers(ms_address.clone(), Signatory::Account(dave_key.clone())),
         true
     );
 
     // Transfer funds back to Alice
     assert_ok!(Balances::transfer(
-        Origin::signed(musig_address.clone()),
+        Origin::signed(ms_address.clone()),
         alice.acc().into(),
         1
     ));
@@ -803,17 +803,17 @@ fn do_remove_secondary_keys_test_with_externalities() {
     // Empty multisig's funds and remove as signer
     assert_ok!(Identity::remove_secondary_keys(
         alice.origin(),
-        vec![Signatory::Account(musig_address.clone())]
+        vec![Signatory::Account(ms_address.clone())]
     ));
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), None);
+    assert_eq!(Identity::get_identity(&ms_address), None);
     assert_eq!(Identity::get_identity(&bob.acc()), None);
 
     // Check multisig's signer
     assert_eq!(
-        MultiSig::ms_signers(musig_address.clone(), Signatory::Account(dave_key)),
+        MultiSig::ms_signers(ms_address.clone(), Signatory::Account(dave_key)),
         true
     );
 }
@@ -833,7 +833,7 @@ fn leave_identity_test_with_externalities() {
     let bob_sk = SecondaryKey::new(bob.signatory_acc(), Permissions::empty());
     let dave_key = AccountKeyring::Dave.to_account_id();
 
-    let musig_address = MultiSig::get_next_multisig_address(alice.acc());
+    let ms_address = MultiSig::get_next_multisig_address(alice.acc());
 
     assert_ok!(MultiSig::create_multisig(
         alice.origin(),
@@ -865,50 +865,50 @@ fn leave_identity_test_with_externalities() {
     assert_eq!(Identity::did_records(alice.did).secondary_keys.len(), 0);
     assert_eq!(Identity::get_identity(&bob.acc()), None);
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), None);
+    assert_eq!(Identity::get_identity(&ms_address), None);
 
-    add_secondary_key_with_perms(alice.did, musig_address.clone(), Permissions::empty());
+    add_secondary_key_with_perms(alice.did, ms_address.clone(), Permissions::empty());
     // send funds to multisig
     assert_ok!(Balances::transfer(
         alice.origin(),
-        musig_address.clone().into(),
+        ms_address.clone().into(),
         1
     ));
     // multisig tries leaving identity while it has funds
     assert_noop!(
-        Identity::leave_identity_as_key(Origin::signed(musig_address.clone())),
+        Identity::leave_identity_as_key(Origin::signed(ms_address.clone())),
         Error::MultiSigHasBalance
     );
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), Some(alice.did));
+    assert_eq!(Identity::get_identity(&ms_address), Some(alice.did));
 
     // Check multisig's signer
     assert_eq!(
-        MultiSig::ms_signers(musig_address.clone(), Signatory::Account(dave_key.clone())),
+        MultiSig::ms_signers(ms_address.clone(), Signatory::Account(dave_key.clone())),
         true
     );
 
     // send funds back to alice from multisig
     assert_ok!(Balances::transfer(
-        Origin::signed(musig_address.clone()),
+        Origin::signed(ms_address.clone()),
         alice.acc().into(),
         1
     ));
 
     // Empty multisig's funds and remove as signer
     assert_ok!(Identity::leave_identity_as_key(Origin::signed(
-        musig_address.clone()
+        ms_address.clone()
     )));
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);
-    assert_eq!(Identity::get_identity(&musig_address), None);
+    assert_eq!(Identity::get_identity(&ms_address), None);
 
     // Check multisig's signer
     assert_eq!(
-        MultiSig::ms_signers(musig_address.clone(), Signatory::Account(dave_key)),
+        MultiSig::ms_signers(ms_address.clone(), Signatory::Account(dave_key)),
         true
     );
 }

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -774,10 +774,13 @@ fn do_remove_secondary_keys_test_with_externalities() {
     assert_eq!(Identity::get_identity(&bob_key), None);
 
     // Try removing multisig while it has funds
-    assert_ok!(Identity::remove_secondary_keys(
-        alice.origin(),
-        vec![Signatory::Account(musig_address.clone())]
-    ));
+    assert_noop!(
+        Identity::remove_secondary_keys(
+            alice.origin(),
+            vec![Signatory::Account(musig_address.clone())]
+        ),
+        Error::MultiSigHasBalance
+    );
 
     // Check DidRecord.
     assert_eq!(Identity::get_identity(&dave_key), None);

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -22,6 +22,7 @@ use pallet_identity::types::DidRecords as RpcDidRecords;
 use pallet_identity::{self as identity, DidRecords};
 use polymesh_common_utilities::{
     asset::AssetSubTrait,
+    constants::currency::POLY,
     protocol_fee::ProtocolOp,
     traits::{
         group::GroupTrait,
@@ -741,7 +742,7 @@ fn do_remove_secondary_keys_test_with_externalities() {
     assert_ok!(Balances::transfer(
         alice.origin(),
         ms_address.clone().into(),
-        1
+        2 * POLY
     ));
 
     // Check DidRecord.
@@ -797,7 +798,7 @@ fn do_remove_secondary_keys_test_with_externalities() {
     assert_ok!(Balances::transfer(
         Origin::signed(ms_address.clone()),
         alice.acc().into(),
-        1
+        2 * POLY
     ));
 
     // Empty multisig's funds and remove as signer
@@ -872,7 +873,7 @@ fn leave_identity_test_with_externalities() {
     assert_ok!(Balances::transfer(
         alice.origin(),
         ms_address.clone().into(),
-        1
+        2 * POLY
     ));
     // multisig tries leaving identity while it has funds
     assert_noop!(
@@ -894,7 +895,7 @@ fn leave_identity_test_with_externalities() {
     assert_ok!(Balances::transfer(
         Origin::signed(ms_address.clone()),
         alice.acc().into(),
-        1
+        2 * POLY
     ));
 
     // Empty multisig's funds and remove as signer

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -503,7 +503,7 @@ fn make_multisig_primary() {
 }
 
 #[test]
-fn make_multisig_signer() {
+fn make_multisig_secondary_key() {
     ExtBuilder::default().monied(true).build().execute_with(|| {
         let alice = User::new(AccountKeyring::Alice);
         let bob = User::new(AccountKeyring::Bob);
@@ -526,7 +526,8 @@ fn make_multisig_signer() {
         };
         assert!(!has_ms_sk());
 
-        let mk_ms_signer = |u: User| MultiSig::make_multisig_signer(u.origin(), multisig.clone());
+        let mk_ms_signer =
+            |u: User| MultiSig::make_multisig_secondary(u.origin(), multisig.clone());
         assert_noop!(mk_ms_signer(bob), Error::IdentityNotCreator);
 
         assert_ok!(mk_ms_signer(alice));

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use frame_support::{assert_noop, assert_ok};
 use pallet_multisig as multisig;
+use polymesh_common_utilities::constants::currency::POLY;
 use polymesh_primitives::{AccountId, AuthorizationData, Permissions, SecondaryKey, Signatory};
 use test_client::AccountKeyring;
 
@@ -520,7 +521,7 @@ fn rotate_multisig_primary_key_with_balance() {
         assert_ok!(Balances::transfer(
             bob.origin(),
             ms_address.clone().into(),
-            1
+            2 * POLY
         ));
 
         // Add RotatePrimaryKey authorization for charlie_key to become the primary_key for Alice.

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -467,9 +467,6 @@ impl AssetSubTrait for Test {
 }
 
 impl MultiSigSubTrait<AccountId> for Test {
-    fn get_key_signers(_multisig: &AccountId) -> Vec<AccountId> {
-        unimplemented!()
-    }
     fn is_multisig(_account: &AccountId) -> bool {
         unimplemented!()
     }

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -344,6 +344,7 @@ impl polymesh_common_utilities::traits::identity::Config for Test {
     type IdentityFn = identity::Module<Test>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 parameter_types! {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -569,6 +569,7 @@ impl polymesh_common_utilities::traits::identity::Config for TestStorage {
     type IdentityFn = identity::Module<TestStorage>;
     type SchedulerOrigin = OriginCaller;
     type InitialPOLYX = InitialPOLYX;
+    type MultiSigBalanceLimit = polymesh_runtime_common::MultiSigBalanceLimit;
 }
 
 pub struct TestSessionHandler;

--- a/pallets/weights/src/pallet_multisig.rs
+++ b/pallets/weights/src/pallet_multisig.rs
@@ -142,7 +142,7 @@ impl pallet_multisig::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
-    fn make_multisig_signer() -> Weight {
+    fn make_multisig_secondary() -> Weight {
         (76_564_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))

--- a/scripts/cli/src/interfaces/lookup.ts
+++ b/scripts/cli/src/interfaces/lookup.ts
@@ -2040,7 +2040,7 @@ export default {
       change_sigs_required: {
         sigsRequired: 'u64',
       },
-      make_multisig_signer: {
+      make_multisig_secondary: {
         multisig: 'AccountId32',
       },
       make_multisig_primary: {


### PR DESCRIPTION
Fix balance check when removing a MultiSig from an identity.

## changelog

### modified API

- Rename `multisig.make_multisig_signer` -> `multisig.make_multisig_secondary`.  The old name was confusing to users, since it adds the multisig as a secondary key to the identity that created the multisig.

### modified logic

- Fixed the balance check for MultiSig primary/secondary keys.
- MultiSig balance limit changed from zero to `1.0 POLYX`.
- Remove dead code `unlink_multisig_signers_from_did()`, since the signers for a multisig are never linked to the identity.
