### PR TITLE
MESH-1824: Empty perms default + MESH-1825: Contracts RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,6 +4580,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-contracts-rpc"
+version = "4.0.0-dev"
+source = "git+https://github.com/PolymathNetwork/substrate?branch=polymesh-develop#c430d99d1c8fb601e3e0838821ad19c71b2402c6"
+dependencies = [
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
+ "parity-scale-codec 2.3.1",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-contracts-rpc-runtime-api"
+version = "4.0.0-dev"
+source = "git+https://github.com/PolymathNetwork/substrate?branch=polymesh-develop#c430d99d1c8fb601e3e0838821ad19c71b2402c6"
+dependencies = [
+ "pallet-contracts-primitives",
+ "parity-scale-codec 2.3.1",
+ "scale-info",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-corporate-actions"
 version = "0.1.0"
 dependencies = [
@@ -5847,6 +5879,7 @@ dependencies = [
  "pallet-balances 0.1.0",
  "pallet-bridge",
  "pallet-committee",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-group",
@@ -6005,6 +6038,7 @@ version = "0.1.0"
 dependencies = [
  "jsonrpc-core",
  "node-rpc",
+ "pallet-contracts-rpc",
  "pallet-group-rpc",
  "pallet-protocol-fee-rpc",
  "pallet-staking-rpc",
@@ -6095,6 +6129,8 @@ dependencies = [
  "pallet-committee",
  "pallet-compliance-manager",
  "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-grandpa",
@@ -6212,6 +6248,8 @@ dependencies = [
  "pallet-committee",
  "pallet-compliance-manager",
  "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-grandpa",
@@ -6293,6 +6331,8 @@ dependencies = [
  "pallet-committee",
  "pallet-compliance-manager",
  "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-grandpa",
@@ -6375,6 +6415,8 @@ dependencies = [
  "pallet-committee",
  "pallet-compliance-manager",
  "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-grandpa",
@@ -6465,6 +6507,8 @@ dependencies = [
  "pallet-committee",
  "pallet-compliance-manager",
  "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-contracts-rpc-runtime-api",
  "pallet-corporate-actions",
  "pallet-external-agents",
  "pallet-grandpa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ pallet-babe = { git = "https://github.com/PolymathNetwork/substrate", branch = "
 pallet-balances = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
 pallet-contracts = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
 pallet-contracts-primitives = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
-#pallet-contracts-rpc = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
-#pallet-contracts-rpc-runtime-api = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
+pallet-contracts-rpc = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
 pallet-grandpa = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
 pallet-im-online = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
 pallet-indices = { git = "https://github.com/PolymathNetwork/substrate", branch = "polymesh-develop" }
@@ -122,7 +122,7 @@ members = [
     "pallets/committee",
     "pallets/common",
     "pallets/compliance-manager",
-    #"pallets/contracts",
+    "pallets/contracts",
     "pallets/corporate-actions",
     "pallets/external-agents",
     "pallets/group",
@@ -212,8 +212,7 @@ frame-support = "4.0.0-dev"
 frame-system = "4.0.0-dev"
 frame-system-rpc-runtime-api = "4.0.0-dev"
 grandpa = { package = "sc-finality-grandpa", version = "0.10.0-dev" }
-#pallet-contracts = "4.0.0-dev"
-#pallet-contracts-rpc-runtime-api = "4.0.0-dev"
+pallet-contracts-rpc-runtime-api = "4.0.0-dev"
 pallet-babe = "4.0.0-dev"
 pallet-im-online = "4.0.0-dev"
 pallet-indices = "4.0.0-dev"

--- a/node-rpc/Cargo.toml
+++ b/node-rpc/Cargo.toml
@@ -11,7 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 polymesh-primitives = { path = "../primitives", default-features = false }
-#pallet-contracts-rpc = { version = "4.0.0-dev" }
+pallet-contracts-rpc = { version = "4.0.0-dev" }
 pallet-group-rpc = { path = "../pallets/group/rpc" }
 pallet-staking-rpc = { path = "../pallets/staking/rpc" }
 pallet-protocol-fee-rpc = {  path = "../pallets/protocol-fee/rpc" }

--- a/node-rpc/src/lib.rs
+++ b/node-rpc/src/lib.rs
@@ -30,7 +30,9 @@
 
 #![warn(missing_docs)]
 
-use polymesh_primitives::{AccountId, Block, BlockNumber, Hash, IdentityId, Index, Moment, Ticker};
+use polymesh_primitives::{
+    AccountId, Balance, Block, BlockNumber, Hash, IdentityId, Index, Moment, Ticker,
+};
 use sc_client_api::AuxStore;
 use sc_consensus_babe::{Config, Epoch};
 use sc_consensus_epochs::SharedEpochChanges;
@@ -117,7 +119,7 @@ where
         + Send
         + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-    //C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
+    C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
     C::Api: node_rpc::transaction_payment::TransactionPaymentRuntimeApi<Block, UE>,
     C::Api: pallet_staking_rpc::StakingRuntimeApi<Block>,
     C::Api: node_rpc::pips::PipsRuntimeApi<Block, AccountId>,
@@ -141,7 +143,7 @@ where
         pips::{Pips, PipsApi},
         transaction_payment::{TransactionPayment, TransactionPaymentApi},
     };
-    //use pallet_contracts_rpc::{Contracts, ContractsApi};
+    use pallet_contracts_rpc::{Contracts, ContractsApi};
     use pallet_group_rpc::{Group, GroupApi};
     use pallet_protocol_fee_rpc::{ProtocolFee, ProtocolFeeApi};
     use pallet_staking_rpc::{Staking, StakingApi};
@@ -181,7 +183,7 @@ where
     // Making synchronous calls in light client freezes the browser currently,
     // more context: https://github.com/PolymathNetwork/substrate/pull/3480
     // These RPCs should use an asynchronous caller instead.
-    //io.extend_with(ContractsApi::to_delegate(Contracts::new(client.clone())));
+    io.extend_with(ContractsApi::to_delegate(Contracts::new(client.clone())));
     io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
         client.clone(),
     )));

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -60,7 +60,7 @@ fn free_balance<T: Config>(acc: &T::AccountId) -> Balance {
 /// Returns the address of the new contract.
 fn instantiate<T: Config>(user: &User<T>, wasm: WasmModule<T>, salt: Vec<u8>) -> T::AccountId {
     let callee = Base::<T>::contract_address(&user.account(), &wasm.hash, &salt);
-    Pallet::<T>::instantiate_with_code(
+    Pallet::<T>::instantiate_with_code_perms(
         user.origin().into(),
         Base::<T>::subsistence_threshold(), // endowment
         Weight::MAX,                        // gas limit
@@ -201,7 +201,7 @@ benchmarks! {
 
         // Pre-instantiate a contract so that one with the hash exists.
         let _ = instantiate::<T>(&user, wasm, salt());
-    }: _(user.origin(), ENDOWMENT, Weight::MAX, hash, vec![], other_salt, Permissions::empty())
+    }: instantiate(user.origin(), ENDOWMENT, Weight::MAX, hash, vec![], other_salt)
     verify {
         // Ensure contract has the full value.
         assert_eq!(free_balance::<T>(&addr), ENDOWMENT);
@@ -232,7 +232,7 @@ benchmarks! {
         // Construct the contract code + get addr.
         let wasm = WasmModule::<T>::sized(c);
         let addr = Base::<T>::contract_address(&user.account(), &wasm.hash, &salt);
-    }: _(user.origin(), ENDOWMENT, Weight::MAX, wasm.code, vec![], salt, Permissions::empty())
+    }: _(user.origin(), ENDOWMENT, Weight::MAX, wasm.code, vec![], salt)
     verify {
         // Ensure contract has the full value.
         assert_eq!(free_balance::<T>(&addr), ENDOWMENT);

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -232,7 +232,7 @@ decl_module! {
         /// Instantiates a smart contract defining it with the given `code` and `salt`.
         ///
         /// The contract will be attached as a secondary key,
-        /// with `perms` as its permissions, to `origin`'s identity.
+        /// with empty permissions, to `origin`'s identity.
         ///
         /// The contract is transferred `endowment` amount of POLYX.
         /// This is distinct from the `gas_limit`,
@@ -249,8 +249,41 @@ decl_module! {
         /// - All the errors in `pallet_contracts::Call::instantiate_with_code` can also happen here.
         /// - CDD/Permissions are checked, unlike in `pallet_contracts`.
         /// - Errors that arise when adding a new secondary key can also occur here.
-        #[weight = Module::<T>::weight_instantiate_with_code(&code, &salt, &perms)]
+        #[weight = Module::<T>::weight_instantiate_with_code(&code, &salt, &Permissions::empty())]
         pub fn instantiate_with_code(
+            origin,
+            endowment: Balance,
+            gas_limit: Weight,
+            code: Vec<u8>,
+            data: Vec<u8>,
+            salt: Vec<u8>
+        ) -> DispatchResultWithPostInfo {
+            Self::base_instantiate_with_code(origin, endowment, gas_limit, code, data, salt, Permissions::empty())
+        }
+
+        /// Instantiates a smart contract defining it with the given `code` and `salt`.
+        ///
+        /// The contract will be attached as a secondary key,
+        /// with `perms` as its permissions, to `origin`'s identity.
+        ///
+        /// The contract is transferred `endowment` amount of POLYX.
+        /// This is distinct from the `gas_limit`,
+        /// which controls how much gas the deployment code may at most consume.
+        ///
+        /// # Arguments
+        /// - `endowment` amount of POLYX to transfer to the contract.
+        /// - `gas_limit` for how much gas the `deploy` code in the contract may at most consume.
+        /// - `code` with the WASM binary defining the smart contract.
+        /// - `salt` used for contract address derivation.
+        ///    By varying this, the same `code` can be used under the same identity.
+        /// - `perms` that the new secondary key will have.
+        ///
+        /// # Errors
+        /// - All the errors in `pallet_contracts::Call::instantiate_with_code` can also happen here.
+        /// - CDD/Permissions are checked, unlike in `pallet_contracts`.
+        /// - Errors that arise when adding a new secondary key can also occur here.
+        #[weight = Module::<T>::weight_instantiate_with_code(&code, &salt, &perms)]
+        pub fn instantiate_with_code_perms(
             origin,
             endowment: Balance,
             gas_limit: Weight,
@@ -260,6 +293,41 @@ decl_module! {
             perms: Permissions
         ) -> DispatchResultWithPostInfo {
             Self::base_instantiate_with_code(origin, endowment, gas_limit, code, data, salt, perms)
+        }
+
+        /// Instantiates a smart contract defining using the given `code_hash` and `salt`.
+        ///
+        /// Unlike `instantiate_with_code`,
+        /// this assumes that at least one contract with the same WASM code has already been uploaded.
+        ///
+        /// The contract will be attached as a secondary key,
+        /// with empty permissions, to `origin`'s identity.
+        ///
+        /// The contract is transferred `endowment` amount of POLYX.
+        /// This is distinct from the `gas_limit`,
+        /// which controls how much gas the deployment code may at most consume.
+        ///
+        /// # Arguments
+        /// - `endowment` amount of POLYX to transfer to the contract.
+        /// - `gas_limit` for how much gas the `deploy` code in the contract may at most consume.
+        /// - `code_hash` of an already uploaded WASM binary.
+        /// - `salt` used for contract address derivation.
+        ///    By varying this, the same `code` can be used under the same identity.
+        ///
+        /// # Errors
+        /// - All the errors in `pallet_contracts::Call::instantiate` can also happen here.
+        /// - CDD/Permissions are checked, unlike in `pallet_contracts`.
+        /// - Errors that arise when adding a new secondary key can also occur here.
+        #[weight = Module::<T>::weight_instantiate_with_hash(&salt, &Permissions::empty())]
+        pub fn instantiate(
+            origin,
+            endowment: Balance,
+            gas_limit: Weight,
+            code_hash: CodeHash<T>,
+            data: Vec<u8>,
+            salt: Vec<u8>
+        ) -> DispatchResultWithPostInfo {
+            Self::base_instantiate_with_hash(origin, endowment, gas_limit, code_hash, data, salt, Permissions::empty())
         }
 
         /// Instantiates a smart contract defining using the given `code_hash` and `salt`.
@@ -280,13 +348,14 @@ decl_module! {
         /// - `code_hash` of an already uploaded WASM binary.
         /// - `salt` used for contract address derivation.
         ///    By varying this, the same `code` can be used under the same identity.
+        /// - `perms` that the new secondary key will have.
         ///
         /// # Errors
         /// - All the errors in `pallet_contracts::Call::instantiate` can also happen here.
         /// - CDD/Permissions are checked, unlike in `pallet_contracts`.
         /// - Errors that arise when adding a new secondary key can also occur here.
         #[weight = Module::<T>::weight_instantiate_with_hash(&salt, &perms)]
-        pub fn instantiate_with_hash(
+        pub fn instantiate_with_hash_perms(
             origin,
             endowment: Balance,
             gas_limit: Weight,
@@ -561,9 +630,23 @@ where
             code: decode!(),
             data: decode!(),
             salt: decode!(),
+        }),
+        on!(0, 2) => CommonCall::Contracts(Call::instantiate_with_code_perms {
+            endowment: decode!(),
+            gas_limit: decode!(),
+            code: decode!(),
+            data: decode!(),
+            salt: decode!(),
             perms: decode!(),
         }),
-        on!(0, 2) => CommonCall::Contracts(Call::instantiate_with_hash {
+        on!(0, 3) => CommonCall::Contracts(Call::instantiate {
+            endowment: decode!(),
+            gas_limit: decode!(),
+            code_hash: decode!(),
+            data: decode!(),
+            salt: decode!(),
+        }),
+        on!(0, 4) => CommonCall::Contracts(Call::instantiate_with_hash_perms {
             endowment: decode!(),
             gas_limit: decode!(),
             code_hash: decode!(),

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -510,7 +510,7 @@ impl<T: Config> Module<T> {
             let did =
                 pallet_permissions::Module::<T>::ensure_call_permissions(&sender)?.primary_did;
 
-            // Roll back `prepare_instantiate` if contract was not instantiated.
+            // Add a secondary key. Deployment contract code might need this.
             let code_hash = Self::code_hash(&code);
             Self::prepare_instantiate(did, &sender, &code_hash, &salt, Permissions::empty())?;
 

--- a/pallets/runtime/ci/Cargo.toml
+++ b/pallets/runtime/ci/Cargo.toml
@@ -49,7 +49,7 @@ pallet-test-utils = { path = "../../test-utils", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-staking-rpc-runtime-api = { package = "pallet-staking-rpc-runtime-api", path = "../../staking/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runtime-api", path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-#pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 
 # Crypto
 cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
@@ -81,7 +81,7 @@ sp-arithmetic = { version = "4.0.0-dev", default-features = false }
 
 pallet-authorship = { version = "4.0.0-dev", default-features = false }
 pallet-contracts = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
+pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
 pallet-executive = { package = "frame-executive", version = "4.0.0-dev", default-features = false }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", default-features = false }
@@ -129,8 +129,7 @@ std = [
     "pallet-bridge/std",
     "pallet-committee/std",
     "pallet-compliance-manager/std",
-    #"pallet-contracts-primitives/std",
-    #"pallet-contracts-rpc-runtime-api/std",
+    "pallet-contracts-rpc-runtime-api/std",
     "pallet-contracts/std",
     "pallet-executive/std",
     "pallet-external-agents/std",

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -725,34 +725,41 @@ macro_rules! runtime_apis {
                 }
             }
 
-            /*
-            impl pallet_contracts_rpc_runtime_api::ContractsApi<Block, polymesh_primitives::AccountId, Balance, BlockNumber>
-                for Runtime
-            {
+            impl pallet_contracts_rpc_runtime_api::ContractsApi<
+                Block,
+                polymesh_primitives::AccountId,
+                Balance,
+                BlockNumber,
+                polymesh_primitives::Hash,
+            > for Runtime {
                 fn call(
                     origin: polymesh_primitives::AccountId,
                     dest: polymesh_primitives::AccountId,
                     value: Balance,
                     gas_limit: u64,
                     input_data: Vec<u8>,
-                ) -> ContractExecResult {
-                    BaseContracts::bare_call(origin, dest.into(), value, gas_limit, input_data)
+                ) -> pallet_contracts_primitives::ContractExecResult {
+                    Contracts::bare_call(origin, dest, value, gas_limit, input_data, false)
+                }
+
+                fn instantiate(
+                    origin: polymesh_primitives::AccountId,
+                    endowment: Balance,
+                    gas_limit: u64,
+                    code: pallet_contracts_primitives::Code<polymesh_primitives::Hash>,
+                    data: Vec<u8>,
+                    salt: Vec<u8>,
+                ) -> pallet_contracts_primitives::ContractInstantiateResult<polymesh_primitives::AccountId> {
+                    Contracts::bare_instantiate(origin, endowment, gas_limit, code, data, salt, false)
                 }
 
                 fn get_storage(
                     address: polymesh_primitives::AccountId,
                     key: [u8; 32],
                 ) -> pallet_contracts_primitives::GetStorageResult {
-                    BaseContracts::get_storage(address, key)
-                }
-
-                fn rent_projection(
-                    address: polymesh_primitives::AccountId,
-                ) -> pallet_contracts_primitives::RentProjectionResult<BlockNumber> {
-                    BaseContracts::rent_projection(address)
+                    Contracts::get_storage(address, key)
                 }
             }
-            */
 
             impl node_rpc_runtime_api::transaction_payment::TransactionPaymentApi<
                 Block,

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -743,14 +743,14 @@ macro_rules! runtime_apis {
                 }
 
                 fn instantiate(
-                    origin: polymesh_primitives::AccountId,
+                    sender: polymesh_primitives::AccountId,
                     endowment: Balance,
                     gas_limit: u64,
                     code: pallet_contracts_primitives::Code<polymesh_primitives::Hash>,
                     data: Vec<u8>,
                     salt: Vec<u8>,
                 ) -> pallet_contracts_primitives::ContractInstantiateResult<polymesh_primitives::AccountId> {
-                    Contracts::bare_instantiate(origin, endowment, gas_limit, code, data, salt, false)
+                    PolymeshContracts::rpc_instantiate(sender, endowment, gas_limit, code, data, salt)
                 }
 
                 fn get_storage(

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -70,7 +70,7 @@ sp-arithmetic = { version = "4.0.0-dev", default-features = false }
 #
 pallet-authorship = { version = "4.0.0-dev", default-features = false }
 pallet-contracts = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false }
 pallet-executive = { package = "frame-executive", version = "4.0.0-dev", default-features = false }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", default-features = false }
@@ -93,7 +93,7 @@ cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 pallet-group-rpc-runtime-api = { path = "../../group/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-#pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 pallet-staking-rpc-runtime-api = { path = "../../staking/rpc/runtime-api", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 
@@ -137,8 +137,7 @@ std = [
     "pallet-bridge/std",
     "pallet-committee/std",
     "pallet-compliance-manager/std",
-    #"pallet-contracts-primitives/std",
-    #"pallet-contracts-rpc-runtime-api/std",
+    "pallet-contracts-rpc-runtime-api/std",
     "pallet-contracts/std",
     "pallet-corporate-actions/std",
     "pallet-executive/std",

--- a/pallets/runtime/mainnet/Cargo.toml
+++ b/pallets/runtime/mainnet/Cargo.toml
@@ -48,7 +48,7 @@ polymesh-contracts = { path = "../../contracts", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-staking-rpc-runtime-api = { package = "pallet-staking-rpc-runtime-api", path = "../../staking/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runtime-api", path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-#pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 
 # Others
 log = "0.4.8"
@@ -66,7 +66,7 @@ pallet-authority-discovery = { version = "4.0.0-dev", default-features = false }
 pallet-authorship = { version = "4.0.0-dev", default-features = false }
 pallet-babe = { version = "4.0.0-dev", default-features = false }
 pallet-contracts = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
+pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
 pallet-executive = { package = "frame-executive", version = "4.0.0-dev", default-features = false }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", default-features = false }
@@ -128,8 +128,7 @@ std = [
     "pallet-bridge/std",
     "pallet-committee/std",
     "pallet-compliance-manager/std",
-    #"pallet-contracts-primitives/std",
-    #"pallet-contracts-rpc-runtime-api/std",
+    "pallet-contracts-rpc-runtime-api/std",
     "pallet-contracts/std",
     "pallet-executive/std",
     "pallet-external-agents/std",

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -49,7 +49,7 @@ polymesh-contracts = { path = "../../contracts", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-staking-rpc-runtime-api = { package = "pallet-staking-rpc-runtime-api", path = "../../staking/rpc/runtime-api", default-features = false }
 pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runtime-api", path = "../../protocol-fee/rpc/runtime-api", default-features = false }
-#pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 
 # Crypto
 cryptography_core = { git = "https://github.com/PolymathNetwork/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
@@ -81,7 +81,7 @@ sp-arithmetic = { version = "4.0.0-dev", default-features = false }
 
 pallet-authorship = { version = "4.0.0-dev", default-features = false }
 pallet-contracts = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
+pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false}
 pallet-executive = { package = "frame-executive", version = "4.0.0-dev", default-features = false }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", default-features = false }
@@ -129,8 +129,7 @@ std = [
     "pallet-bridge/std",
     "pallet-committee/std",
     "pallet-compliance-manager/std",
-    #"pallet-contracts-primitives/std",
-    #"pallet-contracts-rpc-runtime-api/std",
+    "pallet-contracts-rpc-runtime-api/std",
     "pallet-contracts/std",
     "pallet-executive/std",
     "pallet-external-agents/std",

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -69,8 +69,8 @@ pallet-authority-discovery = { version = "4.0.0-dev", default-features = false }
 pallet-authorship = { version = "4.0.0-dev", default-features = false }
 pallet-babe = { version = "4.0.0-dev", default-features = false }
 pallet-contracts = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false }
-#pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false }
+pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 pallet-executive = { package = "frame-executive", version = "4.0.0-dev", default-features = false }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false }
 pallet-im-online = { version = "4.0.0-dev", default-features = false }

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -65,7 +65,7 @@ fn misc_polymesh_extensions() {
                 ..Permissions::empty()
             };
             let instantiate = || {
-                Contracts::instantiate_with_code(
+                Contracts::instantiate_with_code_perms(
                     owner.origin(),
                     FrameContracts::subsistence_threshold(),
                     GAS_LIMIT,

--- a/src/service.rs
+++ b/src/service.rs
@@ -108,7 +108,7 @@ pub trait RuntimeApiCollection<Extrinsic: RuntimeExtrinsic>:
     + sp_offchain::OffchainWorkerApi<Block>
     + sp_session::SessionKeys<Block>
     + sp_authority_discovery::AuthorityDiscoveryApi<Block>
-    //+ pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber>
+    + pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber, Hash>
     + pallet_staking_rpc_runtime_api::StakingApi<Block>
     + node_rpc_runtime_api::pips::PipsApi<Block, AccountId>
     + node_rpc_runtime_api::identity::IdentityApi<Block, IdentityId, Ticker, AccountId, Moment>
@@ -134,7 +134,7 @@ where
         + sp_offchain::OffchainWorkerApi<Block>
         + sp_session::SessionKeys<Block>
         + sp_authority_discovery::AuthorityDiscoveryApi<Block>
-        //+ pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber>
+        + pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber, Hash>
         + pallet_staking_rpc_runtime_api::StakingApi<Block>
         + node_rpc_runtime_api::pips::PipsApi<Block, AccountId>
         + node_rpc_runtime_api::identity::IdentityApi<Block, IdentityId, Ticker, AccountId, Moment>


### PR DESCRIPTION
## changelog

### modified API

- Contracts `instantiate` APIs now use empty permissions by default.
- Enable RPC for contracts.