### PR TITLE
Update tags to include latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
           at: .
       - run: |
           export VERSION=`grep ^version ./Cargo.toml | head -1 | cut -d"=" -f2 | sed 's/[^a-zA-Z0-9\.]//g'`
-          docker build -f ./.docker/Dockerfile.debian --tag $IMAGE_NAME:$CIRCLE_BRANCH-debian --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian .
+          docker build -f ./.docker/Dockerfile.debian --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-debian --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-debian .
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker push $IMAGE_NAME
   build-docker-distroless:
@@ -265,7 +265,7 @@ jobs:
           at: .
       - run: |
           export VERSION=`grep ^version ./Cargo.toml | head -1 | cut -d"=" -f2 | sed 's/[^a-zA-Z0-9\.]//g'`
-          docker build -f ./.docker/Dockerfile.distroless --tag $IMAGE_NAME:$CIRCLE_BRANCH-distroless --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-distroless .
+          docker build -f ./.docker/Dockerfile.distroless --tag $IMAGE_NAME:latest-$CIRCLE_BRANCH-distroless --tag $IMAGE_NAME:$VERSION-$CIRCLE_BRANCH-distroless .
           echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
           docker push $IMAGE_NAME
   build-docker-rust-debian:


### PR DESCRIPTION
Information to be added to docker hub readme once PR is merged:

Polymesh publishes two docker image variants - `distroless` and `debian`

For each variant, images are tagged as follows:
`latest-<branch>-<debian / distroless>` - contains the latest image for the particular environment (mainnet, testnet, staging or develop) that is available - this is generally the image you should use.
`<version>-<branch>-<debian / distroless>` - if you need to pin a particular version you can use the tag that references the version explicitly
