### PR TITLE
MESH-1813 - reject invalid distributions

### DIFF
--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -204,6 +204,8 @@ decl_module! {
         /// - `InsufficientPortfolioBalance` if `portfolio` has less than `amount` of `currency`.
         /// - `InsufficientBalance` if the protocol fee couldn't be charged.
         /// - `CANotBenefit` if the CA is not of kind PredictableBenefit/UnpredictableBenefit
+        /// - `DistributionAmountIsZero` if the `amount` is zero.
+        /// - `DistributionPerShareIsZero` if the `per_share` is zero.
         ///
         /// # Permissions
         /// * Asset

--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -87,6 +87,7 @@ use polymesh_primitives::{
     SecondaryKey, Ticker,
 };
 use scale_info::TypeInfo;
+use sp_runtime::traits::Zero;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
 use sp_std::prelude::*;
@@ -378,6 +379,10 @@ decl_error! {
         DistributionStarted,
         /// A distribution has insufficient remaining amount of currency to distribute.
         InsufficientRemainingAmount,
+        /// Distribution `amount` cannot be zero.
+        DistributionAmountIsZero,
+        /// Distribution `per_share` cannot be zero.
+        DistributionPerShareIsZero,
     }
 }
 
@@ -606,6 +611,10 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         // Ensure CA's asset is distinct from the distributed currency.
         ensure!(ca_id.ticker != currency, Error::<T>::DistributingAsset);
