### PR TITLE
Mesh 1929/fix transaction state rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "5.1.3"
+version = "5.2.0"
 dependencies = [
  "chrono",
  "clap 3.2.22",

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -1042,10 +1042,9 @@ decl_module! {
             ensure!(InstructionLegs::iter_prefix(id).count() as u32 <= legs_count, Error::<T>::LegCountTooSmall);
 
             // Executes the instruction
-            match Self::execute_instruction_retryable(id) {
-                Ok(_) => Self::deposit_event(RawEvent::SettlementManuallyExecuted(did, id)),
-                Err(e) => Self::deposit_event(RawEvent::FailedToExecuteInstruction(id, e)),
-            }
+            Self::execute_instruction_retryable(id)?;
+
+            Self::deposit_event(RawEvent::SettlementManuallyExecuted(did, id));
         }
 
     }


### PR DESCRIPTION
Adds an event for failing to execute an Instruction. To avoid rolling back the state (once the code is updated to the new substrate version) the result of `execute_instruction_retryable` is now matched

## changelog

### modified API

- Adds an event: `FailedToExecuteInstruction`;
- `execute_scheduled_instruction` will no longer return an error;

### modified logic

- To avoid a state rollback (i.e allow setting instruction status to the failed state) the return of `execute_instruction_retryable` is now matched, and returns an event in case of failure. 