### PR TITLE
MESH-1924: Register cdd with add claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "5.1.2"
+version = "5.1.3"
 dependencies = [
  "chrono",
  "clap 3.2.22",

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -583,6 +583,30 @@ decl_module! {
         pub fn register_custom_claim_type(origin, ty: Vec<u8>) {
             Self::base_register_custom_claim_type(origin, ty)?;
         }
+
+        /// Register `target_account` with a new Identity.
+        ///
+        /// # Failure
+        /// - `origin` has to be a active CDD provider. Inactive CDD providers cannot add new
+        /// claims.
+        /// - `target_account` (primary key of the new Identity) can be linked to just one and only
+        /// one identity.
+        /// - External secondary keys can be linked to just one identity.
+        ///
+        /// # Weight
+        /// `7_000_000_000 + 600_000 * secondary_keys.len()`
+        #[weight = <T as Config>::WeightInfo::cdd_register_did(secondary_keys.len() as u32).add(<T as Config>::WeightInfo::add_claim())]
+        pub fn cdd_register_did_with_cdd(
+            origin,
+            target_account: T::AccountId,
+            secondary_keys: Vec<SecondaryKey<T::AccountId>>,
+            expiry: Option<T::Moment>
+        ) {
+            let (cdd_did, target_did) = Self::base_cdd_register_did(origin, target_account, secondary_keys)?;
+            let cdd_claim = Claim::CustomerDueDiligence(CddId::default());
+            Self::base_add_claim(target_did, cdd_claim, cdd_did, expiry)?;
+        }
+
     }
 }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -274,9 +274,6 @@ decl_module! {
         /// - `target_account` (primary key of the new Identity) can be linked to just one and only
         /// one identity.
         /// - External secondary keys can be linked to just one identity.
-        ///
-        /// # Weight
-        /// `7_000_000_000 + 600_000 * secondary_keys.len()`
         #[weight = <T as Config>::WeightInfo::cdd_register_did(secondary_keys.len() as u32)]
         pub fn cdd_register_did(
             origin,
@@ -584,7 +581,7 @@ decl_module! {
             Self::base_register_custom_claim_type(origin, ty)?;
         }
 
-        /// Register `target_account` with a new Identity.
+        /// Register `target_account` with a new Identity and issue a CDD claim with a blank CddId
         ///
         /// # Failure
         /// - `origin` has to be a active CDD provider. Inactive CDD providers cannot add new
@@ -592,10 +589,7 @@ decl_module! {
         /// - `target_account` (primary key of the new Identity) can be linked to just one and only
         /// one identity.
         /// - External secondary keys can be linked to just one identity.
-        ///
-        /// # Weight
-        /// `7_000_000_000 + 600_000 * secondary_keys.len()`
-        #[weight = <T as Config>::WeightInfo::cdd_register_did(secondary_keys.len() as u32).add(<T as Config>::WeightInfo::add_claim())]
+        #[weight = <T as Config>::WeightInfo::cdd_register_did(secondary_keys.len() as u32).saturating_add(<T as Config>::WeightInfo::add_claim())]
         pub fn cdd_register_did_with_cdd(
             origin,
             target_account: T::AccountId,


### PR DESCRIPTION
## changelog

### modified API

- new extrinsic `identity::cdd_register_did_with_cdd` to allow CDD providers to create an identity and add a CDD claim with a blank CddId, in a single extrinsic call.