+
+        // Ensure valid `amount` and `per_share`.
+        ensure!(!amount.is_zero(), Error::<T>::DistributionAmountIsZero);
+        ensure!(!per_share.is_zero(), Error::<T>::DistributionPerShareIsZero);
 
         // Ensure that any expiry date doesn't come before the payment date.
         ensure!(

--- a/pallets/corporate-actions/src/distribution/mod.rs
+++ b/pallets/corporate-actions/src/distribution/mod.rs
@@ -218,15 +218,8 @@ decl_module! {
             payment_at: Moment,
             expires_at: Option<Moment>,
         ) -> DispatchResult {
-            let PermissionedCallOriginData {
-                primary_did: agent,
-                secondary_key,
-                ..
-            } = <ExternalAgents<T>>::ensure_agent_asset_perms(origin, ca_id.ticker)?;
-
-            Self::unsafe_distribute(
-                agent,
-                secondary_key,
+            Self::base_distribute(
+                origin,
                 ca_id,
                 portfolio,
                 currency,
@@ -262,8 +255,7 @@ decl_module! {
         /// - Other errors can occur if the compliance manager rejects the transfer.
         #[weight = <T as Config>::DistWeightInfo::claim(T::MaxTargetIds::get(), T::MaxDidWhts::get())]
         pub fn claim(origin, ca_id: CAId) {
-            let did = <Identity<T>>::ensure_perms(origin)?;
-            Self::transfer_benefit(did.for_event(), did, ca_id)?;
+            Self::base_claim(origin, ca_id)?;
         }
 
         /// Push benefit of an ongoing distribution to the given `holder`.
@@ -292,8 +284,7 @@ decl_module! {
         /// - Other errors can occur if the compliance manager rejects the transfer.
         #[weight = <T as Config>::DistWeightInfo::push_benefit(T::MaxTargetIds::get(), T::MaxDidWhts::get())]
         pub fn push_benefit(origin, ca_id: CAId, holder: IdentityId) {
-            let agent = <ExternalAgents<T>>::ensure_perms(origin, ca_id.ticker)?.for_event();
-            Self::transfer_benefit(agent, holder, ca_id)?;
+            Self::base_push_benefit(origin, ca_id, holder)?;
         }
 
         /// Assuming a distribution has expired,
@@ -309,27 +300,7 @@ decl_module! {
         /// - `NotExpired` if `now < expiry`.
         #[weight = <T as Config>::DistWeightInfo::reclaim()]
         pub fn reclaim(origin, ca_id: CAId) {
-            // Ensure distribution is created, they haven't reclaimed, and that expiry has passed.
-            // CA must be authorized and be the custodian.
-            let PermissionedCallOriginData {
-                primary_did: agent,
-                secondary_key,
-                ..
-            } = <ExternalAgents<T>>::ensure_agent_asset_perms(origin.clone(), ca_id.ticker)?;
-            let dist = Self::ensure_distribution_exists(ca_id)?;
-            ensure!(!dist.reclaimed, Error::<T>::AlreadyReclaimed);
-            ensure!(expired(dist.expires_at, <Checkpoint<T>>::now_unix()), Error::<T>::NotExpired);
-            <Portfolio<T>>::ensure_portfolio_custody_and_permission(dist.from, agent, secondary_key.as_ref())?;
-
-            // Unlock `remaining` of `currency` from DID's portfolio.
-            // This won't fail, as we've already locked the requisite amount prior.
-            Self::unlock(&dist, dist.remaining)?;
-
-            // Zero `remaining` + note that we've reclaimed.
-            Distributions::insert(ca_id, Distribution { reclaimed: true, remaining:0u32.into(), ..dist });
-
-            // Emit event.
-            Self::deposit_event(Event::Reclaimed(agent.for_event(), ca_id, dist.remaining));
+            Self::base_reclaim(origin, ca_id)?;
         }
 
         /// Removes a distribution that hasn't started yet,
@@ -345,9 +316,7 @@ decl_module! {
         /// - `DistributionStarted` if `payment_at <= now`.
         #[weight = <T as Config>::DistWeightInfo::remove_distribution()]
         pub fn remove_distribution(origin, ca_id: CAId) {
-            let agent = <ExternalAgents<T>>::ensure_perms(origin, ca_id.ticker)?.for_event();
-            let dist = Self::ensure_distribution_exists(ca_id)?;
-            Self::remove_distribution_base(agent, ca_id, &dist)?;
+            Self::base_remove_distribution(origin, ca_id)?;
         }
     }
 }
@@ -413,8 +382,97 @@ decl_error! {
 }
 
 impl<T: Config> Module<T> {
+    fn base_distribute(
+        origin: T::Origin,
+        ca_id: CAId,
+        portfolio: Option<PortfolioNumber>,
+        currency: Ticker,
+        per_share: Balance,
+        amount: Balance,
+        payment_at: Moment,
+        expires_at: Option<Moment>,
+    ) -> DispatchResult {
+        let PermissionedCallOriginData {
+            primary_did: agent,
+            secondary_key,
+            ..
+        } = <ExternalAgents<T>>::ensure_agent_asset_perms(origin, ca_id.ticker)?;
+
+        Self::unsafe_distribute(
+            agent,
+            secondary_key,
+            ca_id,
+            portfolio,
+            currency,
+            per_share,
+            amount,
+            payment_at,
+            expires_at,
+        )
+    }
+
+    fn base_claim(origin: T::Origin, ca_id: CAId) -> DispatchResult {
+        let did = <Identity<T>>::ensure_perms(origin)?;
+        Self::transfer_benefit(did.for_event(), did, ca_id)?;
+        Ok(())
+    }
+
+    fn base_push_benefit(origin: T::Origin, ca_id: CAId, holder: IdentityId) -> DispatchResult {
+        let agent = <ExternalAgents<T>>::ensure_perms(origin, ca_id.ticker)?.for_event();
+        Self::transfer_benefit(agent, holder, ca_id)?;
+        Ok(())
+    }
+
+    fn base_reclaim(origin: T::Origin, ca_id: CAId) -> DispatchResult {
+        // Ensure distribution is created, they haven't reclaimed, and that expiry has passed.
+        // CA must be authorized and be the custodian.
+        let PermissionedCallOriginData {
+            primary_did: agent,
+            secondary_key,
+            ..
+        } = <ExternalAgents<T>>::ensure_agent_asset_perms(origin.clone(), ca_id.ticker)?;
+        let dist = Self::ensure_distribution_exists(ca_id)?;
+        ensure!(!dist.reclaimed, Error::<T>::AlreadyReclaimed);
+        ensure!(
+            expired(dist.expires_at, <Checkpoint<T>>::now_unix()),
+            Error::<T>::NotExpired
+        );
+        <Portfolio<T>>::ensure_portfolio_custody_and_permission(
+            dist.from,
+            agent,
+            secondary_key.as_ref(),
+        )?;
+
+        // Unlock `remaining` of `currency` from DID's portfolio.
+        // This won't fail, as we've already locked the requisite amount prior.
+        Self::unlock(&dist, dist.remaining)?;
+
+        // Zero `remaining` + note that we've reclaimed.
+        Distributions::insert(
+            ca_id,
+            Distribution {
+                reclaimed: true,
+                remaining: 0u32.into(),
+                ..dist
+            },
+        );
+
+        // Emit event.
+        Self::deposit_event(Event::Reclaimed(agent.for_event(), ca_id, dist.remaining));
+
+        Ok(())
+    }
+
+    fn base_remove_distribution(origin: T::Origin, ca_id: CAId) -> DispatchResult {
+        let agent = <ExternalAgents<T>>::ensure_perms(origin, ca_id.ticker)?.for_event();
+        let dist = Self::ensure_distribution_exists(ca_id)?;
+        Self::unverified_remove_distribution(agent, ca_id, &dist)?;
+
+        Ok(())
+    }
+
     /// Kill the distribution identified by `ca_id`.
-    crate fn remove_distribution_base(
+    crate fn unverified_remove_distribution(
         agent: EventDid,
         ca_id: CAId,
         dist: &Distribution,

--- a/pallets/corporate-actions/src/lib.rs
+++ b/pallets/corporate-actions/src/lib.rs
@@ -652,7 +652,7 @@ decl_module! {
                 }
                 CAKind::PredictableBenefit | CAKind::UnpredictableBenefit => {
                     if let Some(dist) = <Distribution<T>>::distributions(ca_id) {
-                        <Distribution<T>>::remove_distribution_base(agent, ca_id, &dist)?;
+                        <Distribution<T>>::unverified_remove_distribution(agent, ca_id, &dist)?;
                     }
                 }
             }

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -253,6 +253,7 @@ fn only_caa_authorized() {
         transfer(&ticker, owner, other);
 
         let currency = create_asset(b"BETA", owner);
+        transfer(&currency, owner, caa);
 
         macro_rules! checks {
             ($user:expr, $assert:ident $(, $tail:expr)?) => {
@@ -301,7 +302,7 @@ fn only_caa_authorized() {
                 // ..., `distribute`,
                 let id = next_ca_id(ticker);
                 $assert!(mk_ca(CAKind::UnpredictableBenefit) $(, $tail)?);
-                $assert!(Dist::distribute($user.origin(), id, None, currency, 0, 0, 3000, None) $(, $tail)?);
+                $assert!(Dist::distribute($user.origin(), id, None, currency, 1, 1, 3000, None) $(, $tail)?);
                 // ..., and `remove_distribution`.
                 $assert!(Dist::remove_distribution($user.origin(), id) $(, $tail)?);
             };
@@ -837,7 +838,7 @@ fn remove_ca_works() {
                 None,
                 currency,
                 2,
-                0,
+                2,
                 3000,
                 None,
             ));
@@ -851,8 +852,8 @@ fn remove_ca_works() {
                 from: PortfolioId::default_portfolio(owner.did),
                 currency,
                 per_share: 2,
-                amount: 0,
-                remaining: 0,
+                amount: 2,
+                remaining: 2,
                 reclaimed: false,
                 payment_at: 3000,
                 expires_at: None,
@@ -1013,8 +1014,8 @@ fn change_record_date_works() {
             id,
             None,
             create_asset(b"BETA", owner),
-            0,
-            0,
+            1,
+            2,
             5000,
             None,
         ));
@@ -1756,7 +1757,7 @@ fn dist_distribute_works() {
         // Test no CA at id.
         let id = next_ca_id(ticker);
         assert_noop!(
-            Dist::distribute(owner.origin(), id, None, currency, 0, 0, 1, None),
+            Dist::distribute(owner.origin(), id, None, currency, 1, 1, 1, None),
             Error::NoSuchCA
         );
 
@@ -1767,32 +1768,44 @@ fn dist_distribute_works() {
 
         // Test same-asset logic.
         assert_noop!(
-            Dist::distribute(owner.origin(), id2, None, ticker, 0, 0, 0, None),
+            Dist::distribute(owner.origin(), id2, None, ticker, 1, 1, 0, None),
             DistError::DistributingAsset
         );
 
         // Test expiry.
         for &(pay, expiry) in &[(5, 5), (6, 5)] {
             assert_noop!(
-                Dist::distribute(owner.origin(), id2, None, currency, 0, 0, pay, Some(expiry)),
+                Dist::distribute(owner.origin(), id2, None, currency, 1, 1, pay, Some(expiry)),
                 DistError::ExpiryBeforePayment
             );
         }
         Timestamp::set_timestamp(5);
+
+        // Test `amount == 0`.
+        assert_noop!(
+            Dist::distribute(owner.origin(), id2, None, currency, 1, 0, 5, Some(6)),
+            DistError::DistributionAmountIsZero
+        );
+        // Test `per_share == 0`.
+        assert_noop!(
+            Dist::distribute(owner.origin(), id2, None, currency, 0, 1, 5, Some(6)),
+            DistError::DistributionPerShareIsZero
+        );
+
         assert_ok!(Dist::distribute(
             owner.origin(),
             id2,
             None,
             currency,
-            0,
-            0,
+            1,
+            1,
             5,
             Some(6)
         ));
 
         // Distribution already exists.
         assert_noop!(
-            Dist::distribute(owner.origin(), id2, None, currency, 0, 0, 5, None),
+            Dist::distribute(owner.origin(), id2, None, currency, 1, 1, 5, None),
             DistError::AlreadyExists
         );
 
@@ -1802,8 +1815,8 @@ fn dist_distribute_works() {
             id1,
             None,
             currency,
-            0,
-            0,
+            1,
+            1,
             4,
             None
         ));
@@ -1812,14 +1825,14 @@ fn dist_distribute_works() {
         let id = dist_ca(owner, ticker, Some(5)).unwrap();
         let num = PortfolioNumber(42);
         assert_noop!(
-            Dist::distribute(owner.origin(), id, Some(num), currency, 0, 0, 5, None),
+            Dist::distribute(owner.origin(), id, Some(num), currency, 1, 1, 5, None),
             PError::PortfolioDoesNotExist
         );
 
         // No custody over portfolio.
         let custody =
             |who: User| Custodian::insert(PortfolioId::default_portfolio(owner.did), who.did);
-        let dist = |id| Dist::distribute(owner.origin(), id, None, currency, 0, 0, 6, None);
+        let dist = |id| Dist::distribute(owner.origin(), id, None, currency, 1, 1, 6, None);
         custody(other);
         assert_noop!(dist(id), PError::UnauthorizedCustodian);
         custody(owner);
@@ -1841,7 +1854,7 @@ fn dist_distribute_works() {
 
         // Record date after start.
         let dist =
-            |id, start| Dist::distribute(owner.origin(), id, None, currency, 0, 0, start, None);
+            |id, start| Dist::distribute(owner.origin(), id, None, currency, 1, 1, start, None);
         let id = dist_ca(owner, ticker, Some(5000)).unwrap();
         assert_noop!(dist(id, 4999), Error::RecordDateAfterStart);
         assert_ok!(dist(id, 5000));
@@ -1888,8 +1901,8 @@ fn dist_remove_works() {
             id,
             None,
             create_asset(b"BETA", owner),
-            0,
-            0,
+            1,
+            1,
             5,
             Some(6)
         ));
@@ -1926,7 +1939,7 @@ fn dist_reclaim_works() {
             id,
             None,
             currency,
-            0,
+            1,
             AMOUNT,
             5,
             Some(6)
@@ -1998,8 +2011,8 @@ fn dist_claim_misc_bad() {
             id,
             None,
             create_asset(b"BETA", owner),
-            0,
-            0,
+            1,
+            1,
             5,
             Some(6)
         ));
@@ -2028,8 +2041,8 @@ fn dist_claim_not_targeted() {
                 id,
                 None,
                 currency,
-                0,
-                0,
+                1,
+                1,
                 1,
                 None,
             ));
@@ -2202,7 +2215,7 @@ fn dist_claim_no_remaining() {
         // One has sufficient tokens but we'll claim from the other.
         // Previously, this would cause `remaining -= benefit` underflow.
         mk_dist(1_000_000);
-        let id = mk_dist(0);
+        let id = mk_dist(1);
 
         Timestamp::set_timestamp(5);
         assert_noop!(


### PR DESCRIPTION

## changelog

### modified logic

- `capitalDistribution.distribute()` will throw error `DistributionAmountIsZero` when `amount` is zero and throw `DistributionPerShareIsZero` when `per_share` is zero.
