### PR TITLE
Add granular check to portfolio move/lock.

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -969,6 +969,10 @@ decl_error! {
 }
 
 impl<T: Config> AssetFnTrait<T::AccountId, T::Origin> for Module<T> {
+    fn ensure_granular(ticker: &Ticker, value: Balance) -> DispatchResult {
+        Self::ensure_granular(ticker, value)
+    }
+
     /// Get the asset `id` balance of `who`.
     fn balance(ticker: &Ticker, who: IdentityId) -> Balance {
         Self::balance_of(ticker, &who)

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -55,6 +55,9 @@ pub trait AssetSubTrait {
 }
 
 pub trait AssetFnTrait<Account, Origin> {
+    /// Ensure the granularity of `value` meets the requirements of `ticker`.
+    fn ensure_granular(ticker: &Ticker, value: Balance) -> DispatchResult;
+
     fn balance(ticker: &Ticker, did: IdentityId) -> Balance;
 
     fn create_asset(

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -17,10 +17,7 @@
 //!
 //! The interface allows to accept portfolio custody
 
-use crate::{
-    traits::{balances::Memo, base, identity},
-    CommonConfig,
-};
+use crate::{asset::AssetFnTrait, balances::Memo, base, identity, CommonConfig};
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::weights::Weight;
@@ -80,6 +77,8 @@ pub trait WeightInfo {
 
 pub trait Config: CommonConfig + identity::Config + base::Config {
     type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
+    /// Asset module.
+    type Asset: AssetFnTrait<Self::AccountId, Self::Origin>;
     type WeightInfo: WeightInfo;
 }
 

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -89,7 +89,7 @@ benchmarks! {
         let a in 1 .. 500;
         let mut items = Vec::with_capacity(a as usize);
         let target = user::<T>("target", 0);
-        let first_ticker = make_asset::<T>(&target, Some(&Ticker::generate(0u64)));
+        let first_ticker = Ticker::generate_into(0u64);
         let amount = Balance::from(10u32);
         let portfolio_name = PortfolioName(vec![65u8; 5]);
         let next_portfolio_num = NextPortfolioNumber::get(&target.did());

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -17,7 +17,8 @@ use crate::*;
 use core::convert::TryInto;
 use frame_benchmarking::benchmarks;
 use polymesh_common_utilities::{
-    benchs::{user, AccountIdOf, User},
+    asset::Config as AssetConfig,
+    benchs::{make_asset, user, AccountIdOf, User},
     TestUtilsFn,
 };
 use polymesh_primitives::{AuthorizationData, PortfolioName, Signatory};
@@ -59,7 +60,7 @@ fn assert_custodian<T: Config>(pid: PortfolioId, custodian: &User<T>, holds: boo
 }
 
 benchmarks! {
-    where_clause { where T: TestUtilsFn<AccountIdOf<T>> }
+    where_clause { where T: TestUtilsFn<AccountIdOf<T>> + AssetConfig }
 
     create_portfolio {
         let target = user::<T>("target", 0);
@@ -88,7 +89,7 @@ benchmarks! {
         let a in 1 .. 500;
         let mut items = Vec::with_capacity(a as usize);
         let target = user::<T>("target", 0);
-        let first_ticker = Ticker::generate_into(0u64);
+        let first_ticker = make_asset::<T>(&target, Some(&Ticker::generate(0u64)));
         let amount = Balance::from(10u32);
         let portfolio_name = PortfolioName(vec![65u8; 5]);
         let next_portfolio_num = NextPortfolioNumber::get(&target.did());
@@ -96,7 +97,7 @@ benchmarks! {
         let user_portfolio = PortfolioId::user_portfolio(target.did(), next_portfolio_num.clone());
 
         for x in 0..a as u64 {
-            let ticker = Ticker::generate_into(x);
+            let ticker = make_asset::<T>(&target, Some(&Ticker::generate(x)));
             items.push(MovePortfolioItem {
                 ticker,
                 amount: amount,

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -55,7 +55,10 @@ use frame_support::{
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::traits::balances::Memo;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
-pub use polymesh_common_utilities::traits::portfolio::{Config, Event, WeightInfo};
+pub use polymesh_common_utilities::traits::{
+    asset::AssetFnTrait,
+    portfolio::{Config, Event, WeightInfo},
+};
 use polymesh_primitives::{
     extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, Balance, IdentityId,
     PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber, SecondaryKey, Ticker,
@@ -576,6 +579,7 @@ impl<T: Config> Module<T> {
         ticker: &Ticker,
         amount: Balance,
     ) -> DispatchResult {
+        T::Asset::ensure_granular(ticker, amount)?;
         Self::portfolio_asset_balances(portfolio, ticker)
             .saturating_sub(Self::locked_assets(portfolio, ticker))
             .checked_sub(amount)

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -286,6 +286,7 @@ macro_rules! misc_pallet_impls {
 
         impl pallet_portfolio::Config for Runtime {
             type Event = Event;
+            type Asset = Asset;
             type WeightInfo = polymesh_weights::pallet_portfolio::WeightInfo;
         }
 


### PR DESCRIPTION
## changelog

### modified logic

- Extrinsic `Portfolio.movePortfolioFunds` will throw error `InvalidGranularity` if trying to move a fraction of a non-divisible token.
- Settlement affirms calls will also check granularity of token transfer when trying to lock the tokens.  Will throw a `FailedToLockTokens` error.
