### PR TITLE
[WIP] Mesh 1915/add transfer nft extrinsic

### DIFF
--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -466,6 +466,7 @@ macro_rules! misc_pallet_impls {
             type Scheduler = Scheduler;
             type WeightInfo = polymesh_weights::pallet_settlement::WeightInfo;
             type MaxLegsInInstruction = MaxLegsInInstruction;
+            type MaxNumberOfLegAssets = MaxNumberOfLegAssets;
         }
 
         impl pallet_sto::Config for Runtime {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -92,6 +92,7 @@ parameter_types! {
 
     // Settlement:
     pub const MaxLegsInInstruction: u32 = 10;
+    pub const MaxNumberOfLegAssets: u8 = u8::MAX;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -89,6 +89,7 @@ parameter_types! {
 
     // Settlement:
     pub const MaxLegsInInstruction: u32 = 10;
+    pub const MaxNumberOfLegAssets: u8 = u8::MAX;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -95,6 +95,7 @@ parameter_types! {
 
     // Settlement:
     pub const MaxLegsInInstruction: u32 = 10;
+    pub const MaxNumberOfLegAssets: u8 = u8::MAX;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -17,7 +17,7 @@ use pallet_portfolio::MovePortfolioItem;
 use pallet_scheduler as scheduler;
 use pallet_settlement::{
     AffirmationStatus, Instruction, InstructionId, InstructionMemo, InstructionStatus, Leg,
-    LegAssetType, LegId, LegStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
+    LegAsset, LegId, LegStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
     VenueDetails, VenueId, VenueInstructions, VenueType,
 };
 use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
@@ -316,10 +316,10 @@ fn basic_settlement() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount
-                }
+                }]
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -364,10 +364,10 @@ fn create_and_affirm_instruction() {
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
                         amount,
-                    },
+                    }],
                 }],
                 affirm_from_portfolio,
             )
@@ -418,10 +418,10 @@ fn overdraft_failure() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount
-                }
+                }]
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -456,18 +456,18 @@ fn token_swap() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                },
+                }],
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER2,
                     amount,
-                },
+                }],
             },
         ];
 
@@ -591,18 +591,18 @@ fn claiming_receipt() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                },
+                }],
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER2,
                     amount,
-                },
+                }],
             },
         ];
 
@@ -652,8 +652,10 @@ fn claiming_receipt() {
             receipt_uid: 0,
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: TICKER,
-            amount,
+            assets: vec![LegAsset::Fungible {
+                ticker: TICKER,
+                amount,
+            }],
         };
         let signature = AccountKeyring::Alice.sign(&msg.encode());
 
@@ -693,8 +695,10 @@ fn claiming_receipt() {
             receipt_uid: 0,
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(alice.did),
-            asset: TICKER,
-            amount,
+            assets: vec![LegAsset::Fungible {
+                ticker: TICKER,
+                amount,
+            }],
         };
         let signature2 = AccountKeyring::Alice.sign(&msg2.encode());
 
@@ -820,18 +824,18 @@ fn settle_on_block() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                },
+                }],
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER2,
                     amount,
-                },
+                }],
             },
         ];
 
@@ -943,18 +947,18 @@ fn failed_execution() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                },
+                }],
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER2,
                     amount,
-                },
+                }],
             },
         ];
 
@@ -1082,10 +1086,10 @@ fn venue_filtering() {
         let legs = vec![Leg {
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset_type: LegAssetType::Fungible {
+            assets: vec![LegAsset::Fungible {
                 ticker: TICKER,
                 amount: 10,
-            },
+            }],
         }];
         assert_ok!(Settlement::add_instruction(
             alice.origin(),
@@ -1246,8 +1250,10 @@ fn basic_fuzzing() {
                                     .unwrap(),
                                 from: PortfolioId::default_portfolio(users[user_id].did),
                                 to: PortfolioId::default_portfolio(users[k].did),
-                                asset: tickers[ticker_id * 4 + user_id],
-                                amount: 1u128,
+                                assets: vec![LegAsset::Fungible {
+                                    ticker: tickers[ticker_id * 4 + user_id],
+                                    amount: 1,
+                                }],
                             });
                             receipt_legs.insert(receipts.last().unwrap().encode(), legs.len());
                         } else {
@@ -1269,10 +1275,10 @@ fn basic_fuzzing() {
                         legs.push(Leg {
                             from: PortfolioId::default_portfolio(users[user_id].did),
                             to: PortfolioId::default_portfolio(users[k].did),
-                            asset_type: LegAssetType::Fungible {
+                            assets: vec![LegAsset::Fungible {
                                 ticker: tickers[ticker_id * 4 + user_id],
                                 amount: 1,
-                            },
+                            }],
                         });
                         *legs_count.entry(users[user_id].did).or_insert(0) += 1;
                         if legs.len() >= 100 {
@@ -1487,18 +1493,18 @@ fn claim_multiple_receipts_during_authorization() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                },
+                }],
             },
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER2,
                     amount,
