### PR TITLE
Add NonFungible types; Add `BalanceOf` to the NFT pallet; Add `asset_type` checks

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2627,10 +2627,7 @@ impl<T: Config> Module<T> {
     /// Returns `None` if there's no asset associated to the given ticker,
     /// returns Some(true) if the asset exists and is of type `AssetType::NonFungible`, and returns Some(false) otherwise.
     pub fn nft_asset(ticker: &Ticker) -> Option<bool> {
-        let security_token = Tokens::try_get(ticker).ok()?;
-        match security_token.asset_type {
-            AssetType::NonFungible(_) => Some(true),
-            _ => Some(false),
-        }
+        let token = Tokens::try_get(ticker).ok()?;
+        Some(token.asset_type.is_non_fungible())
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1500,7 +1500,7 @@ impl<T: Config> Module<T> {
         let mut token = Self::token_details(ticker);
         // Ensures the token is fungible
         ensure!(
-            Tokens::get(&ticker).asset_type.is_fungible(),
+            token.asset_type.is_fungible(),
             Error::<T>::UnexpectedNonFungibleToken
         );
 
@@ -2015,7 +2015,7 @@ impl<T: Config> Module<T> {
         Tokens::try_mutate(&ticker, |token| -> DispatchResult {
             // Ensures the token is fungible
             ensure!(
-                Tokens::get(&ticker).asset_type.is_fungible(),
+                token.asset_type.is_fungible(),
                 Error::<T>::UnexpectedNonFungibleToken
             );
             ensure!(!token.divisible, Error::<T>::AssetAlreadyDivisible);

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -3,7 +3,7 @@ use frame_system::RawOrigin;
 use polymesh_common_utilities::benchs::{user, AccountIdOf};
 use polymesh_common_utilities::traits::asset::AssetFnTrait;
 use polymesh_common_utilities::TestUtilsFn;
-use polymesh_primitives::asset::{AssetType, NonFungibleType};
+use polymesh_primitives::asset::NonFungibleType;
 use polymesh_primitives::asset_metadata::{
     AssetMetadataGlobalKey, AssetMetadataKey, AssetMetadataSpec, AssetMetadataValue,
 };
@@ -21,11 +21,11 @@ const MAX_COLLECTION_KEYS: u32 = 255;
 fn create_collection<T: Config>(
     origin: T::Origin,
     ticker: Ticker,
-    asset_type: Option<AssetType>,
+    nft_type: Option<NonFungibleType>,
     n: u32,
 ) -> NFTCollectionId {
     let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n);
-    Module::<T>::create_nft_collection(origin, ticker, asset_type, collection_keys)
+    Module::<T>::create_nft_collection(origin, ticker, nft_type, collection_keys)
         .expect("failed to create nft collection");
     Module::<T>::collection_id()
 }
@@ -53,13 +53,13 @@ fn creates_keys_register_metadata_types<T: Config>(n: u32) -> NFTCollectionKeys 
 pub fn create_collection_mint_nfts<T: Config>(
     origin: T::Origin,
     ticker: Ticker,
-    asset_type: Option<AssetType>,
+    nft_type: Option<NonFungibleType>,
     n_keys: u32,
     n_nfts: u32,
     portfolio_kind: PortfolioKind,
 ) {
     let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n_keys);
-    Module::<T>::create_nft_collection(origin.clone(), ticker, asset_type, collection_keys)
+    Module::<T>::create_nft_collection(origin.clone(), ticker, nft_type, collection_keys)
         .expect("failed to create nft collection");
     let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n_keys + 1)
         .map(|key| NFTMetadataAttribute {
@@ -86,9 +86,9 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
+        let nft_type: Option<NonFungibleType> = Some(NonFungibleType::Derivative);
         let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n);
-    }: _(user.origin, ticker, asset_type, collection_keys)
+    }: _(user.origin, ticker, nft_type, collection_keys)
     verify {
         assert!(Collection::contains_key(NFTCollectionId(1)));
         assert_eq!(CollectionKeys::get(NFTCollectionId(1)).len(), n as usize);
@@ -99,8 +99,8 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
-        let collection_id = create_collection::<T>(user.origin().into(), ticker, asset_type, n);
+        let nft_type: Option<NonFungibleType> = Some(NonFungibleType::Derivative);
+        let collection_id = create_collection::<T>(user.origin().into(), ticker, nft_type, n);
         let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n + 1)
             .map(|key| {
                 NFTMetadataAttribute{
@@ -126,8 +126,8 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
-        let collection_id = create_collection::<T>(user.origin().into(), ticker, asset_type, n);
+        let nft_type: Option<NonFungibleType> = Some(NonFungibleType::Derivative);
+        let collection_id = create_collection::<T>(user.origin().into(), ticker, nft_type, n);
 
         let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n + 1)
             .map(|key| {

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -3,6 +3,7 @@ use frame_system::RawOrigin;
 use polymesh_common_utilities::benchs::{user, AccountIdOf};
 use polymesh_common_utilities::traits::asset::AssetFnTrait;
 use polymesh_common_utilities::TestUtilsFn;
+use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataGlobalKey, AssetMetadataKey, AssetMetadataSpec, AssetMetadataValue,
 };
@@ -17,9 +18,14 @@ use crate::*;
 const MAX_COLLECTION_KEYS: u32 = 255;
 
 /// Creates an NFT collection with `n` global metadata keys.
-fn create_collection<T: Config>(origin: T::Origin, ticker: Ticker, n: u32) -> NFTCollectionId {
+fn create_collection<T: Config>(
+    origin: T::Origin,
+    ticker: Ticker,
+    asset_type: Option<AssetType>,
+    n: u32,
+) -> NFTCollectionId {
     let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n);
-    Module::<T>::create_nft_collection(origin, ticker, collection_keys)
+    Module::<T>::create_nft_collection(origin, ticker, asset_type, collection_keys)
         .expect("failed to create nft collection");
     Module::<T>::collection_id()
 }
@@ -47,12 +53,13 @@ fn creates_keys_register_metadata_types<T: Config>(n: u32) -> NFTCollectionKeys 
 pub fn create_collection_mint_nfts<T: Config>(
     origin: T::Origin,
     ticker: Ticker,
+    asset_type: Option<AssetType>,
     n_keys: u32,
     n_nfts: u32,
     portfolio_kind: PortfolioKind,
 ) {
     let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n_keys);
-    Module::<T>::create_nft_collection(origin.clone(), ticker, collection_keys)
+    Module::<T>::create_nft_collection(origin.clone(), ticker, asset_type, collection_keys)
         .expect("failed to create nft collection");
     let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n_keys + 1)
         .map(|key| NFTMetadataAttribute {
@@ -79,8 +86,9 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
+        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
         let collection_keys: NFTCollectionKeys = creates_keys_register_metadata_types::<T>(n);
-    }: _(user.origin, ticker, collection_keys)
+    }: _(user.origin, ticker, asset_type, collection_keys)
     verify {
         assert!(Collection::contains_key(NFTCollectionId(1)));
         assert_eq!(CollectionKeys::get(NFTCollectionId(1)).len(), n as usize);
@@ -91,7 +99,8 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let collection_id = create_collection::<T>(user.origin().into(), ticker, n);
+        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
+        let collection_id = create_collection::<T>(user.origin().into(), ticker, asset_type, n);
         let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n + 1)
             .map(|key| {
                 NFTMetadataAttribute{
@@ -117,7 +126,8 @@ benchmarks! {
 
         let user = user::<T>("target", 0);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let collection_id = create_collection::<T>(user.origin().into(), ticker, n);
+        let asset_type: Option<AssetType> = Some(AssetType::NonFungible(NonFungibleType::Derivative));
+        let collection_id = create_collection::<T>(user.origin().into(), ticker, asset_type, n);
 
         let metadata_attributes: Vec<NFTMetadataAttribute> = (1..n + 1)
             .map(|key| {

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -68,7 +68,7 @@ decl_module! {
         /// # Arguments
         /// * `origin` - contains the secondary key of the caller (i.e. who signed the transaction to execute this function).
         /// * `ticker` - the ticker associated to the new collection.
-        /// * `asset_type` - in case the asset hasn't been created yet, one will be created with the given type.
+        /// * `nft_type` - in case the asset hasn't been created yet, one will be created with the given type.
         /// * `collection_keys` - all mandatory metadata keys that the tokens in the collection must have.
         ///
         /// ## Errors

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -1,12 +1,11 @@
 use chrono::prelude::Utc;
 use frame_support::{assert_noop, assert_ok};
 use frame_support::{StorageDoubleMap, StorageMap};
-use pallet_asset::BalanceOf;
-use pallet_nft::{Collection, CollectionKeys, MetadataValue};
+use pallet_nft::{BalanceOf, Collection, CollectionKeys, MetadataValue};
 use pallet_portfolio::PortfolioNFT;
 use polymesh_common_utilities::constants::currency::ONE_UNIT;
 use polymesh_common_utilities::with_transaction;
-use polymesh_primitives::asset::AssetType;
+use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataName, AssetMetadataSpec,
     AssetMetadataValue,
@@ -45,7 +44,10 @@ fn create_collection_unregistered_ticker() {
             collection_keys
         ));
         assert_eq!(Asset::token_details(&ticker).divisible, false);
-        assert_eq!(Asset::token_details(&ticker).asset_type, AssetType::NFT);
+        assert_eq!(
+            Asset::token_details(&ticker).asset_type,
+            AssetType::NonFungible(NonFungibleType::Placeholder)
+        );
     });
 }
 
@@ -168,7 +170,7 @@ pub(crate) fn create_nft_collection(
         ticker.as_ref().into(),
         ticker.clone(),
         false,
-        AssetType::NFT,
+        AssetType::NonFungible(NonFungibleType::Placeholder),
         Vec::new(),
         None,
         false,

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -1,9 +1,8 @@
 use chrono::prelude::Utc;
 use frame_support::{assert_noop, assert_ok};
 use frame_support::{StorageDoubleMap, StorageMap};
-use pallet_nft::{BalanceOf, Collection, CollectionKeys, MetadataValue};
+use pallet_nft::{Collection, CollectionKeys, MetadataValue, NumberOfNFTs};
 use pallet_portfolio::PortfolioNFT;
-use polymesh_common_utilities::constants::currency::ONE_UNIT;
 use polymesh_common_utilities::with_transaction;
 use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
@@ -417,7 +416,7 @@ fn mint_nft_successfully() {
             ),
             AssetMetadataValue(b"test".to_vec())
         );
-        assert_eq!(BalanceOf::get(&ticker, alice.did), ONE_UNIT);
+        assert_eq!(NumberOfNFTs::get(&ticker, alice.did), 1);
         assert_eq!(
             PortfolioNFT::get(
                 PortfolioId::default_portfolio(alice.did),
@@ -519,7 +518,7 @@ fn burn_nft() {
             (NFTCollectionId(1), NFTId(1)),
             AssetMetadataKey::Local(AssetMetadataLocalKey(1))
         ),);
-        assert_eq!(BalanceOf::get(&ticker, alice.did), 0);
+        assert_eq!(NumberOfNFTs::get(&ticker, alice.did), 0);
         assert!(!PortfolioNFT::contains_key(
             PortfolioId::default_portfolio(alice.did),
             (&ticker, NFTId(1))
@@ -779,7 +778,7 @@ fn transfer_nft() {
         assert_ok!(with_transaction(|| {
             NFT::base_nft_transfer(&sender_portfolio, &receiver_portfolio, &nfts)
         }));
-        assert_eq!(BalanceOf::get(&ticker, alice.did), 0);
+        assert_eq!(NumberOfNFTs::get(&ticker, alice.did), 0);
         assert_eq!(
             PortfolioNFT::get(
                 PortfolioId::default_portfolio(alice.did),
@@ -787,7 +786,7 @@ fn transfer_nft() {
             ),
             false
         );
-        assert_eq!(BalanceOf::get(&ticker, bob.did), ONE_UNIT);
+        assert_eq!(NumberOfNFTs::get(&ticker, bob.did), 1);
         assert_eq!(
             PortfolioNFT::get(PortfolioId::default_portfolio(bob.did), (&ticker, NFTId(1))),
             true

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -35,17 +35,20 @@ fn create_collection_unregistered_ticker() {
 
         let alice: User = User::new(AccountKeyring::Alice);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: AssetType = AssetType::NonFungible(NonFungibleType::Derivative);
+        let nft_type = NonFungibleType::Derivative;
         let collection_keys: NFTCollectionKeys = vec![].into();
 
         assert_ok!(NFT::create_nft_collection(
             alice.origin(),
             ticker.clone(),
-            Some(asset_type),
+            Some(nft_type),
             collection_keys
         ));
         assert_eq!(Asset::token_details(&ticker).divisible, false);
-        assert_eq!(Asset::token_details(&ticker).asset_type, asset_type);
+        assert_eq!(
+            Asset::token_details(&ticker).asset_type,
+            AssetType::NonFungible(nft_type)
+        );
     });
 }
 
@@ -86,17 +89,17 @@ fn create_collection_already_registered() {
 
         let alice: User = User::new(AccountKeyring::Alice);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: AssetType = AssetType::NonFungible(NonFungibleType::Derivative);
+        let nft_type = NonFungibleType::Derivative;
         let collection_keys: NFTCollectionKeys = vec![].into();
 
         assert_ok!(NFT::create_nft_collection(
             alice.origin(),
             ticker,
-            Some(asset_type),
+            Some(nft_type),
             collection_keys.clone()
         ));
         assert_noop!(
-            NFT::create_nft_collection(alice.origin(), ticker, Some(asset_type), collection_keys),
+            NFT::create_nft_collection(alice.origin(), ticker, Some(nft_type), collection_keys),
             NFTError::CollectionAlredyRegistered
         );
     });
@@ -110,7 +113,7 @@ fn create_collection_max_keys_exceeded() {
 
         let alice: User = User::new(AccountKeyring::Alice);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: AssetType = AssetType::NonFungible(NonFungibleType::Derivative);
+        let nft_type = NonFungibleType::Derivative;
         let collection_keys: Vec<AssetMetadataKey> = (0..256)
             .map(|key| AssetMetadataKey::Local(AssetMetadataLocalKey(key)))
             .collect();
@@ -118,7 +121,7 @@ fn create_collection_max_keys_exceeded() {
             NFT::create_nft_collection(
                 alice.origin(),
                 ticker,
-                Some(asset_type),
+                Some(nft_type),
                 collection_keys.into()
             ),
             NFTError::MaxNumberOfKeysExceeded
@@ -134,7 +137,7 @@ fn create_collection_duplicate_key() {
 
         let alice: User = User::new(AccountKeyring::Alice);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: AssetType = AssetType::NonFungible(NonFungibleType::Derivative);
+        let nft_type = NonFungibleType::Derivative;
         let collection_keys: NFTCollectionKeys = vec![
             AssetMetadataKey::Local(AssetMetadataLocalKey(0)),
             AssetMetadataKey::Local(AssetMetadataLocalKey(0)),
@@ -145,7 +148,7 @@ fn create_collection_duplicate_key() {
             NFT::create_nft_collection(
                 alice.origin(),
                 ticker,
-                Some(asset_type),
+                Some(nft_type),
                 collection_keys.into()
             ),
             NFTError::DuplicateMetadataKey
@@ -161,12 +164,12 @@ fn create_collection_unregistered_key() {
 
         let alice: User = User::new(AccountKeyring::Alice);
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
-        let asset_type: AssetType = AssetType::NonFungible(NonFungibleType::Derivative);
+        let nft_type = NonFungibleType::Derivative;
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(0))].into();
 
         assert_noop!(
-            NFT::create_nft_collection(alice.origin(), ticker, Some(asset_type), collection_keys),
+            NFT::create_nft_collection(alice.origin(), ticker, Some(nft_type), collection_keys),
             NFTError::UnregisteredMetadataKey
         );
     });

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -15,6 +15,7 @@ use pallet_portfolio::{
 use pallet_settlement::{InstructionMemo, LegAsset, LegV2, SettlementType};
 use polymesh_common_utilities::balances::Memo;
 use polymesh_common_utilities::portfolio::PortfolioSubTrait;
+use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataValue,
 };
@@ -602,7 +603,12 @@ fn delete_portfolio_with_nfts() {
         .unwrap();
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), ticker, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            ticker,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -636,7 +642,12 @@ fn delete_portfolio_with_locked_nfts() {
         let ticker: Ticker = b"TICKER".as_ref().try_into().unwrap();
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), ticker, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            ticker,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -689,7 +700,12 @@ fn move_nft_not_in_portfolio() {
         };
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -736,7 +752,12 @@ fn move_portfolio_nfts() {
         };
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -11,10 +11,10 @@ use super::{
 use codec::Encode;
 use frame_support::{assert_noop, assert_ok, IterableStorageDoubleMap, StorageDoubleMap};
 use pallet_asset as asset;
-use pallet_asset::BalanceOf;
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;
 use pallet_identity as identity;
+use pallet_nft::BalanceOf;
 use pallet_portfolio::{MovePortfolioItem, PortfolioLockedNFT, PortfolioNFT};
 use pallet_scheduler as scheduler;
 use pallet_settlement::{

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -24,7 +24,7 @@ use pallet_settlement::{
 };
 use polymesh_common_utilities::constants::{currency::ONE_UNIT, ERC1400_TRANSFER_SUCCESS};
 use polymesh_primitives::{
-    asset::AssetType,
+    asset::{AssetType, NonFungibleType},
     asset_metadata::{AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataValue},
     checked_inc::CheckedInc,
     AccountId, AuthorizationData, Balance, Claim, Condition, ConditionType, IdentityId,
@@ -2838,7 +2838,12 @@ fn add_and_affirm_nft_instruction() {
         let bob: User = User::new(AccountKeyring::Bob);
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -2927,7 +2932,12 @@ fn add_and_affirm_nft_not_owned() {
         let bob: User = User::new(AccountKeyring::Bob);
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -2967,7 +2977,12 @@ fn add_same_nft_different_legs() {
         let bob: User = User::new(AccountKeyring::Bob);
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),
@@ -3019,7 +3034,12 @@ fn add_and_affirm_with_receipts_nfts() {
         let bob: User = User::new(AccountKeyring::Bob);
         let collection_keys: NFTCollectionKeys =
             vec![AssetMetadataKey::Local(AssetMetadataLocalKey(1))].into();
-        create_nft_collection(alice.clone(), TICKER, collection_keys);
+        create_nft_collection(
+            alice.clone(),
+            TICKER,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            collection_keys,
+        );
         let nfts_metadata: Vec<NFTMetadataAttribute> = vec![NFTMetadataAttribute {
             key: AssetMetadataKey::Local(AssetMetadataLocalKey(1)),
             value: AssetMetadataValue(b"test".to_vec()),

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -14,7 +14,7 @@ use pallet_asset as asset;
 use pallet_balances as balances;
 use pallet_compliance_manager as compliance_manager;
 use pallet_identity as identity;
-use pallet_nft::BalanceOf;
+use pallet_nft::NumberOfNFTs;
 use pallet_portfolio::{MovePortfolioItem, PortfolioLockedNFT, PortfolioNFT};
 use pallet_scheduler as scheduler;
 use pallet_settlement::{
@@ -22,7 +22,7 @@ use pallet_settlement::{
     LegAsset, LegId, LegStatus, LegV2, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
     VenueDetails, VenueId, VenueInstructions, VenueType,
 };
-use polymesh_common_utilities::constants::{currency::ONE_UNIT, ERC1400_TRANSFER_SUCCESS};
+use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
 use polymesh_primitives::{
     asset::{AssetType, NonFungibleType},
     asset_metadata::{AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataValue},
@@ -2872,7 +2872,7 @@ fn add_and_affirm_nft_instruction() {
         ));
 
         // Before bob accepts the transaction balances must not be changed and the NFT must be locked.
-        assert_eq!(BalanceOf::get(TICKER, alice.did), ONE_UNIT);
+        assert_eq!(NumberOfNFTs::get(TICKER, alice.did), 1);
         assert_eq!(
             PortfolioNFT::get(
                 PortfolioId::default_portfolio(alice.did),
@@ -2896,8 +2896,8 @@ fn add_and_affirm_nft_instruction() {
             1
         ));
         next_block();
-        assert_eq!(BalanceOf::get(TICKER, alice.did), 0);
-        assert_eq!(BalanceOf::get(TICKER, bob.did), ONE_UNIT);
+        assert_eq!(NumberOfNFTs::get(TICKER, alice.did), 0);
+        assert_eq!(NumberOfNFTs::get(TICKER, bob.did), 1);
         assert_eq!(
             PortfolioNFT::get(
                 PortfolioId::default_portfolio(alice.did),
@@ -3077,7 +3077,7 @@ fn add_and_affirm_with_receipts_nfts() {
                                 from: PortfolioId::default_portfolio(alice.did),
                                 to: PortfolioId::default_portfolio(bob.did),
                                 asset: TICKER,
-                                amount: ONE_UNIT,
+                                amount: 1,
                             }
                             .encode()
                         )

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -29,6 +29,7 @@ use polymesh_common_utilities::{
     TestUtilsFn,
 };
 use polymesh_primitives::{
+    asset::{AssetType, NonFungibleType},
     checked_inc::CheckedInc,
     statistics::{Stat2ndKey, StatType, StatUpdate},
     transfer_compliance::{TransferCondition, TransferConditionExemptKey},
@@ -623,6 +624,7 @@ fn setup_nft_legs<T: Config>(
     create_collection_mint_nfts::<T>(
         sender.origin().into(),
         ticker,
+        Some(AssetType::NonFungible(NonFungibleType::Derivative)),
         0,
         n_nfts,
         PortfolioKind::Default,

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -29,7 +29,7 @@ use polymesh_common_utilities::{
     TestUtilsFn,
 };
 use polymesh_primitives::{
-    asset::{AssetType, NonFungibleType},
+    asset::NonFungibleType,
     checked_inc::CheckedInc,
     statistics::{Stat2ndKey, StatType, StatUpdate},
     transfer_compliance::{TransferCondition, TransferConditionExemptKey},
@@ -624,7 +624,7 @@ fn setup_nft_legs<T: Config>(
     create_collection_mint_nfts::<T>(
         sender.origin().into(),
         ticker,
-        Some(AssetType::NonFungible(NonFungibleType::Derivative)),
+        Some(NonFungibleType::Derivative),
         0,
         n_nfts,
         PortfolioKind::Default,

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -307,7 +307,7 @@ impl LegAsset {
     pub fn ticker_and_amount(&self) -> (Ticker, Balance) {
         match self {
             LegAsset::Fungible { ticker, amount } => (*ticker, *amount),
-            LegAsset::NonFungible(nfts) => (*nfts.ticker(), nfts.amount()),
+            LegAsset::NonFungible(nfts) => (*nfts.ticker(), nfts.len() as Balance),
         }
     }
 }

--- a/polymesh_schema.json
+++ b/polymesh_schema.json
@@ -50,7 +50,8 @@
         "StructuredProduct": "",
         "Derivative": "",
         "Custom": "CustomAssetTypeId",
-        "StableCoin": ""
+        "StableCoin": "",
+        "NonFungible": "NonFungibleType"
       }
     },
     "AssetIdentifier": {
@@ -1218,6 +1219,14 @@
     "Fund": {
       "description": "FundDescription",
       "memo": "Option<Memo>"
+    },
+    "NonFungibleType": {
+      "_enum": {
+        "Derivative": "",
+        "FixedIncome": "",
+        "Invoice": "",
+        "Custom": "CustomAssetTypeId"
+      }
     }
   },
   "rpc": {

--- a/primitives/src/asset.rs
+++ b/primitives/src/asset.rs
@@ -79,8 +79,6 @@ pub enum AssetType {
 /// Defines all non-fungible variants.
 #[derive(Encode, Decode, TypeInfo, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NonFungibleType {
-    /// TODO: remove this.
-    Placeholder,
     /// Derivative contract - a contract between two parties for buying or selling a security at a
     /// predetermined price within a specific time period.
     /// Examples: forwards, futures, options or swaps.
@@ -98,6 +96,34 @@ pub enum NonFungibleType {
 impl Default for AssetType {
     fn default() -> Self {
         Self::EquityCommon
+    }
+}
+
+impl AssetType {
+    /// Returns true if the asset type is non-fungible.
+    pub fn is_non_fungible(&self) -> bool {
+        if let AssetType::NonFungible(_) = self {
+            return true;
+        }
+        false
+    }
+
+    /// Returns true if the asset type is fungible.
+    pub fn is_fungible(&self) -> bool {
+        match self {
+            AssetType::EquityCommon
+            | AssetType::EquityPreferred
+            | AssetType::Commodity
+            | AssetType::FixedIncome
+            | AssetType::REIT
+            | AssetType::Fund
+            | AssetType::RevenueShareAgreement
+            | AssetType::StructuredProduct
+            | AssetType::Derivative
+            | AssetType::Custom(_)
+            | AssetType::StableCoin => true,
+            AssetType::NonFungible(_) => false,
+        }
     }
 }
 

--- a/primitives/src/asset.rs
+++ b/primitives/src/asset.rs
@@ -73,7 +73,26 @@ pub enum AssetType {
     /// A stablecoin can be pegged to a cryptocurrency, fiat money, or to exchange-traded commodities.
     StableCoin,
     /// Non-fungible token.
-    NFT,
+    NonFungible(NonFungibleType),
+}
+
+/// Defines all non-fungible variants.
+#[derive(Encode, Decode, TypeInfo, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NonFungibleType {
+    /// TODO: remove this.
+    Placeholder,
+    /// Derivative contract - a contract between two parties for buying or selling a security at a
+    /// predetermined price within a specific time period.
+    /// Examples: forwards, futures, options or swaps.
+    Derivative,
+    /// Fixed income security - an investment that provides a return in the form of fixed periodic
+    /// interest payments and the eventual return of principal at maturity.
+    /// Examples: bonds, treasury bills, certificates of deposit.
+    FixedIncome,
+    /// Invoice - a list of goods sent or services provided, with a statement of the sum due for these.
+    Invoice,
+    /// The Id of a user definied type.
+    Custom(CustomAssetTypeId),
 }
 
 impl Default for AssetType {

--- a/primitives/src/nft.rs
+++ b/primitives/src/nft.rs
@@ -5,8 +5,10 @@ use sp_std::vec::IntoIter;
 use sp_std::vec::Vec;
 
 use crate::asset_metadata::{AssetMetadataKey, AssetMetadataValue};
-use crate::Balance;
 use crate::{impl_checked_inc, Ticker};
+
+/// Controls the total number of NFTs per identity.
+pub type NFTCount = u64;
 
 /// Controls the next available id for an NFT collection.
 #[derive(Clone, Copy, Debug, Decode, Default, Eq, Encode, PartialEq, TypeInfo)]
@@ -79,11 +81,6 @@ impl NFTs {
     /// Returns the number nfts being transferred.
     pub fn len(&self) -> usize {
         self.ids.len()
-    }
-
-    /// Returns the amount being transferred (currently each NFT is equal to ONE_UNIT).
-    pub fn amount(&self) -> Balance {
-        (self.ids.len() * 1_000_000) as u128
     }
 }
 


### PR DESCRIPTION
Adresses the comments in [#1389](https://github.com/PolymeshAssociation/Polymesh/pull/1389#issuecomment-1420942425l)

## changelog

### modified API

* Adds the following error variants to the asset pallet: 
   - `UnexpectedNonFungibleToken`, `IncompatibleAssetTypeUpdate`;
* Adds the following error variants to the nft pallet: 
   - `InvalidNFTTransferFrozenAsset`;
* Adds `NonFungible(NonFungibleType)` to `AssetType`: 
* Adds `BalanceOf` storage in the NFT pallet;

### modified logic

- `validate_nft_transfer` checks if the asset is frozen;
- `base_update_asset_type` fails updating a fungible asset to a non-fungible one, and the other way around.
- `unsafe_transfer`, `_mint`, `base_make_divisible`, and `base_redeem` return an error for non-fungible tokens.
