### PR TITLE
Update BlockHashCount to 4096

### DIFF
--- a/pallets/runtime/common/src/lib.rs
+++ b/pallets/runtime/common/src/lib.rs
@@ -60,7 +60,7 @@ const MAXIMUM_BLOCK_WEIGHT: Weight = 2 * WEIGHT_PER_SECOND;
 
 // TODO (miguel) Remove unused constants.
 parameter_types! {
-    pub const BlockHashCount: BlockNumber = 250;
+    pub const BlockHashCount: BlockNumber = 4096;
     /// We allow for 2 seconds of compute with a 6 second average block time.
     ///
     /// If this is updated, `PipsEnactSnapshotMaximumWeight` needs to be updated accordingly.


### PR DESCRIPTION
## changelog

### new features

### modified logic

- Store block hashes for the last 4,096 blocks rather than the current 250 blocks - as per https://github.com/paritytech/polkadot/pull/6037