### PR TITLE
MESH-1878 - Pin tracing-core package to work around logging bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,6 +5286,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances 0.1.0",
  "pallet-base",
  "pallet-committee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,9 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 clap = { version = "3.1.6", features = ["derive"] }
 rustc-hex = "2.1.0"
 
+# Pin version to work around substrate logging issue.
+tracing-core = "=0.1.26"
+
 # Substrate
 codec = { version = "3.0.0", package = "parity-scale-codec" }
 frame-support = "4.0.0-dev"


### PR DESCRIPTION
Work around logging issue in Substrate.

