### PR TITLE
Update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: small
     environment:
       VERBOSE: "1"
@@ -13,7 +13,7 @@ jobs:
           command: ./scripts/rustfmt.sh
   check-storage-version:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: small
     environment:
       VERBOSE: "1"
@@ -24,7 +24,7 @@ jobs:
           command: ./scripts/check_storage_versions.sh
   build:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -62,7 +62,7 @@ jobs:
             - "~/.cache/sccache"
   build-ci:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -95,7 +95,7 @@ jobs:
       image: ubuntu-2004:current
     resource_class: arm.xlarge
     environment:
-      - NIGHTLY: "nightly-2022-05-10"
+      - NIGHTLY: "nightly-2022-11-02"
       - VERBOSE: "1"
       - RUSTFLAGS: -D warnings
       - RUSTC_WRAPPER: /usr/local/cargo/bin/sccache
@@ -141,7 +141,7 @@ jobs:
             - "~/.cache/sccache"
   benchmark-build:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -186,7 +186,7 @@ jobs:
           no_output_timeout: 1h
   migration-tests:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: large
     environment:
       - VERBOSE: "1"
@@ -210,7 +210,7 @@ jobs:
             - "/usr/local/cargo"
   test:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: large
     environment:
       - VERBOSE: "1"
@@ -249,7 +249,7 @@ jobs:
             - "~/.cache/sccache"
   coverage:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: xlarge
     environment:
       - VERBOSE: "1"
@@ -299,7 +299,7 @@ jobs:
           no_output_timeout: 10m
   clippy:
     docker:
-      - image: polymeshassociation/rust:debian-nightly-2022-09-15
+      - image: polymeshassociation/rust:debian-nightly-2022-11-02
     resource_class: xlarge
     environment:
       - VERBOSE: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
           docker push --all-tags $IMAGE_NAME
   build-docker-rust-debian:
     environment:
-      RUST_BASE: 1.63.0
+      RUST_BASE: 1.65.0
       IMAGE_NAME: polymeshassociation/rust
     docker:
       - image: docker:stable-git
@@ -405,7 +405,7 @@ jobs:
           docker push $IMAGE_NAME
   build-docker-rust-alpine:
     environment:
-      RUST_BASE: 1.63.0
+      RUST_BASE: 1.65.0
       IMAGE_NAME: polymeshassociation/rust
     docker:
       - image: docker:stable-git
@@ -425,7 +425,7 @@ jobs:
           docker push $IMAGE_NAME
   build-docker-arm64-rust-debian:
     environment:
-      RUST_BASE: 1.63.0
+      RUST_BASE: 1.65.0
       IMAGE_NAME: polymeshassociation/rust-arm64
     machine:
       image: ubuntu-2004:current
@@ -444,7 +444,7 @@ jobs:
           docker push --all-tags $IMAGE_NAME
   build-docker-arm64-rust-alpine:
     environment:
-      RUST_BASE: 1.63.0
+      RUST_BASE: 1.65.0
       IMAGE_NAME: polymeshassociation/rust-arm64
     machine:
       image: ubuntu-2004:current

--- a/.docker/arm64/rust/Dockerfile.alpine
+++ b/.docker/arm64/rust/Dockerfile.alpine
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
         openssl-dev \
         make \
         pkgconfig \
+        protobuf \
         rsync
 RUN rustup toolchain install $TOOLCHAIN && \
   rustup target add wasm32-unknown-unknown && \

--- a/.docker/arm64/rust/Dockerfile.debian
+++ b/.docker/arm64/rust/Dockerfile.debian
@@ -16,6 +16,7 @@ RUN apt update && \
   libssl-dev \
   pkg-config \
   rsync \
+  protobuf-compiler \
   -y --no-install-recommends && \
   apt autoremove -y && \
   apt clean

--- a/.docker/rust-nightly/Dockerfile.alpine
+++ b/.docker/rust-nightly/Dockerfile.alpine
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
         openssl-dev \
         make \
         pkgconfig \
+        protobuf \
         rsync
 RUN rustup toolchain install $TOOLCHAIN && \
         rustup target add wasm32-unknown-unknown --toolchain $TOOLCHAIN

--- a/.docker/rust-nightly/Dockerfile.debian
+++ b/.docker/rust-nightly/Dockerfile.debian
@@ -16,6 +16,7 @@ RUN apt update && \
   libssl-dev \
   pkg-config \
   rsync \
+  protobuf-compiler \
   -y --no-install-recommends && \
   apt autoremove -y && \
   apt clean

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -5,7 +5,7 @@ function run_tests() {
     LLVM_PROFILE_FILE="json5format-%m.profraw" \
     SKIP_WASM_BUILD=1 RUST_BACKTRACE=1 \
     INTEGRATION_TEST=1 \
-    cargo +nightly-2022-09-15 test --tests \
+    cargo +nightly-2022-11-02 test --tests \
         --package pallet-staking \
         --package pallet-group \
         --package pallet-sudo \
@@ -32,10 +32,10 @@ function get_tests_filenames() {
 
 run_tests
 
-cargo +nightly-2022-09-15 profdata -- merge -sparse $(find . -name 'json5format-*.profraw') -o json5format.profdata
+cargo +nightly-2022-11-02 profdata -- merge -sparse $(find . -name 'json5format-*.profraw') -o json5format.profdata
 
 if [[ -v CIRCLECI ]]; then
-    cargo +nightly-2022-09-15 cov -- export \
+    cargo +nightly-2022-11-02 cov -- export \
     $( get_tests_filenames ) \
     --format='lcov' \
     --instr-profile=json5format.profdata \
@@ -50,7 +50,7 @@ if [[ -v CIRCLECI ]]; then
 
     bash <(curl -s https://codecov.io/bash)
 else
-    cargo +nightly-2022-09-15 cov -- report \
+    cargo +nightly-2022-11-02 cov -- report \
     $( get_tests_filenames ) \
     --instr-profile=json5format.profdata \
     --use-color \


### PR DESCRIPTION
Add `protoc` binary to rust docker images for supporting newer Substrate builds.
Update to Rust stable 1.65 and nightly 2022-11-02 compiler versions.

And forced rebuilding of our Rust 2022-11-02 nightly docker images.