### PR TITLE
Update confidential-identity to not use failure crate.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             - "/usr/local/cargo"
   integration-test:
     docker:
-      - image: polymathnet/node:v16
+      - image: node:16-bullseye
     resource_class: medium+
     environment:
       VERBOSE: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: small
     environment:
       VERBOSE: "1"
@@ -13,7 +13,7 @@ jobs:
           command: ./scripts/rustfmt.sh
   build:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -28,9 +28,6 @@ jobs:
           keys:
             - v6-release-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
-          name: Setup sccache.
-          command: ./scripts/install_sccache.sh
-      - run:
           name: Build release
           command: cargo build --release
           no_output_timeout: 1h
@@ -38,9 +35,6 @@ jobs:
           root: ./target/release
           paths:
             - polymesh
-      - run:
-          name: sccache stats
-          command: ./scripts/install_sccache.sh
       - save_cache:
           key: v6-release-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
@@ -48,7 +42,7 @@ jobs:
             - "~/.cache/sccache"
   benchmark-build:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -63,18 +57,12 @@ jobs:
           keys:
             - v3-bench-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
-          name: Setup sccache.
-          command: ./scripts/install_sccache.sh
-      - run:
           name: Build binary with runtime-benchmarks
           command: cargo build --release --features=runtime-benchmarks,running-ci
           no_output_timeout: 1h
       - run:
           name: Rename the benchmarks binary.
           command: mv ./target/release/polymesh ./polymesh-benchmarks
-      - run:
-          name: sccache stats
-          command: ./scripts/install_sccache.sh
       - persist_to_workspace:
           root: ./
           paths:
@@ -99,7 +87,7 @@ jobs:
           no_output_timeout: 1h
   migration-tests:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: large
     environment:
       - VERBOSE: "1"
@@ -123,7 +111,7 @@ jobs:
             - "/usr/local/cargo"
   test:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: large
     environment:
       - VERBOSE: "1"
@@ -140,9 +128,6 @@ jobs:
           keys:
             - v12-test-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
-          name: Setup sccache.
-          command: ./scripts/install_sccache.sh
-      - run:
           name: Tests
           command: >-
             cargo test
@@ -158,9 +143,6 @@ jobs:
             --package asset-metadata
             --features default_identity
           no_output_timeout: 1h
-      - run:
-          name: sccache stats
-          command: ./scripts/install_sccache.sh
       - save_cache:
           key: v12-test-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
@@ -168,14 +150,11 @@ jobs:
             - "~/.cache/sccache"
   coverage:
     docker:
-      - image: cimg/rust:1.60.0
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
     steps:
-      - run:
-          name: Install libclang
-          command: sudo apt-get update && sudo apt-get install libclang-dev
       - checkout
       - run:
           name: Store rust version in a file for cache key
@@ -183,9 +162,6 @@ jobs:
       - restore_cache:
           keys:
             - v7-coverage-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
-      - run:
-          name: Install dependencies
-          command: rustup component add llvm-tools-preview && cargo install rustfilt cargo-binutils
       - run:
           name: Coverage
           command: bash ./scripts/coverage.sh
@@ -224,7 +200,7 @@ jobs:
           no_output_timeout: 10m
   clippy:
     docker:
-      - image: polymathnet/rust:debian-nightly-2022-05-10
+      - image: polymeshassociation/rust:debian-nightly-2022-05-10
     resource_class: xlarge
     environment:
       VERBOSE: "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,16 +917,16 @@ dependencies = [
 [[package]]
 name = "confidential_identity"
 version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#7485147c0765c6a0048f561f360c1649b0d78429"