-                },
+                }],
             },
         ];
 
@@ -1518,22 +1524,28 @@ fn claim_multiple_receipts_during_authorization() {
             receipt_uid: 0,
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: TICKER,
-            amount,
+            assets: vec![LegAsset::Fungible {
+                ticker: TICKER,
+                amount,
+            }],
         };
         let msg2 = Receipt {
             receipt_uid: 0,
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: TICKER2,
-            amount,
+            assets: vec![LegAsset::Fungible {
+                ticker: TICKER2,
+                amount,
+            }],
         };
         let msg3 = Receipt {
             receipt_uid: 1,
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: TICKER2,
-            amount,
+            assets: vec![LegAsset::Fungible {
+                ticker: TICKER2,
+                amount,
+            }],
         };
 
         assert_noop!(
@@ -1630,10 +1642,10 @@ fn overload_instruction() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
-                    amount: 1u128,
-                }
+                    amount: 1,
+                }]
             };
             leg_limit + 1
         ];
@@ -1684,8 +1696,10 @@ fn encode_receipt() {
                 .unwrap()
                 .into(),
             ),
-            asset: ticker,
-            amount: 100u128,
+            assets: vec![LegAsset::Fungible {
+                ticker,
+                amount: 100,
+            }],
         };
         println!("{:?}", AccountKeyring::Alice.sign(&msg1.encode()));
     });
@@ -1776,10 +1790,10 @@ fn test_weights_for_settlement_transaction() {
             let legs = vec![Leg {
                 from: PortfolioId::default_portfolio(alice_did),
                 to: PortfolioId::default_portfolio(bob_did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount: 100,
-                },
+                }],
             }];
 
             assert_ok!(Settlement::add_instruction(
@@ -1838,10 +1852,10 @@ fn cross_portfolio_settlement() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::user_portfolio(bob.did, num),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
                     amount,
-                }
+                }]
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -1921,18 +1935,18 @@ fn multiple_portfolio_settlement() {
                 Leg {
                     from: PortfolioId::user_portfolio(alice.did, alice_num),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
-                        amount: amount,
-                    }
+                        amount,
+                    }]
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::user_portfolio(bob.did, bob_num),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
-                        amount: amount,
-                    }
+                        amount,
+                    }]
                 }
             ],
         ));
@@ -2088,18 +2102,18 @@ fn multiple_custodian_settlement() {
                 Leg {
                     from: PortfolioId::user_portfolio(alice.did, alice_num),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
-                        amount: amount,
-                    }
+                        amount,
+                    }]
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::user_portfolio(bob.did, bob_num),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
-                        amount: amount,
-                    }
+                        amount,
+                    }]
                 }
             ],
         ));
@@ -2293,18 +2307,18 @@ fn dirty_storage_with_tx() {
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
                         amount: amount1,
-                    }
+                    }]
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
                         amount: amount2,
-                    }
+                    }]
                 }
             ],
         ));
@@ -2528,10 +2542,10 @@ fn reject_instruction_with_zero_amount() {
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset_type: LegAssetType::Fungible {
+                    assets: vec![LegAsset::Fungible {
                         ticker: TICKER,
-                        amount: amount,
-                    }
+                        amount,
+                    }]
                 }]
             ),
             Error::ZeroAmount
@@ -2562,10 +2576,10 @@ fn basic_settlement_with_memo() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset_type: LegAssetType::Fungible {
+                assets: vec![LegAsset::Fungible {
                     ticker: TICKER,
-                    amount: amount,
-                }
+                    amount,
+                }]
             }],
             Some(InstructionMemo::default()),
         ));
