### PR TITLE
MESH-1806 verify did in treasury disbursement

### DIFF
--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -73,6 +73,16 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
+    /// Get the primary key for an identity if it exists.
+    ///
+    /// Returns `None` if the identity doesn't exist or it doesn't have a primary key.
+    pub fn get_primary_key(did: IdentityId) -> Option<T::AccountId> {
+        <DidRecords<T>>::try_get(did)
+            .ok()
+            .map(|record| record.primary_key)
+            .filter(|key| key != &T::AccountId::default())
+    }
+
     /// Returns the DID associated with `key`, if any,
     /// assuming it is either the primary key or isn't frozen.
     pub fn get_identity(key: &T::AccountId) -> Option<IdentityId> {

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -7,7 +7,7 @@ pub mod storage;
 pub use storage::{
     account_from, add_secondary_key, fast_forward_blocks, fast_forward_to_block, get_identity_id,
     make_account, make_account_with_balance, make_account_without_cdd, next_block,
-    register_keyring_account_with_balance, register_keyring_account_without_cdd, TestStorage,
+    register_keyring_account_with_balance, TestStorage,
 };
 
 pub mod ext_builder;

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -739,12 +739,6 @@ pub fn register_keyring_account_with_balance(
     make_account_with_balance(acc_id, uid, balance).map(|(_, id)| id)
 }
 
-pub fn register_keyring_account_without_cdd(
-    acc: AccountKeyring,
-) -> Result<IdentityId, &'static str> {
-    make_account_without_cdd(acc.to_account_id()).map(|(_, id)| id)
-}
-
 pub fn add_secondary_key_with_perms(did: IdentityId, acc: AccountId, perms: AuthPermissions) {
     let _primary_key = Identity::did_records(&did).primary_key;
     let auth_id = Identity::add_auth(

--- a/pallets/runtime/tests/src/treasury_test.rs
+++ b/pallets/runtime/tests/src/treasury_test.rs
@@ -1,6 +1,6 @@
 use super::{
+    exec_noop, exec_ok,
     storage::{root, TestStorage, User},
-    exec_ok, exec_noop,
     ExtBuilder,
 };
 
@@ -88,7 +88,8 @@ fn bad_disbursement_did_we() {
     let beneficiary = |id: IdentityId, amount| Beneficiary { id, amount };
     let beneficiaries = vec![
         // Valid identities.
-        beneficiary(alice.did, 100), beneficiary(bob.did, 500),
+        beneficiary(alice.did, 100),
+        beneficiary(bob.did, 500),
         // Invalid identities.
         beneficiary(0x00001u128.into(), 100),
         beneficiary(0x00002u128.into(), 200),
@@ -110,7 +111,10 @@ fn bad_disbursement_did_we() {
     assert_eq!(Treasury::balance(), treasury_balance);
     assert_eq!(Balances::free_balance(&alice.acc()), before_alice_balance);
     assert_eq!(Balances::free_balance(&bob.acc()), before_bob_balance);
-    assert_eq!(Balances::free_balance(&default_key), before_default_key_balance);
+    assert_eq!(
+        Balances::free_balance(&default_key),
+        before_default_key_balance
+    );
 
     // Make sure total POLYX issuance hasn't changed.
     assert_eq!(total_issuance, Balances::total_issuance());

--- a/pallets/runtime/tests/src/treasury_test.rs
+++ b/pallets/runtime/tests/src/treasury_test.rs
@@ -43,10 +43,14 @@ fn reimbursement_and_disbursement_we() {
     let beneficiary = |u: User, amount| Beneficiary { id: u.did, amount };
     let beneficiaries = vec![beneficiary(alice, 100), beneficiary(bob, 500)];
 
-    // Providing a random DID to Root, In an ideal world root will have a valid DID
+    // Save balances before disbursement.
     let before_alice_balance = Balances::free_balance(&alice.acc());
     let before_bob_balance = Balances::free_balance(&bob.acc());
-    exec_ok!(Treasury::disbursement(root(), beneficiaries));
+
+    // Try disbursement.
+    exec_ok!(Treasury::disbursement(root(), beneficiaries.clone()));
+
+    // Check balances after disbursement.
     assert_eq!(Treasury::balance(), 400);
     assert_eq!(
         Balances::free_balance(&alice.acc()),
@@ -61,6 +65,12 @@ fn reimbursement_and_disbursement_we() {
         DispatchError::BadOrigin
     );
     assert_eq!(total_issuance, Balances::total_issuance());
+
+    // Repeat disbursement.  This time there is not enough POLYX in the treasury.
+    exec_noop!(
+        Treasury::disbursement(root(), beneficiaries),
+        TreasuryError::InsufficientBalance,
+    );
 }
 
 #[test]

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -150,7 +150,7 @@ impl<T: Config> Module<T> {
             .iter()
             .map(|b| -> Result<_, DispatchError> {
                 total_amount = total_amount.saturating_add(b.amount);
-                // Ensure the identity exists and get it's primary key.
+                // Ensure the identity exists and get its primary key.
                 let primary_key =
                     Identity::<T>::get_primary_key(b.id).ok_or(Error::<T>::InvalidIdentity)?;
                 Ok((primary_key, b.id, b.amount))

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -129,17 +129,24 @@ decl_module! {
 }
 
 impl<T: Config> Module<T> {
-    fn base_disbursement(origin: T::Origin, beneficiaries: Vec<Beneficiary<BalanceOf<T>>>) -> DispatchResult {
+    fn base_disbursement(
+        origin: T::Origin,
+        beneficiaries: Vec<Beneficiary<BalanceOf<T>>>,
+    ) -> DispatchResult {
         ensure_root(origin)?;
 
         // Get the primary key for each Beneficiary.
         let mut total_amount: BalanceOf<T> = 0u32.into();
-        let beneficiaries = beneficiaries.iter().map(|b| -> Result<_, DispatchError> {
-            total_amount = total_amount.saturating_add(b.amount);
-            // Ensure the identity exists and get it's primary key.
-            let primary_key = Identity::<T>::get_primary_key(b.id).ok_or(Error::<T>::InvalidIdentity)?;
-            Ok((primary_key, b.id, b.amount))
-        }).collect::<Result<Vec<_>, DispatchError>>()?;
+        let beneficiaries = beneficiaries
+            .iter()
+            .map(|b| -> Result<_, DispatchError> {
+                total_amount = total_amount.saturating_add(b.amount);
+                // Ensure the identity exists and get it's primary key.
+                let primary_key =
+                    Identity::<T>::get_primary_key(b.id).ok_or(Error::<T>::InvalidIdentity)?;
+                Ok((primary_key, b.id, b.amount))
+            })
+            .collect::<Result<Vec<_>, DispatchError>>()?;
 
         // Ensure treasury has enough balance.
         ensure!(

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -38,7 +38,9 @@ pub mod benchmarking;
 
 use frame_support::traits::{StorageInfo, StorageInfoTrait};
 use frame_support::{
-    decl_error, decl_event, decl_module, ensure,
+    decl_error, decl_event, decl_module,
+    dispatch::DispatchError,
+    ensure,
     traits::{Currency, ExistenceRequirement, Imbalance, OnUnbalanced, WithdrawReasons},
     weights::Weight,
 };
@@ -93,6 +95,8 @@ decl_error! {
     pub enum Error for Module<T: Config> {
         /// Proposer's balance is too low.
         InsufficientBalance,
+        /// Invalid identity for disbursement.
+        InvalidIdentity,
     }
 }
 
@@ -108,17 +112,30 @@ decl_module! {
         /// # Error
         /// * `BadOrigin`: Only root can execute transaction.
         /// * `InsufficientBalance`: If treasury balances is not enough to cover all beneficiaries.
-        #[weight = <T as Config>::WeightInfo::disbursement( beneficiaries.len() as u32)]
+        /// * `InvalidIdentity`: If one of the beneficiaries has an invalid identity.
+        #[weight = <T as Config>::WeightInfo::disbursement(beneficiaries.len() as u32)]
         pub fn disbursement(origin, beneficiaries: Vec<Beneficiary<BalanceOf<T>>>) {
             ensure_root(origin)?;
 
+            // Get the primary key for each Beneficiary.
+            let mut total_amount: BalanceOf<T> = 0u32.into();
+            let beneficiaries = beneficiaries.iter().map(|b| -> Result<_, DispatchError> {
+                total_amount = total_amount.saturating_add(b.amount);
+                // Ensure the identity exists and get it's primary key.
+                let primary_key = Identity::<T>::get_primary_key(b.id).ok_or(Error::<T>::InvalidIdentity)?;
+                Ok((primary_key, b.id, b.amount))
+            }).collect::<Result<Vec<_>, DispatchError>>()?;
+
             // Ensure treasury has enough balance.
-            let total_amount = beneficiaries.iter().fold(0u32.into(), |acc,b| b.amount.saturating_add(acc));
             ensure!(
                 Self::balance() >= total_amount,
                 Error::<T>::InsufficientBalance
             );
-            beneficiaries.into_iter().for_each(|b| Self::unsafe_disbursement(b.id, b.amount));
+
+            // Do disbursement.
+            for (primary_key, id, amount) in beneficiaries {
+                Self::unsafe_disbursement(primary_key, id, amount);
+            }
         }
 
         /// It transfers the specific `amount` from `origin` account into treasury.
@@ -155,14 +172,13 @@ impl<T: Config> Module<T> {
         TREASURY_PALLET_ID.into_account()
     }
 
-    fn unsafe_disbursement(target: IdentityId, amount: BalanceOf<T>) {
+    fn unsafe_disbursement(primary_key: T::AccountId, target: IdentityId, amount: BalanceOf<T>) {
         let _ = T::Currency::withdraw(
             &Self::account_id(),
             amount,
             WithdrawReasons::TRANSFER,
             ExistenceRequirement::AllowDeath,
         );
-        let primary_key = Identity::<T>::did_records(target).primary_key;
         let _ = T::Currency::deposit_into_existing(&primary_key, amount);
         Self::deposit_event(RawEvent::TreasuryDisbursement(GC_DID, target, amount));
     }


### PR DESCRIPTION
## TODO

- [x] Emit `Balances::Transfer` event during disbursement.

## changelog

### modified API

- Added error `Treasury::InvalidIdentity` returned from `Treasury::disbursement` if one of the beneficiaries doesn't exist or doesn't have a primary key.
- Added the primary key to event `Treasury::TreasuryDisbursement`.
- Added event `Treasury::TreasuryDisbursementFailed` event for disbursements that fail.

### modified logic

- `Treasury::disbursement()` now checks if the beneficiaries exist and have a primary key.
- If the treasury disbursement transfer fails (treasury balance locked, beneficiary missing CDD), then event `Treasury::TreasuryDisbursementFailed`.

### modified agent functionality

- `Treasury::disbursement` emits the `Balances::Transfer` event for each disbursement beneficiary.