+source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#e89cd8eb49141597b412790cfe8f30d0adac4711"
 dependencies = [
  "blake2",
  "byteorder",
  "criterion",
  "curve25519-dalek-ng",
- "failure",
  "lazy_static",
  "merlin 3.0.0",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "schnorrkel 0.10.2",
  "serde",
@@ -940,14 +940,13 @@ dependencies = [
 [[package]]
 name = "confidential_identity"
 version = "1.1.2"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#a01e852dee0b24b450294d92d0833786ac173149"
+source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#c5468bf6ed9a04b87af0e24c08006438bb641831"
 dependencies = [
  "blake2",
  "byteorder",
  "criterion",
  "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2)",
  "curve25519-dalek-ng",
- "failure",
  "parity-scale-codec 3.1.2",
  "rand 0.8.5",
  "rand_core 0.6.3",
@@ -1262,13 +1261,12 @@ dependencies = [
 [[package]]
 name = "cryptography_core"
 version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#7485147c0765c6a0048f561f360c1649b0d78429"
+source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#e89cd8eb49141597b412790cfe8f30d0adac4711"
 dependencies = [
  "bulletproofs",
  "byteorder",
  "criterion",
  "curve25519-dalek-ng",
- "failure",
  "merlin 3.0.0",
  "parity-scale-codec 3.1.2",
  "rand 0.8.5",
@@ -1282,14 +1280,13 @@ dependencies = [
 [[package]]
 name = "cryptography_core"
 version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#a01e852dee0b24b450294d92d0833786ac173149"
+source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#c5468bf6ed9a04b87af0e24c08006438bb641831"
 dependencies = [
  "blake2",
  "bulletproofs",
  "byteorder",
  "criterion",
  "curve25519-dalek-ng",
- "failure",
  "merlin 3.0.0",
  "parity-scale-codec 3.1.2",
  "rand 0.8.5",
@@ -1784,28 +1781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
  "futures 0.3.21",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,11 @@ dependencies = [
 
 [[package]]
 name = "bulletproofs"
-version = "2.0.1"
-source = "git+https://github.com/PolymathNetwork/bulletproofs.git?branch=bump-dalek#dbf5215c1c7c8b30b37e979018340d73678cad29"
+version = "4.0.0"
+source = "git+https://github.com/PolymeshAssociation/bulletproofs?branch=polymesh#def499bb056771bf4986034f8d09d7dc91078563"
 dependencies = [
  "byteorder",
+ "clear_on_drop",
  "curve25519-dalek-ng",
  "digest 0.9.0",
  "merlin 3.0.0",
@@ -641,7 +642,6 @@ dependencies = [
  "sha3 0.9.1",
  "subtle-ng",
  "thiserror",
- "zeroize",
 ]
 
 [[package]]
@@ -897,6 +897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,9 +924,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "confidential_identity"
+name = "confidential_identity_core"
 version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#e89cd8eb49141597b412790cfe8f30d0adac4711"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3c20971d45d23a2eb5909e2dedce60e4736b0223bada9e0b5747c43a78f621"
+dependencies = [
+ "blake2",
+ "bulletproofs",
+ "byteorder",
+ "criterion",
+ "curve25519-dalek-ng",
+ "merlin 3.0.0",
+ "parity-scale-codec 3.1.2",
+ "rand 0.8.5",
+ "rand_core 0.6.3",
+ "serde",
+ "sha3 0.9.1",
+ "sp-std",
+ "zeroize",
+]
+
+[[package]]
+name = "confidential_identity_v1"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a140dd3425471b44b3fc0ab89c6eb8e72c484de0aa80e138ea41b706dbff00f"
 dependencies = [
  "blake2",
  "byteorder",
@@ -938,14 +969,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "confidential_identity"
-version = "1.1.2"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#c5468bf6ed9a04b87af0e24c08006438bb641831"
+name = "confidential_identity_v2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b9cef2c3d5d42769ce099822dbea11959f6a38fe4eb9ef2a431eaeaf24a24b"
 dependencies = [
  "blake2",
  "byteorder",
+ "confidential_identity_core",
  "criterion",
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2)",
  "curve25519-dalek-ng",
  "parity-scale-codec 3.1.2",
  "rand 0.8.5",
@@ -1222,7 +1254,7 @@ dependencies = [
 name = "crypto-cli"
 version = "1.0.0"
 dependencies = [
- "confidential_identity 1.0.0",
+ "confidential_identity_v1",
  "hex",
  "parity-scale-codec 3.1.2",
  "polymesh-primitives",
@@ -1256,45 +1288,6 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.5",
  "subtle",
-]
-
-[[package]]
-name = "cryptography_core"
-version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1#e89cd8eb49141597b412790cfe8f30d0adac4711"
-dependencies = [
- "bulletproofs",
- "byteorder",
- "criterion",
- "curve25519-dalek-ng",
- "merlin 3.0.0",
- "parity-scale-codec 3.1.2",
- "rand 0.8.5",
- "rand_core 0.6.3",
- "serde",
- "sha3 0.9.1",
- "sp-std",
- "zeroize",
-]
-
-[[package]]
-name = "cryptography_core"
-version = "1.0.0"
-source = "git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v2#c5468bf6ed9a04b87af0e24c08006438bb641831"
-dependencies = [
- "blake2",
- "bulletproofs",
- "byteorder",
- "criterion",
- "curve25519-dalek-ng",
- "merlin 3.0.0",
- "parity-scale-codec 3.1.2",
- "rand 0.8.5",
- "rand_core 0.6.3",
- "serde",
- "sha3 0.9.1",
- "sp-std",
- "zeroize",
 ]
 
 [[package]]
@@ -5173,8 +5166,7 @@ dependencies = [
 name = "pallet-identity"
 version = "0.1.0"
 dependencies = [
- "confidential_identity 1.0.0",
- "confidential_identity 1.1.2",
+ "confidential_identity_v2",
  "either",
  "frame-benchmarking",
  "frame-support",
@@ -5675,7 +5667,7 @@ dependencies = [
 name = "pallet-test-utils"
 version = "0.1.0"
 dependencies = [
- "confidential_identity 1.0.0",
+ "confidential_identity_v1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6517,8 +6509,8 @@ version = "2.0.0"
 dependencies = [
  "blake2",
  "chrono",
- "confidential_identity 1.0.0",
- "confidential_identity 1.1.2",
+ "confidential_identity_v1",
+ "confidential_identity_v2",
  "either",
  "frame-support",
  "frame-system",
@@ -6556,7 +6548,7 @@ dependencies = [
 name = "polymesh-runtime-ci"
 version = "0.1.0"
 dependencies = [
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1)",
+ "confidential_identity_core",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -6674,7 +6666,7 @@ dependencies = [
 name = "polymesh-runtime-develop"
 version = "0.1.0"
 dependencies = [
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1)",
+ "confidential_identity_core",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -6761,7 +6753,7 @@ dependencies = [
 name = "polymesh-runtime-mainnet"
 version = "0.1.0"
 dependencies = [
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1)",
+ "confidential_identity_core",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -6846,7 +6838,7 @@ dependencies = [
 name = "polymesh-runtime-testnet"
 version = "0.1.0"
 dependencies = [
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1)",
+ "confidential_identity_core",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -6933,8 +6925,8 @@ name = "polymesh-runtime-tests"
 version = "1.0.0"
 dependencies = [
  "chrono",
- "confidential_identity 1.0.0",
- "cryptography_core 1.0.0 (git+https://github.com/PolymeshAssociation/cryptography.git?branch=confidential-identity-v1)",
+ "confidential_identity_core",
+ "confidential_identity_v1",
  "env_logger 0.7.1",
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10737,7 +10729,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",
@@ -10940,7 +10932,7 @@ checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
 dependencies = [
  "bitflags",
  "chrono",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,8 @@ substrate-test-utils = { git = "https://github.com/PolymeshAssociation/substrate
 substrate-test-utils-derive = { git = "https://github.com/PolymeshAssociation/substrate", branch = "polymesh-monthly-2022-05" }
 substrate-wasm-builder = { git = "https://github.com/PolymeshAssociation/substrate", branch = "polymesh-monthly-2022-05" }
 
+bulletproofs = { version = "4.0.0", git = "https://github.com/PolymeshAssociation/bulletproofs", branch = "polymesh" }
+
 [workspace]
 members = [
     "bin/bench",

--- a/bin/crypto-cli/Cargo.toml
+++ b/bin/crypto-cli/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 polymesh-primitives = { path = "../../primitives" }
-confidential_identity = { git = "https://github.com/PolymeshAssociation/cryptography.git", branch = "confidential-identity-v1" }
+confidential_identity_v1 = { version = "1.0.0" }
 codec = { version = "3.0.0", package = "parity-scale-codec" }
 hex = "0.4.0"

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -18,8 +18,7 @@ serde_derive = { version = "1.0.104", optional = true, default-features = false 
 either = { version = "1.6.1", default-features = false }
 
 # Cryptography
-confidential_identity = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v2" }
-confidential_identity_v1 = { package = "confidential_identity", git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_v2 = { version = "2.0.0", default-features = false }
 schnorrkel = { version = "0.10.1", default-features = false, optional = true }
 
 # Substrate
@@ -44,12 +43,15 @@ equalize = []
 default = ["std", "equalize"]
 no_cdd = []
 running-ci = []
-no_std = [ "confidential_identity/u64_backend", ]
+no_std = [
+  "confidential_identity_v2/no_std",
+	"confidential_identity_v2/u64_backend",
+]
 only-staking = []
 std = [
     "codec/std",
-    "confidential_identity/std",
-    "confidential_identity/u64_backend",
+    "confidential_identity_v2/std",
+    "confidential_identity_v2/u64_backend",
     "frame-support/std",
     "frame-system/std",
     "pallet-balances/std",

--- a/pallets/identity/src/benchmarking.rs
+++ b/pallets/identity/src/benchmarking.rs
@@ -15,8 +15,7 @@
 
 use crate::*;
 
-use confidential_identity::mocked::make_investor_uid as make_investor_uid_v2;
-use confidential_identity_v1::mocked::make_investor_uid as make_investor_uid_v1;
+use confidential_identity_v2::mocked::make_investor_uid;
 use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
 use polymesh_common_utilities::{
@@ -78,7 +77,7 @@ where
 {
     setup_investor_uniqueness_claim_common::<T, _, _, _, _, _, _>(
         name,
-        |raw_did| make_investor_uid_v2(raw_did).into(),
+        |raw_did| make_investor_uid(raw_did).into(),
         CddId::new_v2,
         v2::InvestorZKProofData::make_scope_id,
         |_scope, _scope_id, cdd_id| Claim::InvestorUniquenessV2(cdd_id),
@@ -112,7 +111,7 @@ where
 
     setup_investor_uniqueness_claim_common::<T, _, _, _, _, _, _>(
         name,
-        |raw_did| make_investor_uid_v1(raw_did).into(),
+        |raw_did| make_investor_uid(raw_did).into(),
         CddId::new_v1,
         v1::InvestorZKProofData::make_scope_id,
         |scope, scope_id, cdd_id| Claim::InvestorUniqueness(scope, scope_id, cdd_id),

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -92,7 +92,7 @@ pub use types::{Claim1stKey, Claim2ndKey, DidStatus, PermissionedCallOriginData,
 pub mod benchmarking;
 
 use codec::{Decode, Encode};
-use confidential_identity::ScopeClaimProof;
+use confidential_identity_v2::ScopeClaimProof;
 use core::convert::From;
 use frame_support::{
     decl_error, decl_module, decl_storage,

--- a/pallets/runtime/ci/Cargo.toml
+++ b/pallets/runtime/ci/Cargo.toml
@@ -52,7 +52,7 @@ pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runti
 pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_core = { version = "1.0.0", default-features = false }
 
 # Others
 lazy_static = { version = "1.4.0", default-features = false }
@@ -109,8 +109,8 @@ default = ["std", "equalize"]
 equalize = []
 
 # Backends
-u64_backend = ["cryptography_core/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend"]
+u64_backend = ["confidential_identity_core/u64_backend"]
+avx2_backend = ["confidential_identity_core/avx2_backend"]
 
 migration-dry-run = []
 no_std = ["u64_backend"]

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -88,7 +88,7 @@ frame-system = { version = "4.0.0-dev", default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_core = { version = "1.0.0", default-features = false }
 
 # RPC
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
@@ -114,11 +114,11 @@ default = ["std", "equalize"]
 equalize = []
 
 # Backends
-u64_backend = ["cryptography_core/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend"]
+u64_backend = ["confidential_identity_core/u64_backend"]
+avx2_backend = ["confidential_identity_core/avx2_backend"]
 
 no_std = [
-    "cryptography_core/no_std",
+    "confidential_identity_core/no_std",
     "u64_backend"
 ]
 
@@ -130,7 +130,7 @@ std = [
     "frame-system-rpc-runtime-api/std",
     "frame-system/std",
     "node-rpc-runtime-api/std",
-    "cryptography_core/std",
+    "confidential_identity_core/std",
     "pallet-asset/std",
     "pallet-authority-discovery/std",
     "pallet-authorship/std",

--- a/pallets/runtime/mainnet/Cargo.toml
+++ b/pallets/runtime/mainnet/Cargo.toml
@@ -96,7 +96,7 @@ sp-transaction-pool = { version = "4.0.0-dev", default-features = false }
 sp-version = { version = "5.0.0", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_core = { version = "1.0.0", default-features = false }
 
 [build-dependencies]
 polymesh-build-tool = { path = "../build_tool", default-features = false }
@@ -106,12 +106,12 @@ default = ["std", "equalize"]
 equalize = []
 
 # Backends
-u64_backend = ["cryptography_core/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend"]
+u64_backend = ["confidential_identity_core/u64_backend"]
+avx2_backend = ["confidential_identity_core/avx2_backend"]
 
 migration-dry-run = []
 no_std = [
-    "cryptography_core/no_std",
+    "confidential_identity_core/no_std",
     "u64_backend",
 ]
 std = [

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -52,7 +52,7 @@ pallet-protocol-fee-rpc-runtime-api = { package = "pallet-protocol-fee-rpc-runti
 pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false }
 
 # Crypto
-cryptography_core = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_core = { version = "1.0.0", default-features = false }
 
 # Others
 lazy_static = { version = "1.4.0", default-features = false }
@@ -109,8 +109,8 @@ default = ["std", "equalize"]
 equalize = []
 
 # Backends
-u64_backend = ["cryptography_core/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend"]
+u64_backend = ["confidential_identity_core/u64_backend"]
+avx2_backend = ["confidential_identity_core/avx2_backend"]
 
 migration-dry-run = []
 no_std = ["u64_backend"]

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Polymath"]
 edition = "2021"
 
 [dependencies]
-confidential_identity = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
-cryptography_core = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_v1 = { version = "1.0.0", default-features = false }
+confidential_identity_core = { version = "1.0.0", default-features = false }
 node-rpc-runtime-api = { path = "../../../rpc/runtime-api", default-features = false }
 pallet-asset = { path = "../../asset", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }
@@ -118,18 +118,18 @@ equalize = []
 only-staking = []
 
 # Backends
-u64_backend = ["cryptography_core/u64_backend", "polymesh-primitives/u64_backend"]
-avx2_backend = ["cryptography_core/avx2_backend", "polymesh-primitives/avx2_backend"]
+u64_backend = ["confidential_identity_core/u64_backend", "polymesh-primitives/u64_backend"]
+avx2_backend = ["confidential_identity_core/avx2_backend", "polymesh-primitives/avx2_backend"]
 
 no_std = [
-    "cryptography_core/no_std",
+    "confidential_identity_core/no_std",
     "u64_backend"
 ]
 
 std = [
     "avx2_backend",
-    "cryptography_core/std",
-    "confidential_identity/std",
+    "confidential_identity_core/std",
+    "confidential_identity_v1/std",
     "frame-support/std",
     "frame-system/std",
     "frame-election-provider-support/std",

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -1,5 +1,5 @@
 use crate::TestStorage;
-use confidential_identity::mocked::make_investor_uid as make_investor_uid_v2;
+use confidential_identity_v1::mocked::make_investor_uid;
 use pallet_asset::{self as asset, TickerRegistrationConfig};
 use pallet_balances as balances;
 use pallet_bridge::BridgeTx;
@@ -327,7 +327,7 @@ impl ExtBuilder {
             .map(|(idx, primary_key)| {
                 let did_index = (idx + offset + 1) as u128;
                 let did = IdentityId::from(did_index);
-                let investor: InvestorUid = make_investor_uid_v2(did.as_bytes()).into();
+                let investor: InvestorUid = make_investor_uid(did.as_bytes()).into();
 
                 GenesisIdentityRecord {
                     primary_key,

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -11,7 +11,7 @@ use super::{
     ExtBuilder,
 };
 use codec::Encode;
-use confidential_identity::mocked::make_investor_uid as make_investor_uid_v2;
+use confidential_identity_v1::mocked::make_investor_uid;
 use frame_support::{
     assert_noop, assert_ok, dispatch::DispatchResult, traits::Currency, StorageDoubleMap,
 };
@@ -2005,7 +2005,7 @@ fn add_investor_uniqueness_claim_v2_data(
 )> {
     let ticker = Ticker::default();
     let did = Identity::get_identity(&user).unwrap();
-    let investor: InvestorUid = make_investor_uid_v2(did.as_bytes()).into();
+    let investor: InvestorUid = make_investor_uid(did.as_bytes()).into();
     let cdd_id = CddId::new_v2(did, investor.clone());
     let proof = v2::InvestorZKProofData::new(&did, &investor, &ticker);
     let claim = Claim::InvestorUniquenessV2(cdd_id);

--- a/pallets/test-utils/Cargo.toml
+++ b/pallets/test-utils/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false  }
 
 # Crypto
-confidential_identity = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_v1 = { version = "1.0.0", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -30,10 +30,10 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional
 [features]
 default = ["std"]
 running-ci = []
-no_std = ["confidential_identity/no_std"]
+no_std = ["confidential_identity_v1/no_std"]
 std = [
     "codec/std",
-    "confidential_identity/std",
+    "confidential_identity_v1/std",
     "serde/std",
     "serde_derive",
     "sp-std/std",

--- a/pallets/test-utils/src/lib.rs
+++ b/pallets/test-utils/src/lib.rs
@@ -147,7 +147,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::mock_cdd_register_did()]
         pub fn mock_cdd_register_did(origin, target_account: T::AccountId) {
             let (cdd_did, target_did) = Identity::<T>::base_cdd_register_did(origin, target_account, vec![])?;
-            let target_uid = confidential_identity::mocked::make_investor_uid(target_did.as_bytes());
+            let target_uid = confidential_identity_v1::mocked::make_investor_uid(target_did.as_bytes());
 
             // Add CDD claim for the target
             let cdd_claim = Claim::CustomerDueDiligence(CddId::new_v1(target_did, target_uid.clone().into()));

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,8 +17,8 @@ polymesh-primitives-derive = { path = "../primitives_derive", default-features =
 
 # Crypto
 blake2 = { version = "0.10.2", default-features = false }
-confidential_identity = { git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v2" }
-confidential_identity_v1 = { package = "confidential_identity", git = "https://github.com/PolymeshAssociation/cryptography.git", default-features = false, branch = "confidential-identity-v1" }
+confidential_identity_v1 = { version = "1.0.0", default-features = false }
+confidential_identity_v2 = { version = "2.0.0", default-features = false }
 schnorrkel = { version = "0.10.1", default-features = false }
 
 
@@ -49,7 +49,10 @@ u32_backend = [ "confidential_identity_v1/u32_backend", "schnorrkel/u32_backend"
 u64_backend = [ "confidential_identity_v1/u64_backend", "schnorrkel/u64_backend"]
 avx2_backend = [ "confidential_identity_v1/avx2_backend", "schnorrkel/avx2_backend"]
 
-no_std = ["confidential_identity_v1/no_std"]
+no_std = [
+	"confidential_identity_v1/no_std",
+	"confidential_identity_v2/no_std"
+]
 
 std = [
     "chrono/std",
@@ -67,8 +70,8 @@ std = [
     # Crypto
     "blake2/simd",
     "blake2/std",
-    "confidential_identity/std",
     "confidential_identity_v1/std",
+    "confidential_identity_v2/std",
     "polymesh-primitives-derive/std",
     "schnorrkel/std",
     "sp-application-crypto/std",

--- a/primitives/src/cdd_id.rs
+++ b/primitives/src/cdd_id.rs
@@ -1,8 +1,8 @@
 use crate::{investor_zkproof_data::v1, IdentityId};
 
 use codec::{Decode, Encode};
-use confidential_identity as v2;
 use confidential_identity_v1 as ci_v1;
+use confidential_identity_v2 as v2;
 use polymesh_primitives_derive::SliceU8StrongTyped;
 #[cfg(feature = "std")]
 use polymesh_primitives_derive::{DeserializeU8StrongTyped, SerializeU8StrongTyped};

--- a/primitives/src/investor_zkproof_data/mod.rs
+++ b/primitives/src/investor_zkproof_data/mod.rs
@@ -1,6 +1,6 @@
 use crate::{IdentityId, InvestorUid, Ticker};
 
-use confidential_identity::ScopeClaimProof;
+use confidential_identity_v2::ScopeClaimProof;
 use schnorrkel::Signature;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};

--- a/primitives/src/investor_zkproof_data/v2.rs
+++ b/primitives/src/investor_zkproof_data/v2.rs
@@ -1,6 +1,6 @@
 use crate::{host_functions::native_rng, IdentityId, InvestorUid, Ticker};
 
-use confidential_identity::{
+use confidential_identity_v2::{
     claim_proofs::{slice_to_ristretto_point, slice_to_scalar, Investor},
     CddClaimData, InvestorTrait as _, ScopeClaimData, ScopeClaimProof,
 };

--- a/primitives/src/valid_proof_of_investor/v2.rs
+++ b/primitives/src/valid_proof_of_investor/v2.rs
@@ -1,8 +1,8 @@
 use crate::{investor_zkproof_data::v2::InvestorZKProofData, CddId, Claim, IdentityId, Scope};
 
-use confidential_identity::{
+use confidential_identity_v2::{
     claim_proofs::{slice_to_scalar, Verifier},
-    cryptography_core::cdd_claim::CddId as CryptoCddId,
+    confidential_identity_core::cdd_claim::CddId as CryptoCddId,
     CompressedRistretto, VerifierTrait as _,
 };
 


### PR DESCRIPTION
This PR is to resolve a Dependabot alert by removing the use of the `failure` crate that isn't supported anymore.

Also use published `confidential-identity` crates that depend on `bulletproofs` 4.0.