@@ -2611,10 +2625,7 @@ fn create_instruction(
         vec![Leg {
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset_type: LegAssetType::Fungible {
-                ticker,
-                amount: amount,
-            }
+            assets: vec![LegAsset::Fungible { ticker, amount }]
         }],
         default_portfolio_vec(alice.did),
     ));

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -16,9 +16,9 @@ use pallet_identity as identity;
 use pallet_portfolio::MovePortfolioItem;
 use pallet_scheduler as scheduler;
 use pallet_settlement::{
-    AffirmationStatus, Instruction, InstructionId, InstructionMemo, InstructionStatus, Leg, LegId,
-    LegStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType, VenueDetails, VenueId,
-    VenueInstructions, VenueType,
+    AffirmationStatus, Instruction, InstructionId, InstructionMemo, InstructionStatus, Leg,
+    LegAssetType, LegId, LegStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
+    VenueDetails, VenueId, VenueInstructions, VenueType,
 };
 use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
 use polymesh_primitives::{
@@ -316,8 +316,10 @@ fn basic_settlement() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount: amount
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount
+                }
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -362,8 +364,10 @@ fn create_and_affirm_instruction() {
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount,
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount,
+                    },
                 }],
                 affirm_from_portfolio,
             )
@@ -414,8 +418,10 @@ fn overdraft_failure() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount: amount
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount
+                }
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -450,14 +456,18 @@ fn token_swap() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                },
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset: TICKER2,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER2,
+                    amount,
+                },
             },
         ];
 
@@ -581,14 +591,18 @@ fn claiming_receipt() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                },
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset: TICKER2,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER2,
+                    amount,
+                },
             },
         ];
 
@@ -806,14 +820,18 @@ fn settle_on_block() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                },
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset: TICKER2,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER2,
+                    amount,
+                },
             },
         ];
 
@@ -925,14 +943,18 @@ fn failed_execution() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                },
             },
             Leg {
                 from: PortfolioId::default_portfolio(bob.did),
                 to: PortfolioId::default_portfolio(alice.did),
-                asset: TICKER2,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER2,
+                    amount,
+                },
             },
         ];
 
@@ -1060,8 +1082,10 @@ fn venue_filtering() {
         let legs = vec![Leg {
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: TICKER,
-            amount: 10,
+            asset_type: LegAssetType::Fungible {
+                ticker: TICKER,
+                amount: 10,
+            },
         }];
         assert_ok!(Settlement::add_instruction(
             alice.origin(),
@@ -1245,8 +1269,10 @@ fn basic_fuzzing() {
                         legs.push(Leg {
                             from: PortfolioId::default_portfolio(users[user_id].did),
                             to: PortfolioId::default_portfolio(users[k].did),
-                            asset: tickers[ticker_id * 4 + user_id],
-                            amount: 1,
+                            asset_type: LegAssetType::Fungible {
+                                ticker: tickers[ticker_id * 4 + user_id],
+                                amount: 1,
+                            },
                         });
                         *legs_count.entry(users[user_id].did).or_insert(0) += 1;
                         if legs.len() >= 100 {
@@ -1461,14 +1487,18 @@ fn claim_multiple_receipts_during_authorization() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                },
             },
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER2,
-                amount,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER2,
+                    amount,
+                },
             },
         ];
 
@@ -1600,8 +1630,10 @@ fn overload_instruction() {
             Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount: 1u128,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount: 1u128,
+                }
             };
             leg_limit + 1
         ];
@@ -1744,8 +1776,10 @@ fn test_weights_for_settlement_transaction() {
             let legs = vec![Leg {
                 from: PortfolioId::default_portfolio(alice_did),
                 to: PortfolioId::default_portfolio(bob_did),
-                asset: TICKER,
-                amount: 100u128,
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount: 100,
+                },
             }];
 
             assert_ok!(Settlement::add_instruction(
@@ -1804,8 +1838,10 @@ fn cross_portfolio_settlement() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::user_portfolio(bob.did, num),
-                asset: TICKER,
-                amount: amount
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount,
+                }
             }],
         ));
         alice.assert_all_balances_unchanged();
@@ -1885,14 +1921,18 @@ fn multiple_portfolio_settlement() {
                 Leg {
                     from: PortfolioId::user_portfolio(alice.did, alice_num),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount: amount
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount,
+                    }
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::user_portfolio(bob.did, bob_num),
-                    asset: TICKER,
-                    amount: amount
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount,
+                    }
                 }
             ],
         ));
@@ -2048,14 +2088,18 @@ fn multiple_custodian_settlement() {
                 Leg {
                     from: PortfolioId::user_portfolio(alice.did, alice_num),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount: amount
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount,
+                    }
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::user_portfolio(bob.did, bob_num),
-                    asset: TICKER,
-                    amount: amount
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount,
+                    }
                 }
             ],
         ));
@@ -2249,14 +2293,18 @@ fn dirty_storage_with_tx() {
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount: amount1
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount1,
+                    }
                 },
                 Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount: amount2
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount2,
+                    }
                 }
             ],
         ));
