### PR TITLE
Add Scheduler/System upgrade guards.

### DIFF
--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -1105,6 +1105,16 @@
       "default_withholding_tax": "Tax",
       "withholding_tax": "Vec<(IdentityId, Tax)>"
     },
+    "InitiateCorporateActionArgs": {
+      "ticker": "Ticker",
+      "kind": "CAKind",
+      "decl_date": "Moment",
+      "record_date": "Option<RecordDateSpec>",
+      "details": "CADetails",
+      "targets": "Option<TargetIdentities>",
+      "default_withholding_tax": "Option<Tax>",
+      "withholding_tax": "Option<Vec<(IdentityId, Tax)>>"
+    },
     "LocalCAId": "u32",
     "CAId": {
       "ticker": "Ticker",

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -58,7 +58,8 @@
         "CUSIP": "[u8; 9]",
         "CINS": "[u8; 9]",
         "ISIN": "[u8; 12]",
-        "LEI": "[u8; 20]"
+        "LEI": "[u8; 20]",
+        "FIGI": "[u8; 12]"
       }
     },
     "AssetOwnershipRelation": {


### PR DESCRIPTION
Add upgrade version checks for the Scheduler v2 -> v3 upgrade and System Dual to Triple ref upgrade.

Also add missing `FIGI` variant and `InitiateCorporateActionArgs` type to `polymesh_schema.json`.