### PR TITLE
Update Mainnet to 5.0.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
           docker push --all-tags $IMAGE_NAME
   publish-github-release:
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
     steps:
       - attach_workspace:
           at: ./assets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "5.0.3"
+version = "5.0.4"
 authors = ["Polymath"]
 build = "build.rs"
 edition = "2021"

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -947,6 +947,10 @@ decl_error! {
 }
 
 impl<T: Config> AssetFnTrait<T::AccountId, T::Origin> for Module<T> {
+    fn ensure_granular(ticker: &Ticker, value: Balance) -> DispatchResult {
+        Self::ensure_granular(ticker, value)
+    }
+
     /// Get the asset `id` balance of `who`.
     fn balance(ticker: &Ticker, who: IdentityId) -> Balance {
         Self::balance_of(ticker, &who)

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -55,6 +55,9 @@ pub trait AssetSubTrait {
 }
 
 pub trait AssetFnTrait<Account, Origin> {
+    /// Ensure the granularity of `value` meets the requirements of `ticker`.
+    fn ensure_granular(ticker: &Ticker, value: Balance) -> DispatchResult;
+
     fn balance(ticker: &Ticker, did: IdentityId) -> Balance;
 
     fn create_asset(

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -17,10 +17,7 @@
 //!
 //! The interface allows to accept portfolio custody
 
-use crate::{
-    traits::{balances::Memo, base, identity},
-    CommonConfig,
-};
+use crate::{asset::AssetFnTrait, balances::Memo, base, identity, CommonConfig};
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::weights::Weight;
@@ -80,6 +77,8 @@ pub trait WeightInfo {
 
 pub trait Config: CommonConfig + identity::Config + base::Config {
     type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
+    /// Asset module.
+    type Asset: AssetFnTrait<Self::AccountId, Self::Origin>;
     type WeightInfo: WeightInfo;
 }
 

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -17,7 +17,8 @@ use crate::*;
 use core::convert::TryInto;
 use frame_benchmarking::benchmarks;
 use polymesh_common_utilities::{
-    benchs::{user, AccountIdOf, User},
+    asset::Config as AssetConfig,
+    benchs::{make_asset, user, AccountIdOf, User},
     TestUtilsFn,
 };
 use polymesh_primitives::{AuthorizationData, PortfolioName, Signatory};
@@ -59,7 +60,7 @@ fn assert_custodian<T: Config>(pid: PortfolioId, custodian: &User<T>, holds: boo
 }
 
 benchmarks! {
-    where_clause { where T: TestUtilsFn<AccountIdOf<T>> }
+    where_clause { where T: TestUtilsFn<AccountIdOf<T>> + AssetConfig }
 
     create_portfolio {
         let target = user::<T>("target", 0);
@@ -96,7 +97,7 @@ benchmarks! {
         let user_portfolio = PortfolioId::user_portfolio(target.did(), next_portfolio_num.clone());
 
         for x in 0..a as u64 {
-            let ticker = Ticker::generate_into(x);
+            let ticker = make_asset::<T>(&target, Some(&Ticker::generate(x)));
             items.push(MovePortfolioItem {
                 ticker,
                 amount: amount,

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -56,7 +56,10 @@ use frame_support::{
 use pallet_identity::{self as identity, PermissionedCallOriginData};
 use polymesh_common_utilities::traits::balances::Memo;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
-pub use polymesh_common_utilities::traits::portfolio::{Config, Event, WeightInfo};
+pub use polymesh_common_utilities::traits::{
+    asset::AssetFnTrait,
+    portfolio::{Config, Event, WeightInfo},
+};
 use polymesh_primitives::{
     extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, Balance, IdentityId,
     PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber, SecondaryKey, Ticker,
@@ -568,6 +571,7 @@ impl<T: Config> Module<T> {
         ticker: &Ticker,
         amount: Balance,
     ) -> DispatchResult {
+        T::Asset::ensure_granular(ticker, amount)?;
         Self::portfolio_asset_balances(portfolio, ticker)
             .saturating_sub(Self::locked_assets(portfolio, ticker))
             .checked_sub(amount)

--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -455,9 +455,8 @@ impl<T: Config> Module<T> {
         match pallet {
             // These pallets are subsidised by the paying key.
             b"Asset" | b"ComplianceManager" | b"CorporateAction" | b"ExternalAgents"
-            | b"Permissions" | b"Portfolio" | b"Settlement" | b"Statistics" | b"Sto" => {
-                Ok(Some(()))
-            }
+            | b"Permissions" | b"Portfolio" | b"Settlement" | b"Statistics" | b"Sto"
+            | b"Balances" => Ok(Some(())),
             // The user key needs to pay for `remove_paying_key` call.
             b"Relayer" => Ok(None),
             // Reject all other pallets.

--- a/pallets/runtime/ci/src/runtime.rs
+++ b/pallets/runtime/ci/src/runtime.rs
@@ -163,6 +163,7 @@ parameter_types! {
     pub const SlashDeferDuration: pallet_staking::EraIndex = 14; // 1/2 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);

--- a/pallets/runtime/ci/src/runtime.rs
+++ b/pallets/runtime/ci/src/runtime.rs
@@ -57,7 +57,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("polymesh_ci"),
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_000_003,
+    spec_version: 5_000_004,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -245,6 +245,7 @@ macro_rules! misc_pallet_impls {
             type MaxIterations = MaxIterations;
             type MinSolutionScoreBump = MinSolutionScoreBump;
             type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+            type OffendingValidatorsThreshold = OffendingValidatorsThreshold;
             type UnsignedPriority = StakingUnsignedPriority;
             type RequiredAddOrigin = Self::SlashCancelOrigin;
             type RequiredRemoveOrigin = Self::SlashCancelOrigin;

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -286,6 +286,7 @@ macro_rules! misc_pallet_impls {
 
         impl pallet_portfolio::Config for Runtime {
             type Event = Event;
+            type Asset = Asset;
             type WeightInfo = polymesh_weights::pallet_portfolio::WeightInfo;
         }
 

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -160,6 +160,7 @@ parameter_types! {
     pub const SlashDeferDuration: pallet_staking::EraIndex = 4;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -55,7 +55,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("polymesh_dev"),
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_000_003,
+    spec_version: 5_000_004,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -157,6 +157,7 @@ parameter_types! {
     pub const SlashDeferDuration: pallet_staking::EraIndex = 14; // 1/2 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -52,7 +52,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("polymesh_mainnet"),
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_000_003,
+    spec_version: 5_000_004,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -163,6 +163,7 @@ parameter_types! {
     pub const SlashDeferDuration: pallet_staking::EraIndex = 14; // 1/2 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -57,7 +57,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("polymesh_testnet"),
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccc` should match node version v`aaa.bbb.ccc`
-    spec_version: 5_000_003,
+    spec_version: 5_000_004,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -7,6 +7,7 @@ use frame_support::{
     weights::{DispatchInfo, Pays, PostDispatchInfo, Weight},
     StorageMap,
 };
+use frame_system;
 use pallet_relayer::Subsidy;
 use polymesh_common_utilities::{
     constants::currency::POLY, protocol_fee::ProtocolOp,
@@ -39,6 +40,12 @@ fn call_balance_transfer(val: Balance) -> <TestStorage as frame_system::Config>:
     Call::Balances(pallet_balances::Call::transfer {
         dest: MultiAddress::Id(AccountKeyring::Alice.to_account_id()),
         value: val,
+    })
+}
+
+fn call_system_remark(size: usize) -> <TestStorage as frame_system::Config>::Call {
+    Call::System(frame_system::Call::remark {
+        remark: vec![0; size],
     })
 }
 
@@ -474,12 +481,12 @@ fn do_relayer_transaction_and_protocol_fees_test() {
         TransactionError::PalletNotSubsidised as u8,
     ));
 
-    // Pallet Balance is not subsidised.
+    // Pallet System is not subsidised.
     // test `validate`
     let pre_err = ChargeTransactionPayment::from(0)
         .validate(
             &bob.acc(),
-            &call_balance_transfer(42),
+            &call_system_remark(42),
             &info_from_weight(5),
             len,
         )
@@ -491,7 +498,7 @@ fn do_relayer_transaction_and_protocol_fees_test() {
     let pre_err = ChargeTransactionPayment::from(0)
         .pre_dispatch(
             &bob.acc(),
-            &call_balance_transfer(42),
+            &call_system_remark(42),
             &info_from_weight(5),
             len,
         )

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -548,6 +548,7 @@ parameter_types! {
     pub const BondingDuration: EraIndex = 3;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
     pub const MaxNominatorRewardedPerValidator: u32 = 64;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const UnsignedPriority: u64 = 1 << 20;
     pub const MinSolutionScoreBump: Perbill = Perbill::zero();
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
@@ -611,6 +612,7 @@ impl Config for Test {
     type MaxIterations = MaxIterations;
     type MinSolutionScoreBump = MinSolutionScoreBump;
     type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+    type OffendingValidatorsThreshold = OffendingValidatorsThreshold;
     type UnsignedPriority = UnsignedPriority;
     type OffchainSolutionWeightLimit = polymesh_runtime_common::OffchainSolutionWeightLimit;
     type WeightInfo = polymesh_weights::pallet_staking::WeightInfo;

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -2558,10 +2558,11 @@ fn slash_in_old_span_does_not_deselect() {
             1,
         );
 
-        // not forcing for zero-slash and previous span.
-        assert_eq!(Staking::force_era(), Forcing::NotForcing);
-        assert!(<Validators<Test>>::contains_key(11));
-        assert!(Session::validators().contains(&11));
+        // the validator doesn't get chilled again
+        assert!(<Validators<Test>>::iter().any(|(stash, _)| stash == 11));
+
+        // but we are still forcing a new era
+        assert_eq!(Staking::force_era(), Forcing::ForceNew);
 
         on_offence_in_era(
             &[OffenceDetails {
@@ -2576,10 +2577,13 @@ fn slash_in_old_span_does_not_deselect() {
             1,
         );
 
-        // or non-zero.
-        assert_eq!(Staking::force_era(), Forcing::NotForcing);
-        assert!(<Validators<Test>>::contains_key(11));
-        assert!(Session::validators().contains(&11));
+        // the validator doesn't get chilled again
+        assert!(<Validators<Test>>::iter().any(|(stash, _)| stash == 11));
+
+        // but it's disabled
+        assert!(is_disabled(10));
+        // and we are still forcing a new era
+        assert_eq!(Staking::force_era(), Forcing::ForceNew);
     });
 }
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -162,6 +162,7 @@ parameter_types! {
     pub const MaxIterations: u32 = 10;
     pub MinSolutionScoreBump: Perbill = Perbill::from_rational(5u32, 10_000);
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const IndexDeposit: Balance = DOLLARS;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -54,8 +54,8 @@ pub struct UserData<T: Config> {
     pub did: IdentityId,
 }
 
-impl<T: Config> From<User<T>> for UserData<T> {
-    fn from(user: User<T>) -> Self {
+impl<T: Config> From<&User<T>> for UserData<T> {
+    fn from(user: &User<T>) -> Self {
         Self {
             account: user.account(),
             did: user.did(),
@@ -118,6 +118,7 @@ fn fund_portfolio<T: Config>(portfolio: &PortfolioId, ticker: &Ticker, amount: B
 }
 
 fn setup_leg_and_portfolio<T: Config + TestUtilsFn<AccountIdOf<T>>>(
+    owner: &User<T>,
     to_user: Option<UserData<T>>,
     from_user: Option<UserData<T>>,
     index: u32,
@@ -126,7 +127,7 @@ fn setup_leg_and_portfolio<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     receiver_portfolios: &mut Vec<PortfolioId>,
 ) {
     let variance = index + 1;
-    let ticker = Ticker::generate_into(variance.into());
+    let ticker = make_asset::<T>(owner, Some(&Ticker::generate(variance.into())));
     let portfolio_from = generate_portfolio::<T>("", variance + 500, from_user);
     let _ = fund_portfolio::<T>(&portfolio_from, &ticker, 500u32.into());
     let portfolio_to = generate_portfolio::<T>("to_did", variance + 800, to_user);
@@ -151,7 +152,7 @@ fn generate_portfolio<T: Config + TestUtilsFn<AccountIdOf<T>>>(
                 .generate_did()
                 .seed(pseudo_random_no)
                 .build(portfolio_to);
-            UserData::from(user)
+            UserData::from(&user)
         }
         Some(u) => u,
     };
@@ -238,7 +239,7 @@ fn emulate_add_instruction<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     let mut receiver_portfolios: Vec<PortfolioId> = Vec::with_capacity(l as usize);
     // create venue
     let user = creator::<T>();
-    let user_data = UserData::from(user);
+    let user_data = UserData::from(&user);
     let venue_id = create_venue_::<T>(user_data.did, vec![user_data.account.clone()]);
 
     // Create legs vector.
@@ -247,6 +248,7 @@ fn emulate_add_instruction<T: Config + TestUtilsFn<AccountIdOf<T>>>(
         // Assumption here is that instruction will never be executed as still there is one auth pending.
         for n in 0..l {
             setup_leg_and_portfolio::<T>(
+                &user,
                 None,
                 Some(user_data.clone()),
                 n,
@@ -385,8 +387,8 @@ fn setup_affirm_instruction<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     let mut portfolios_to: Vec<PortfolioId> = Vec::with_capacity(l as usize);
     let mut legs: Vec<Leg> = Vec::with_capacity(l as usize);
     let mut tickers = Vec::with_capacity(l as usize);
-    let from_data = UserData::from(from.clone());
-    let to_data = UserData::from(to);
+    let from_data = UserData::from(&from);
+    let to_data = UserData::from(&to);
 
     for n in 0..l {
         tickers.push(make_asset::<T>(

--- a/pallets/staking/src/slashing.rs
+++ b/pallets/staking/src/slashing.rs
@@ -57,8 +57,8 @@ use super::{
 use scale_info::TypeInfo;
 use sp_runtime::{traits::{Zero, Saturating}, RuntimeDebug, DispatchResult};
 use frame_support::{
-    StorageMap, StorageDoubleMap, ensure,
-    traits::{Currency, OnUnbalanced, Imbalance},
+    StorageValue, StorageMap, StorageDoubleMap, ensure,
+    traits::{Currency, Get, Imbalance, OnUnbalanced},
 };
 use sp_std::vec::Vec;
 use codec::{Encode, Decode};
@@ -289,14 +289,12 @@ pub(crate) fn compute_slash<T: Config>(params: SlashParams<T>)
             // not continue in the next election. also end the slashing span.
             spans.end_span(now);
             <Module<T>>::chill_stash(stash);
-
-            // make sure to disable validator till the end of this session
-            if T::SessionInterface::disable_validator(stash).unwrap_or(false) {
-                // force a new era, to select a new validator set
-                <Module<T>>::ensure_new_era()
-            }
         }
     }
+
+    // add the validator to the offenders list and make sure it is disabled for
+    // the duration of the era
+    add_offending_validator::<T>(params.stash, true);
 
     let mut nominators_slashed = Vec::new();
 
@@ -333,13 +331,52 @@ fn kick_out_if_recent<T: Config>(
     if spans.era_span(params.slash_era).map(|s| s.index) == Some(spans.span_index()) {
         spans.end_span(params.now);
         <Module<T>>::chill_stash(params.stash);
-
-        // make sure to disable validator till the end of this session
-        if T::SessionInterface::disable_validator(params.stash).unwrap_or(false) {
-            // force a new era, to select a new validator set
-            <Module<T>>::ensure_new_era()
-        }
     }
+
+    // add the validator to the offenders list but since there's no slash being
+    // applied there's no need to disable the validator
+    add_offending_validator::<T>(params.stash, false);
+}
+
+/// Add the given validator to the offenders list and optionally disable it.
+/// If after adding the validator `OffendingValidatorsThreshold` is reached
+/// a new era will be forced.
+fn add_offending_validator<T: Config>(stash: &T::AccountId, disable: bool) {
+    <Module<T> as Store>::OffendingValidators::mutate(|offending| {
+        let validators = T::SessionInterface::validators();
+        let validator_index = match validators.iter().position(|i| i == stash) {
+            Some(index) => index,
+            None => return,
+        };
+        let validator_index_u32 = validator_index as u32;
+
+        match offending.binary_search_by_key(&validator_index_u32, |(index, _)| *index) {
+            // this is a new offending validator
+            Err(index) => {
+                offending.insert(index, (validator_index_u32, disable));
+
+                let offending_threshold =
+                    T::OffendingValidatorsThreshold::get() * validators.len() as u32;
+
+                if offending.len() >= offending_threshold as usize {
+                    // force a new era, to select a new validator set
+                    <Module<T>>::ensure_new_era()
+                }
+
+                if disable {
+                    T::SessionInterface::disable_validator(validator_index_u32);
+                }
+            },
+            Ok(index) => {
+                if disable && !offending[index].1 {
+                    // the validator had previously offended without being disabled,
+                    // let's make sure we disable it now
+                    offending[index].1 = true;
+                    T::SessionInterface::disable_validator(validator_index_u32);
+                }
+            },
+        }
+    });
 }
 
 /// Slash nominators. Accepts general parameters and the prior slash percentage of the validator.

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,11 +5,7 @@ set -e
 echo "*** Initializing WASM build environment"
 
 # Fetch name of preferred toolchain...
-TOOLCHAIN=$(< $(dirname $0)/../rust-toolchain)
+TOOLCHAIN=stable
 # ...and install it + wasm32 target.
 rustup toolchain install $TOOLCHAIN
 rustup target add wasm32-unknown-unknown --toolchain $TOOLCHAIN
-
-# Install wasm-gc. It's useful for stripping slimming down wasm binaries.
-command -v wasm-gc || \
-	cargo install --git https://github.com/alexcrichton/wasm-gc --force


### PR DESCRIPTION
## changelog

### new features

- Allows relayer functionality for the `Balances` module

### modified logic

- Extrinsic `Portfolio.movePortfolioFunds` will throw error `InvalidGranularity` if trying to move a fraction of a non-divisible token.
- Settlement affirms calls will also check granularity of token transfer when trying to lock the tokens.  Will throw a `FailedToLockTokens` error.
- Fixes on-chain election issues following offline offenses