### PR TITLE
Support rust stable in our rust debian image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
           docker push $IMAGE_NAME
   build-docker-rust-debian:
     environment:
-      RUST_BASE: 1.61.0
+      RUST_BASE: 1.63.0
       IMAGE_NAME: polymeshassociation/rust
     docker:
       - image: docker:stable-git
@@ -291,7 +291,7 @@ jobs:
           docker push $IMAGE_NAME
   build-docker-rust-alpine:
     environment:
-      RUST_BASE: 1.61.0
+      RUST_BASE: 1.63.0
       IMAGE_NAME: polymeshassociation/rust
     docker:
       - image: docker:stable-git

--- a/.docker/rust-nightly/Dockerfile.debian
+++ b/.docker/rust-nightly/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG rustbase=1.61.0
+ARG rustbase=1.63.0
 FROM rust:${rustbase}
 
 ARG toolchainversion=nightly-2022-05-10
@@ -21,6 +21,7 @@ RUN apt update && \
   apt clean
 RUN rustup toolchain install $TOOLCHAIN && \
   cargo +$TOOLCHAIN install rustfilt cargo-binutils && \
+  rustup component add rustfmt clippy llvm-tools-preview && \
   rustup component add rustfmt clippy llvm-tools-preview --toolchain $TOOLCHAIN && \
   rustup target add wasm32-unknown-unknown --toolchain $TOOLCHAIN && \
   cargo install sccache cargo-sonar cargo-audit cargo-deny cargo-outdated


### PR DESCRIPTION
Add the required rust components (rustfmt, clippy, llvm-tools-preview) to the stable compiler.  This is needed to support compiling Polymesh with the stable compiler in our CI pipelines.