### PR TITLE
Update to new `spec_version` format

### DIFF
--- a/pallets/runtime/ci/src/runtime.rs
+++ b/pallets/runtime/ci/src/runtime.rs
@@ -56,8 +56,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh_ci"),
     impl_name: create_runtime_str!("polymesh_ci"),
     authoring_version: 1,
-    // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_001_000,
+    // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
+    // N.B. `d` is unpinned from the binary version
+    spec_version: 5_001_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -54,8 +54,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh_dev"),
     impl_name: create_runtime_str!("polymesh_dev"),
     authoring_version: 1,
-    // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_001_000,
+    // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
+    // N.B. `d` is unpinned from the binary version
+    spec_version: 5_001_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -51,8 +51,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh_mainnet"),
     impl_name: create_runtime_str!("polymesh_mainnet"),
     authoring_version: 1,
-    // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_001_000,
+    // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
+    // N.B. `d` is unpinned from the binary version
+    spec_version: 5_001_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -56,8 +56,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("polymesh_testnet"),
     impl_name: create_runtime_str!("polymesh_testnet"),
     authoring_version: 1,
-    // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_001_000,
+    // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
+    // N.B. `d` is unpinned from the binary version
+    spec_version: 5_001_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
## changelog

### new features

- updates to using `aaa.bbb.ccd` to specify `spec_version` allowing chain updates without bumping node binary version