@@ -2480,8 +2528,10 @@ fn reject_instruction_with_zero_amount() {
                 vec![Leg {
                     from: PortfolioId::default_portfolio(alice.did),
                     to: PortfolioId::default_portfolio(bob.did),
-                    asset: TICKER,
-                    amount: amount
+                    asset_type: LegAssetType::Fungible {
+                        ticker: TICKER,
+                        amount: amount,
+                    }
                 }]
             ),
             Error::ZeroAmount
@@ -2512,8 +2562,10 @@ fn basic_settlement_with_memo() {
             vec![Leg {
                 from: PortfolioId::default_portfolio(alice.did),
                 to: PortfolioId::default_portfolio(bob.did),
-                asset: TICKER,
-                amount: amount
+                asset_type: LegAssetType::Fungible {
+                    ticker: TICKER,
+                    amount: amount,
+                }
             }],
             Some(InstructionMemo::default()),
         ));
@@ -2559,8 +2611,10 @@ fn create_instruction(
         vec![Leg {
             from: PortfolioId::default_portfolio(alice.did),
             to: PortfolioId::default_portfolio(bob.did),
-            asset: ticker,
-            amount
+            asset_type: LegAssetType::Fungible {
+                ticker,
+                amount: amount,
+            }
         }],
         default_portfolio_vec(alice.did),
     ));

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -171,6 +171,7 @@ parameter_types! {
     pub const FixedYearlyReward: Balance = 140_000_000 * POLY;
     pub const MinimumBond: Balance = 1 * POLY;
     pub const MaxLegsInInstruction: u32 = 100;
+    pub const MaxNumberOfLegAssets: u8 = u8::MAX;
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
     pub const MaxAuthorities: u32 = 100_000;
     pub const MaxKeys: u32 = 10_000;

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -134,8 +134,10 @@ fn setup_leg_and_portfolio<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     legs.push(Leg {
         from: portfolio_from,
         to: portfolio_to,
-        asset: ticker,
-        amount: 100u32.into(),
+        asset_type: LegAssetType::Fungible {
+            ticker,
+            amount: 100,
+        },
     });
     receiver_portfolios.push(portfolio_to);
     sender_portfolios.push(portfolio_from);
@@ -174,8 +176,10 @@ fn populate_legs_for_instruction<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     legs.push(Leg {
         from: generate_portfolio::<T>("from_did", index + 500, None),
         to: generate_portfolio::<T>("to_did", index + 800, None),
-        asset: Ticker::generate_into(index.into()),
-        amount: 100u32.into(),
+        asset_type: LegAssetType::Fungible {
+            ticker: Ticker::generate_into(index.into()),
+            amount: 100,
+        },
     });
 }
 
@@ -292,8 +296,10 @@ fn emulate_portfolios<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     legs.push(Leg {
         from: sender_portfolio,
         to: receiver_portfolio,
-        asset: ticker,
-        amount: transacted_amount.into(),
+        asset_type: LegAssetType::Fungible {
+            ticker,
+            amount: transacted_amount,
+        },
     })
 }
 
