### PR TITLE
Calculate slot based on timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "chrono",
  "clap 3.2.22",

--- a/pallets/runtime/tests/src/asset_metadata_test.rs
+++ b/pallets/runtime/tests/src/asset_metadata_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::create_token,
+    asset_test::{create_token, set_timestamp},
     exec_noop, exec_ok,
     storage::{TestStorage, User},
     ExtBuilder,
@@ -587,7 +587,7 @@ fn check_locked_until() {
         );
 
         // Move time forward until after `unlock_timestamp`.
-        Timestamp::set_timestamp(unlock_timestamp + 1_000);
+        set_timestamp(unlock_timestamp + 1_000);
 
         // Updated unlocked metadata value for global key.
         exec_ok!(Asset::set_asset_metadata(

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -47,6 +47,7 @@ use polymesh_primitives::{
     PortfolioName, SecondaryKey, Signatory, Ticker,
 };
 use rand::Rng;
+use sp_consensus_babe::Slot;
 use sp_io::hashing::keccak_256;
 use sp_runtime::AnySignature;
 use sp_std::{
@@ -80,7 +81,16 @@ fn now() -> u64 {
 }
 
 fn set_time_to_now() {
-    Timestamp::set_timestamp(now());
+    set_timestamp(now());
+}
+
+fn slot_duration() -> u64 {
+    pallet_babe::Pallet::<TestStorage>::slot_duration()
+}
+
+pub(crate) fn set_timestamp(n: u64) {
+    pallet_babe::CurrentSlot::<TestStorage>::set(Slot::from(n / slot_duration()));
+    Timestamp::set_timestamp(n);
 }
 
 pub(crate) fn max_len() -> u32 {
@@ -472,7 +482,7 @@ fn register_ticker() {
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner.did), true);
         assert_eq!(Asset::is_ticker_available(&ticker), false);
 
-        Timestamp::set_timestamp(now() + 10001);
+        set_timestamp(now() + 10001);
 
         assert_eq!(Asset::is_ticker_registry_valid(&ticker, owner.did), false);
         assert_eq!(Asset::is_ticker_available(&ticker), true);
@@ -1408,7 +1418,7 @@ fn classic_ticker_expired_thus_available() {
     .build()
     .execute_with(|| {
         let signer = Origin::signed(user);
-        Timestamp::set_timestamp(1);
+        set_timestamp(1);
         assert_noop!(
             Asset::claim_classic_ticker(signer, ticker, ethereum::EcdsaSignature([0; 65])),
             AssetError::TickerRegistrationExpired
@@ -1558,7 +1568,7 @@ fn classic_ticker_claim_works() {
 
         // Fast forward, thereby expiring `GAMMA` for which `is_created: true` holds.
         // Thus, fee isn't waived and is charged.
-        Timestamp::set_timestamp(expire_after + 1);
+        set_timestamp(expire_after + 1);
         assert_ok!(create(alice, "GAMMA", init_bal - fee - fee));
 
         // Now `DELTA` has expired as well. Bob registers it, so its not classic anymore and fee is charged.
@@ -1579,7 +1589,7 @@ fn classic_ticker_claim_works() {
 
         // Travel back in time to unexpire `ZETA`,
         // transfer it to Charlie, and ensure its not classic anymore.
-        Timestamp::set_timestamp(0);
+        set_timestamp(0);
         let zeta = ticker("ZETA");
         assert!(ClassicTickers::get(&zeta).is_some());
         let auth_id_alice = Identity::add_auth(
@@ -1726,7 +1736,7 @@ fn next_checkpoint_is_updated_we() {
         _ => panic!("period should be fixed"),
     };
     let period_ms = period_secs * 1000;
-    Timestamp::set_timestamp(start);
+    set_timestamp(start);
     assert_eq!(start, <TestStorage as asset::Config>::UnixTime::now());
 
     let owner = User::new(AccountKeyring::Alice);
@@ -1762,7 +1772,7 @@ fn next_checkpoint_is_updated_we() {
     assert_eq!(vec![checkpoint2], checkpoint_ats(ticker));
 
     let transfer = |at| {
-        Timestamp::set_timestamp(at);
+        set_timestamp(at);
         default_transfer(owner, bob, ticker, total_supply / 2);
     };
 
@@ -1798,7 +1808,7 @@ fn non_recurring_schedule_works_we() {
     let start: u64 = 1_700_000_000_000;
     // Non-recuring schedule.
     let period = CalendarPeriod::default();
-    Timestamp::set_timestamp(start);
+    set_timestamp(start);
     assert_eq!(start, <TestStorage as asset::Config>::UnixTime::now());
 
     let owner = User::new(AccountKeyring::Alice);
@@ -1851,7 +1861,7 @@ fn next_checkpoints(ticker: Ticker, start: u64) -> Vec<Option<u64>> {
 fn schedule_remaining_works() {
     ExtBuilder::default().build().execute_with(|| {
         let start = 1_000;
-        Timestamp::set_timestamp(start);
+        set_timestamp(start);
 
         let owner = User::new(AccountKeyring::Alice);
         let bob = User::new(AccountKeyring::Bob);
@@ -1861,7 +1871,7 @@ fn schedule_remaining_works() {
         assert_ok!(basic_asset(owner, ticker, &token));
 
         let transfer = |at: Moment| {
-            Timestamp::set_timestamp(at * 1_000);
+            set_timestamp(at * 1_000);
             default_transfer(owner, bob, ticker, 1);
         };
         let collect_ts = |sh_id| {
@@ -1956,13 +1966,13 @@ fn mesh_1531_ts_collission_regression_test() {
 
         // First CP is made at 1s.
         let cp = CheckpointId(1);
-        Timestamp::set_timestamp(1_000);
+        set_timestamp(1_000);
         let create = |ticker| Checkpoint::create_checkpoint(owner.origin(), ticker);
         assert_ok!(create(alpha));
         assert_eq!(Checkpoint::timestamps(alpha, cp), 1_000);
 
         // Second CP is for beta, using same ID.
-        Timestamp::set_timestamp(2_000);
+        set_timestamp(2_000);
         assert_ok!(create(beta));
         assert_eq!(Checkpoint::timestamps(alpha, cp), 1_000);
         assert_eq!(Checkpoint::timestamps(beta, cp), 2_000);

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::{allow_all_transfers, create_token},
+    asset_test::{allow_all_transfers, create_token, set_timestamp},
     storage::{
         create_cdd_id, create_investor_uid, get_primary_key,
         provide_scope_claim_to_multiple_parties, set_curr_did, TestStorage, User,
@@ -120,7 +120,7 @@ fn should_add_and_verify_compliance_requirement_we() {
     ));
 
     let now = Utc::now();
-    Timestamp::set_timestamp(now.timestamp() as u64);
+    set_timestamp(now.timestamp() as u64);
 
     let sender_condition =
         Condition::from_dids(ConditionType::IsPresent(Claim::NoData), &[claim_issuer.did]);
@@ -436,7 +436,7 @@ fn pause_resume_asset_compliance_we() {
     ));
 
     let now = Utc::now();
-    Timestamp::set_timestamp(now.timestamp() as u64);
+    set_timestamp(now.timestamp() as u64);
 
     // 4. Define conditions
     let receiver_conditions = vec![Condition::from_dids(
@@ -554,7 +554,7 @@ fn should_successfully_add_and_use_default_issuers_we() {
     ));
 
     let now = Utc::now();
-    Timestamp::set_timestamp(now.timestamp() as u64);
+    set_timestamp(now.timestamp() as u64);
 
     let claim_need_to_posses_1 = Claim::Affiliate(owner.scope());
     let claim_need_to_posses_2 = Claim::Accredited(owner.scope());
@@ -677,7 +677,7 @@ fn should_modify_vector_of_trusted_issuer_we() {
     );
 
     let now = Utc::now();
-    Timestamp::set_timestamp(now.timestamp() as u64);
+    set_timestamp(now.timestamp() as u64);
 
     let create_condition = |claim| -> Condition {
         Condition {

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::{an_asset, basic_asset, max_len, max_len_bytes, token},
+    asset_test::{an_asset, basic_asset, max_len, max_len_bytes, set_timestamp, token},
     committee_test::gc_vmo,
     ext_builder::PROTOCOL_OP_BASE_FEE,
     storage::{
@@ -987,7 +987,7 @@ fn one_step_join_id_with_ext() {
 
     // Check expire
     System::inc_account_nonce(a.acc());
-    Timestamp::set_timestamp(expires_at);
+    set_timestamp(expires_at);
 
     let f = User::new(AccountKeyring::Ferdie);
     let (ferdie_auth, _) = target_id_auth(a);
@@ -1184,7 +1184,7 @@ fn adding_authorizations() {
         );
 
         // Testing the list of filtered authorizations
-        Timestamp::set_timestamp(120);
+        set_timestamp(120);
 
         // Getting expired and non-expired both
         let mut authorizations = Identity::get_filtered_authorizations(
@@ -1656,7 +1656,7 @@ fn invalidate_cdd_claims_we() {
     assert_eq!(Identity::has_valid_cdd(alice_id), true);
 
     // Move to time 8... CDD_1 is inactive: Its claims are valid.
-    Timestamp::set_timestamp(8);
+    set_timestamp(8);
     assert_eq!(Identity::has_valid_cdd(alice_id), true);
     assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd.clone()), bob_acc.clone(), vec![]),
@@ -1664,7 +1664,7 @@ fn invalidate_cdd_claims_we() {
     );
 
     // Move to time 11 ... CDD_1 is expired: Its claims are invalid.
-    Timestamp::set_timestamp(11);
+    set_timestamp(11);
     assert_eq!(Identity::has_valid_cdd(alice_id), false);
     assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd), bob_acc, vec![]),

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -1,4 +1,5 @@
 use super::{
+    asset_test::set_timestamp,
     next_block,
     storage::{
         add_secondary_key, get_last_auth_id, get_primary_key, get_secondary_keys,
@@ -1036,7 +1037,7 @@ fn expired_proposals() {
         );
 
         // Approval fails when proposal has expired
-        Timestamp::set_timestamp(expires_at);
+        set_timestamp(expires_at);
         set_curr_did(Some(charlie_did));
         assert_noop!(
             MultiSig::approve_as_identity(charlie.clone(), ms_address.clone(), proposal_id),
@@ -1051,7 +1052,7 @@ fn expired_proposals() {
         );
 
         // Approval works when time is expiry - 1
-        Timestamp::set_timestamp(expires_at - 1);
+        set_timestamp(expires_at - 1);
         assert_ok!(MultiSig::approve_as_identity(
             charlie.clone(),
             ms_address.clone(),

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -17,6 +17,7 @@
 
 //! Test utilities
 
+use crate::asset_test::set_timestamp;
 use crate::storage::create_cdd_id;
 use chrono::prelude::Utc;
 use frame_election_provider_support::NposSolution;
@@ -941,7 +942,7 @@ impl ExtBuilder {
                 System::set_block_number(1);
                 Session::on_initialize(1);
                 Staking::on_initialize(1);
-                Timestamp::set_timestamp(INIT_TIMESTAMP);
+                set_timestamp(INIT_TIMESTAMP);
             });
         }
 
@@ -1186,7 +1187,7 @@ pub(crate) fn run_to_block(n: BlockNumber) {
         System::set_block_number(b);
         Session::on_initialize(b);
         Staking::on_initialize(b);
-        Timestamp::set_timestamp(System::block_number() * BLOCK_TIME + INIT_TIMESTAMP);
+        set_timestamp(System::block_number() * BLOCK_TIME + INIT_TIMESTAMP);
         if b != n {
             Staking::on_finalize(System::block_number());
         }

--- a/pallets/runtime/tests/src/staking/mod.rs
+++ b/pallets/runtime/tests/src/staking/mod.rs
@@ -94,6 +94,8 @@ macro_rules! __assert_eq_uvec {
 }
 
 mod mock;
+
+use crate::asset_test::set_timestamp;
 use chrono::prelude::Utc;
 use codec::Decode;
 use frame_support::{
@@ -5006,7 +5008,7 @@ fn on_initialize_weight_is_correct() {
             run_to_block(11);
             Staking::on_finalize(System::block_number());
             System::set_block_number((System::block_number() + 1).into());
-            Timestamp::set_timestamp(System::block_number() * 1000 + INIT_TIMESTAMP);
+            set_timestamp(System::block_number() * 1000 + INIT_TIMESTAMP);
             Session::on_initialize(System::block_number());
 
             assert_eq!(Validators::<Test>::iter().count(), 4);
@@ -5048,7 +5050,7 @@ fn add_nominator_with_invalid_expiry() {
             ));
 
             let now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_timestamp(now.timestamp() as u64);
             let validators = vec![10, 20, 30];
             assert_noop!(
                 Staking::nominate(controller_signed.clone(), validators),
@@ -5081,7 +5083,7 @@ fn add_valid_nominator_with_multiple_claims() {
                 RewardDestination::Stash
             ));
 
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_timestamp(now.timestamp() as u64);
             let validators = vec![10, 20, 30];
 
             assert_ok!(Staking::nominate(controller_signed.clone(), validators));
@@ -5140,7 +5142,7 @@ fn validate_nominators_with_valid_cdd() {
             ));
 
             now = Utc::now();
-            Timestamp::set_timestamp(now.timestamp() as u64);
+            set_timestamp(now.timestamp() as u64);
             let validators_1 = vec![10, 20, 30];
             assert_ok!(Staking::nominate(
                 controller_signed_alice.clone(),
@@ -5155,7 +5157,7 @@ fn validate_nominators_with_valid_cdd() {
             ));
             assert!(!Staking::nominators(&account_eve).is_none());
             now = Utc::now();
-            Timestamp::set_timestamp((now.timestamp() as u64) + 800_u64);
+            set_timestamp((now.timestamp() as u64) + 800_u64);
             let claimed_nominator = vec![account_alice.clone(), account_eve.clone()];
 
             println!("Current timestamp: {:?}", Timestamp::now());

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    asset_test::{allow_all_transfers, max_len_bytes},
+    asset_test::{allow_all_transfers, max_len_bytes, set_timestamp},
     exec_noop, exec_ok,
     storage::{make_account_with_portfolio, TestStorage, User},
     ExtBuilder,
@@ -540,7 +540,7 @@ fn fundraiser_expired() {
         Some(Timestamp::get() + 1)
     ));
 
-    Timestamp::set_timestamp(Timestamp::get() + 2);
+    set_timestamp(Timestamp::get() + 2);
 
     assert_noop!(
         Sto::modify_fundraiser_window(


### PR DESCRIPTION
Adds a helper function that sets the current slot before setting the timestamp in unit tests. This change was required because the `Timestamp` hooks the `Babe` pallet and performs the following assertion: 
```
assert!(
    CurrentSlot::<T>::get() == timestamp_slot,
    "Timestamp slot must match `CurrentSlot`"
);
```

## changelog

### modified logic

- Adds a helper function for setting the `Timestamp` in unit tests. 
