### PR TITLE
MESH-1907 Improve payment_queryInfo RPC endpoint.

### DIFF
--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -840,6 +840,12 @@ macro_rules! runtime_apis {
                     let uxt: UncheckedExtrinsic = codec::Decode::decode(&mut &*encoded_xt).ok()?;
                     Some(TransactionPayment::query_info(uxt, len))
                 }
+
+                fn query_fee_details(encoded_xt: Vec<u8>) -> Option<pallet_transaction_payment::FeeDetails<Balance>> {
+                    let len = encoded_xt.len() as u32;
+                    let uxt: UncheckedExtrinsic = codec::Decode::decode(&mut &*encoded_xt).ok()?;
+                    Some(TransactionPayment::query_fee_details(uxt, len))
+                }
             }
 
             impl sp_session::SessionKeys<Block> for Runtime {

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -835,8 +835,10 @@ macro_rules! runtime_apis {
                 Block,
                 UncheckedExtrinsic,
             > for Runtime {
-                fn query_info(uxt: UncheckedExtrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-                    TransactionPayment::query_info(uxt, len)
+                fn query_info(encoded_xt: Vec<u8>) -> Option<RuntimeDispatchInfo<Balance>> {
+                    let len = encoded_xt.len() as u32;
+                    let uxt: UncheckedExtrinsic = codec::Decode::decode(&mut &*encoded_xt).ok()?;
+                    Some(TransactionPayment::query_info(uxt, len))
                 }
             }
 

--- a/rpc/runtime-api/src/transaction_payment.rs
+++ b/rpc/runtime-api/src/transaction_payment.rs
@@ -1,7 +1,21 @@
-use codec::Codec;
+use codec::{Codec, Encode, Output};
 pub use pallet_transaction_payment::{FeeDetails, InclusionFee, RuntimeDispatchInfo};
 use polymesh_primitives::Balance;
 use sp_std::vec::Vec;
+
+/// `Encoded` is used to pass the raw transaction to the runtime.
+/// This type is only used to support runtimes with the old v1 `query_info` interface.
+#[derive(Clone, Debug)]
+pub struct Encoded(pub Vec<u8>);
+
+impl Encode for Encoded {
+    fn size_hint(&self) -> usize {
+        self.0.len()
+    }
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        dest.write(&self.0);
+    }
+}
 
 sp_api::decl_runtime_apis! {
     #[api_version(2)]
@@ -10,7 +24,7 @@ sp_api::decl_runtime_apis! {
     {
         fn query_info(encoded_xt: Vec<u8>) -> Option<RuntimeDispatchInfo<Balance>>;
         #[changed_in(2)]
-        fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
+        fn query_info(uxt: Encoded, len: u32) -> RuntimeDispatchInfo<Balance>;
 
         fn query_fee_details(encoded_xt: Vec<u8>) -> Option<FeeDetails<Balance>>;
     }

--- a/rpc/runtime-api/src/transaction_payment.rs
+++ b/rpc/runtime-api/src/transaction_payment.rs
@@ -1,5 +1,5 @@
 use codec::Codec;
-use pallet_transaction_payment::RuntimeDispatchInfo;
+pub use pallet_transaction_payment::{FeeDetails, InclusionFee, RuntimeDispatchInfo};
 use polymesh_primitives::Balance;
 use sp_std::vec::Vec;
 
@@ -11,5 +11,7 @@ sp_api::decl_runtime_apis! {
         fn query_info(encoded_xt: Vec<u8>) -> Option<RuntimeDispatchInfo<Balance>>;
         #[changed_in(2)]
         fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
+
+            fn query_fee_details(encoded_xt: Vec<u8>) -> Option<FeeDetails<Balance>>;
     }
 }

--- a/rpc/runtime-api/src/transaction_payment.rs
+++ b/rpc/runtime-api/src/transaction_payment.rs
@@ -12,6 +12,6 @@ sp_api::decl_runtime_apis! {
         #[changed_in(2)]
         fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
 
-            fn query_fee_details(encoded_xt: Vec<u8>) -> Option<FeeDetails<Balance>>;
+        fn query_fee_details(encoded_xt: Vec<u8>) -> Option<FeeDetails<Balance>>;
     }
 }

--- a/rpc/runtime-api/src/transaction_payment.rs
+++ b/rpc/runtime-api/src/transaction_payment.rs
@@ -1,11 +1,15 @@
 use codec::Codec;
 use pallet_transaction_payment::RuntimeDispatchInfo;
 use polymesh_primitives::Balance;
+use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
+    #[api_version(2)]
     pub trait TransactionPaymentApi<Extrinsic> where
         Extrinsic: Codec,
     {
+        fn query_info(encoded_xt: Vec<u8>) -> Option<RuntimeDispatchInfo<Balance>>;
+        #[changed_in(2)]
         fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
     }
 }

--- a/rpc/src/transaction_payment.rs
+++ b/rpc/src/transaction_payment.rs
@@ -17,11 +17,11 @@
 //! RPC interface for the transaction payment module.
 
 pub use self::gen_client::Client as TransactionPaymentClient;
-use codec::{Codec, Decode};
+use codec::Codec;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 pub use node_rpc_runtime_api::transaction_payment::{
-    FeeDetails, InclusionFee, RuntimeDispatchInfo,
+    Encoded, FeeDetails, InclusionFee, RuntimeDispatchInfo,
     TransactionPaymentApi as TransactionPaymentRuntimeApi,
 };
 use polymesh_primitives::Balance;
@@ -120,11 +120,8 @@ where
             Some(1) => {
                 let encoded_len = encoded_xt.len() as u32;
 
-                let uxt: Extrinsic = Decode::decode(&mut &*encoded_xt).map_err(|e| RpcError {
-                    code: ErrorCode::ServerError(Error::DecodeError.into()),
-                    message: "Unable to query dispatch info.".into(),
-                    data: Some(format!("{:?}", e).into()),
-                })?;
+                // Pass the raw encoded bytes to the runtime, without decoding them here.
+                let uxt = Encoded(encoded_xt.0);
                 #[allow(deprecated)]
                 api.query_info_before_version_2(&at, uxt, encoded_len)
                     .map_err(|e| RpcError {


### PR DESCRIPTION
## changelog

### new features

- Allow `payment_queryInfo` RPC endpoint to work even when the RPC node is a different version from the chain runtime.

### modified API

- No breaking API changes.
- Add `payment_queryFeeDetails` RPC endpoint.

### modified logic

- Move the decode logic from the RPC wrapper into the chain runtime.  This is an internal change between the host binary and the chain runtime.