@@ -427,12 +433,13 @@ fn create_receipt_details<T: Config + TestUtilsFn<AccountIdOf<T>>>(
     let User {
         account, secret, ..
     } = creator::<T>();
+    let (asset, amount) = leg.asset_and_amount();
     let msg = Receipt {
         receipt_uid: index as u64,
         from: leg.from,
         to: leg.to,
-        asset: leg.asset,
-        amount: leg.amount,
+        asset,
+        amount,
     };
     let origin = RawOrigin::Signed(account.clone());
     let creator = User {
@@ -815,7 +822,7 @@ benchmarks! {
         // Keep the portfolio asset balance before the instruction execution to verify it later.
         let legs_count: u32 = legs.len().try_into().unwrap();
         let first_leg = legs.into_iter().nth(0).unwrap_or_default();
-        let before_transfer_balance = PortfolioAssetBalances::get(first_leg.from, first_leg.asset);
+        let before_transfer_balance = PortfolioAssetBalances::get(first_leg.from, first_leg.asset_and_amount().0);
         // It always be one as no other instruction is already scheduled.
         let instruction_id = InstructionId(1);
         let origin = RawOrigin::Root;
@@ -836,9 +843,10 @@ benchmarks! {
     }: _(origin, instruction_id, l)
     verify {
         // Assert that any one leg processed through that give sufficient evidence of successful execution of instruction.
-        let after_transfer_balance = PortfolioAssetBalances::get(first_leg.from, first_leg.asset);
+        let (asset, amount) = first_leg.asset_and_amount();
+        let after_transfer_balance = PortfolioAssetBalances::get(first_leg.from, asset);
         let traded_amount = before_transfer_balance - after_transfer_balance;
-        let expected_transfer_amount = first_leg.amount;
+        let expected_transfer_amount = amount;
         assert_eq!(traded_amount, expected_transfer_amount,"Settlement: Failed to execute the instruction");
     }
 

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -33,7 +33,7 @@ use frame_support::{
 use pallet_base::try_next_post;
 use pallet_identity::PermissionedCallOriginData;
 use pallet_settlement::{
-    Leg, LegAssetType, ReceiptDetails, SettlementType, VenueId, VenueInfo, VenueType,
+    Leg, LegAsset, ReceiptDetails, SettlementType, VenueId, VenueInfo, VenueType,
 };
 use polymesh_common_utilities::{
     portfolio::PortfolioSubTrait,
@@ -458,13 +458,13 @@ decl_module! {
                 Leg {
                     from: fundraiser.offering_portfolio,
                     to: investment_portfolio,
-                    asset_type: LegAssetType::Fungible { ticker: fundraiser.offering_asset, amount: purchase_amount }
+                    assets: vec![LegAsset::Fungible { ticker: fundraiser.offering_asset, amount: purchase_amount }]
 
                 },
                 Leg {
                     from: funding_portfolio,
                     to: fundraiser.raising_portfolio,
-                    asset_type: LegAssetType::Fungible { ticker: fundraiser.raising_asset, amount: purchase_amount }
+                    assets: vec![LegAsset::Fungible { ticker: fundraiser.raising_asset, amount: purchase_amount }]
                 }
             ];
 

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -32,7 +32,9 @@ use frame_support::{
 };
 use pallet_base::try_next_post;
 use pallet_identity::PermissionedCallOriginData;
-use pallet_settlement::{Leg, ReceiptDetails, SettlementType, VenueId, VenueInfo, VenueType};
+use pallet_settlement::{
+    Leg, LegAssetType, ReceiptDetails, SettlementType, VenueId, VenueInfo, VenueType,
+};
 use polymesh_common_utilities::{
     portfolio::PortfolioSubTrait,
     traits::{identity, portfolio},
@@ -456,14 +458,13 @@ decl_module! {
                 Leg {
                     from: fundraiser.offering_portfolio,
                     to: investment_portfolio,
-                    asset: fundraiser.offering_asset,
-                    amount: purchase_amount
+                    asset_type: LegAssetType::Fungible { ticker: fundraiser.offering_asset, amount: purchase_amount }
+
                 },
                 Leg {
                     from: funding_portfolio,
                     to: fundraiser.raising_portfolio,
-                    asset: fundraiser.raising_asset,
-                    amount: cost
+                    asset_type: LegAssetType::Fungible { ticker: fundraiser.raising_asset, amount: purchase_amount }
                 }
             ];
 

--- a/primitives/src/nft.rs
+++ b/primitives/src/nft.rs
@@ -4,7 +4,7 @@ use sp_std::vec::IntoIter;
 use sp_std::vec::Vec;
 
 use crate::asset_metadata::{AssetMetadataKey, AssetMetadataValue};
-use crate::{impl_checked_inc, Ticker};
+use crate::{impl_checked_inc, Balance, Ticker};
 
 /// Controls the next available id for an NFT collection.
 #[derive(Clone, Copy, Debug, Decode, Default, Eq, Encode, PartialEq, TypeInfo)]
@@ -37,6 +37,30 @@ impl NFTCollection {
     /// Returns a reference to the `Ticker` associated with the collection.
     pub fn ticker(&self) -> &Ticker {
         &self.ticker
+    }
+}
+
+/// Represents an NFT.
+#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq, TypeInfo)]
+pub struct NFT {
+    ticker: Ticker,
+    id: NFTId,
+}
+
+impl NFT {
+    /// Returns a reference to the Ticker of the NFT.
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    /// Returns a reference to the `NFTId` of the NFT.
+    pub fn id(&self) -> &NFTId {
+        &self.id
+    }
+
+    /// Returns the fraction of the NFT being transferred.
+    pub fn amount(&self) -> Balance {
+        1_000_000
     }
 }
 


### PR DESCRIPTION
Change the `Settlement` pallet for allowing transferring NFT.

## changelog

### new features

- Allow NFT transfers.

### modified API

- `leg` now has an `assets` field which takes a `Vec<LegAsset>`;
- `Receipt`now has an `assets` field  which takes a `Vec<LegAsset>`;

### modified logic

- One `Leg` can include more than one asset;


