### PR TITLE
MESH-1882: Allow non-zero priority

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ jobs:
           docker push --all-tags $IMAGE_NAME
   publish-github-release:
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
     steps:
       - attach_workspace:
           at: ./assets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "5.1.2"
+version = "5.1.3"
 dependencies = [
  "chrono",
  "clap 3.2.22",

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -176,7 +176,7 @@ decl_module! {
         const MaxConditionComplexity: u32 = T::MaxConditionComplexity::get();
 
         /// Adds a compliance requirement to an asset's compliance by ticker.
-        /// If the compliance requirement is a duplicate, it does nothing.
+        /// If there are duplicate ClaimTypes for a particular trusted issuer, duplicates are removed.
         ///
         /// # Arguments
         /// * origin - Signer of the dispatchable. It should be the owner of the ticker

--- a/pallets/runtime/extensions/src/check_weight.rs
+++ b/pallets/runtime/extensions/src/check_weight.rs
@@ -45,10 +45,8 @@ where
     /// Do the validate checks. This can be applied to both signed and unsigned.
     ///
     /// It only checks that the block weight and length limit will not exceed.
-    /// NOTE The returned transaction priority is 0 on success.
     fn do_validate(info: &DispatchInfoOf<T::Call>, len: usize) -> TransactionValidity {
-        let mut tv = CW::<T>::do_validate(info, len)?;
-        tv.priority = 0;
+        let tv = CW::<T>::do_validate(info, len)?;
         Ok(tv)
     }
 }


### PR DESCRIPTION
## changelog

Resolves comment mismatch from MESH-1754

Updates golang in circleci to 1.17 as per https://github.com/PolymeshAssociation/Polymesh/commit/993b38d7958f9c920c6db74e8081144478a0dab4

### modified logic

- allow operational extrinsics which are submitted by the GC or a CDD provider to have non-zero tips and corresponding priorities.