### PR TITLE
Mesh 1971/add nft rpc endpoint

### DIFF
--- a/node-rpc/src/lib.rs
+++ b/node-rpc/src/lib.rs
@@ -118,6 +118,7 @@ where
     C::Api: node_rpc::compliance_manager::ComplianceManagerRuntimeApi<Block, AccountId>,
     C::Api: BabeApi<Block>,
     C::Api: BlockBuilder<Block>,
+    C::Api: node_rpc::nft::NFTRuntimeApi<Block>,
     P: TransactionPool + 'static,
     SC: SelectChain<Block> + 'static,
     B: sc_client_api::Backend<Block> + Send + Sync + 'static,
@@ -127,6 +128,7 @@ where
     use node_rpc::{
         asset::{Asset, AssetApi},
         identity::{Identity, IdentityApi},
+        nft::{NFTApi, NFT},
         pips::{Pips, PipsApi},
         transaction_payment::{TransactionPayment, TransactionPaymentApi},
     };
@@ -211,8 +213,9 @@ where
     io.extend_with(AssetApi::to_delegate(Asset::new(client.clone())));
     io.extend_with(GroupApi::to_delegate(Group::from(client.clone())));
     io.extend_with(ComplianceManagerApi::to_delegate(ComplianceManager::new(
-        client,
+        client.clone(),
     )));
+    io.extend_with(NFTApi::to_delegate(NFT::new(client)));
 
     Ok(io)
 }

--- a/pallets/common/src/traits/nft.rs
+++ b/pallets/common/src/traits/nft.rs
@@ -26,6 +26,8 @@ pub trait Config:
     type Compliance: ComplianceManagerConfig;
 
     type MaxNumberOfCollectionKeys: Get<u8>;
+
+    type MaxNumberOfNFTsCount: Get<u32>;
 }
 
 decl_event!(

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -165,7 +165,7 @@ decl_error! {
         NFTNotFound,
         /// At least one of the metadata keys has not been registered.
         UnregisteredMetadataKey,
-        /// Failed to transfer an NFT - asset is frozen.
+        /// Failed to transfer an NFT - duplicate ids are not allowed.
         InvalidNFTTransferDuplicatedNFTId,
     }
 }

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -59,6 +59,7 @@ decl_module! {
         type Error = Error<T>;
 
         const MaxNumberOfCollectionKeys: u8 = T::MaxNumberOfCollectionKeys::get();
+        const MaxNumberOfNFTsCount: u32 = T::MaxNumberOfNFTsCount::get();
 
         /// Initializes the default event for this module.
         fn deposit_event() = default;
@@ -141,6 +142,8 @@ decl_error! {
         CollectionNotFound,
         /// A duplicate metadata key has been passed as parameter.
         DuplicateMetadataKey,
+        /// Duplicate ids are not allowed.
+        DuplicatedNFTId,
         /// The asset must be of type non-fungible.
         InvalidAssetType,
         /// Either the number of keys or the key identifier does not match the keys defined for the collection.
@@ -151,22 +154,24 @@ decl_error! {
         InvalidNFTTransferSamePortfolio,
         /// Failed to transfer an NFT - NFT not found in portfolio.
         InvalidNFTTransferNFTNotOwned,
-        /// Failed to transfer an NFT - balance would overflow.
-        InvalidNFTTransferBalanceOverflow,
-        /// Failed to transfer an NFT - not enough balance.
-        InvalidNFTTransferNoBalance,
+        /// Failed to transfer an NFT - identity count would overflow.
+        InvalidNFTTransferCountOverflow,
         /// Failed to transfer an NFT - compliance failed.
         InvalidNFTTransferComplianceFailure,
         /// Failed to transfer an NFT - asset is frozen.
         InvalidNFTTransferFrozenAsset,
+        /// Failed to transfer an NFT - the number of nfts in the identity is insufficient.
+        InvalidNFTTransferInsufficientCount,
         /// The maximum number of metadata keys was exceeded.
         MaxNumberOfKeysExceeded,
+        /// The maximum number of nfts being transferred in one leg was exceeded.
+        MaxNumberOfNFTsPerLegExceeded,
         /// The NFT does not exist.
         NFTNotFound,
         /// At least one of the metadata keys has not been registered.
         UnregisteredMetadataKey,
-        /// Failed to transfer an NFT - duplicate ids are not allowed.
-        InvalidNFTTransferDuplicatedNFTId,
+        /// It is not possible to transferr zero nft.
+        ZeroCount,
     }
 }
 
@@ -383,7 +388,7 @@ impl<T: Config> Module<T> {
         receiver_portfolio: &PortfolioId,
         nfts: &NFTs,
     ) -> DispatchResult {
-        let transferred_amount = nfts.len() as u64;
+        let nfts_transferred = nfts.len() as u64;
         // Verifies that the sender and receiver are not the same
         ensure!(
             sender_portfolio != receiver_portfolio,
@@ -394,11 +399,13 @@ impl<T: Config> Module<T> {
             !Frozen::get(nfts.ticker()),
             Error::<T>::InvalidNFTTransferFrozenAsset
         );
-        // Verifies that the sender has the required balance
+        // Verifies that the sender has the required nft count
         ensure!(
-            NumberOfNFTs::get(nfts.ticker(), sender_portfolio.did) >= transferred_amount,
-            Error::<T>::InvalidNFTTransferNoBalance
+            NumberOfNFTs::get(nfts.ticker(), sender_portfolio.did) >= nfts_transferred,
+            Error::<T>::InvalidNFTTransferInsufficientCount
         );
+        // Verifies that the number of nfts being transferred are within the allowed limits
+        Self::ensure_within_nfts_transfer_limits(nfts)?;
         // Verifies that all ids are unique
         Self::ensure_no_duplicate_nfts(nfts)?;
         // Verfies that the sender owns the nfts
@@ -410,14 +417,14 @@ impl<T: Config> Module<T> {
         }
         // Verfies that the receiver will not overflow
         NumberOfNFTs::get(nfts.ticker(), receiver_portfolio.did)
-            .checked_add(transferred_amount)
-            .ok_or(Error::<T>::InvalidNFTTransferBalanceOverflow)?;
+            .checked_add(nfts_transferred)
+            .ok_or(Error::<T>::InvalidNFTTransferCountOverflow)?;
         // Verifies that all compliance rules are being respected
         let code = T::Compliance::verify_restriction(
             nfts.ticker(),
             Some(sender_portfolio.did),
             Some(receiver_portfolio.did),
-            transferred_amount.into(),
+            nfts_transferred.into(),
         )?;
         if code != ERC1400_TRANSFER_SUCCESS {
             return Err(Error::<T>::InvalidNFTTransferComplianceFailure.into());
@@ -426,13 +433,20 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
+    /// Verifies that the number of NFTs being transferred is greater than zero and less or equal to `MaxNumberOfNFTsPerLeg`.
+    pub fn ensure_within_nfts_transfer_limits(nfts: &NFTs) -> DispatchResult {
+        ensure!(nfts.len() > 0, Error::<T>::ZeroCount);
+        ensure!(
+            nfts.len() <= (T::MaxNumberOfNFTsCount::get() as usize),
+            Error::<T>::MaxNumberOfNFTsPerLegExceeded
+        );
+        Ok(())
+    }
+
     /// Verifies that there are no duplicate ids in the `NFTs` struct.
     pub fn ensure_no_duplicate_nfts(nfts: &NFTs) -> DispatchResult {
         let unique_nfts: BTreeSet<&NFTId> = nfts.ids().iter().collect();
-        ensure!(
-            unique_nfts.len() == nfts.len(),
-            Error::<T>::InvalidNFTTransferDuplicatedNFTId
-        );
+        ensure!(unique_nfts.len() == nfts.len(), Error::<T>::DuplicatedNFTId);
         Ok(())
     }
 }

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -559,7 +559,7 @@ macro_rules! runtime_apis {
         use pallet_identity::types::{AssetDidResult, CddStatus, RpcDidRecords, DidStatus, KeyIdentityData};
         use pallet_pips::{Vote, VoteCount};
         use pallet_protocol_fee_rpc_runtime_api::CappedFee;
-        use polymesh_primitives::{calendar::CheckpointId, compliance_manager::AssetComplianceResult, IdentityId, Index, PortfolioId, Signatory, Ticker};
+        use polymesh_primitives::{calendar::CheckpointId, compliance_manager::AssetComplianceResult, IdentityId, Index, PortfolioId, Signatory, Ticker, NFTs};
 
         /// The address format for describing accounts.
         pub type Address = <Indices as StaticLookup>::Source;
@@ -992,6 +992,17 @@ macro_rules! runtime_apis {
                     merge_active_and_inactive::<Block>(
                         CommitteeMembership::active_members(),
                         CommitteeMembership::inactive_members())
+                }
+            }
+
+            impl node_rpc_runtime_api::nft::NFTApi<Block> for Runtime {
+                #[inline]
+                fn validate_nft_transfer(
+                    sender_portfolio: &PortfolioId,
+                    receiver_portfolio: &PortfolioId,
+                    nfts: &NFTs
+                ) -> frame_support::dispatch::DispatchResult {
+                    Nft::validate_nft_transfer(sender_portfolio, receiver_portfolio, nfts)
                 }
             }
 

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -545,6 +545,7 @@ macro_rules! misc_pallet_impls {
             type WeightInfo = polymesh_weights::pallet_nft::WeightInfo;
             type Compliance = pallet_compliance_manager::Module<Runtime>;
             type MaxNumberOfCollectionKeys = MaxNumberOfCollectionKeys;
+            type MaxNumberOfNFTsCount = MaxNumberOfNFTsPerLeg;
         }
     };
 }

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -637,7 +637,7 @@ fn transfer_nft_invalid_count() {
             with_transaction(|| {
                 NFT::base_nft_transfer(&sender_portfolio, &receiver_portfolio, &nfts)
             }),
-            NFTError::InvalidNFTTransferNoBalance
+            NFTError::InvalidNFTTransferInsufficientCount
         );
     });
 }
@@ -685,7 +685,7 @@ fn transfer_nft_not_owned() {
             with_transaction(|| {
                 NFT::base_nft_transfer(&sender_portfolio, &receiver_portfolio, &nfts)
             }),
-            NFTError::InvalidNFTTransferNoBalance
+            NFTError::InvalidNFTTransferInsufficientCount
         );
     });
 }

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -54,6 +54,7 @@ type Settlement = pallet_settlement::Module<TestStorage>;
 type System = frame_system::Pallet<TestStorage>;
 type Error = pallet_settlement::Error<TestStorage>;
 type Scheduler = scheduler::Pallet<TestStorage>;
+type NFTError = pallet_nft::Error<TestStorage>;
 
 const TICKER: Ticker = Ticker::new_unchecked([b'A', b'C', b'M', b'E', 0, 0, 0, 0, 0, 0, 0, 0]);
 const TICKER2: Ticker = Ticker::new_unchecked([b'A', b'C', b'M', b'E', b'2', 0, 0, 0, 0, 0, 0, 0]);
@@ -2467,7 +2468,7 @@ fn add_nft_instruction_with_duplicated_nfts() {
                 legs,
                 Some(InstructionMemo::default()),
             ),
-            Error::DuplicatedNFTId
+            NFTError::DuplicatedNFTId
         );
     });
 }
@@ -2511,7 +2512,7 @@ fn add_nft_instruction_exceeding_nfts() {
                 legs,
                 Some(InstructionMemo::default()),
             ),
-            Error::MaxNumberOfNFTsPerLegExceeded
+            NFTError::MaxNumberOfNFTsPerLegExceeded
         );
     });
 }

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -33,7 +33,7 @@ use polymesh_primitives::{
     checked_inc::CheckedInc,
     statistics::{Stat2ndKey, StatType, StatUpdate},
     transfer_compliance::{TransferCondition, TransferConditionExemptKey},
-    Claim, Condition, ConditionType, CountryCode, IdentityId, PortfolioId, PortfolioKind,
+    Claim, Condition, ConditionType, CountryCode, IdentityId, NFTId, PortfolioId, PortfolioKind,
     PortfolioName, PortfolioNumber, Scope, Ticker, TrustedIssuer,
 };
 use sp_runtime::SaturatedConversion;

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -606,13 +606,11 @@ decl_error! {
         InstructionSettleBlockNotReached,
         /// The caller is not a party of this instruction.
         CallerIsNotAParty,
-        /// There is a duplicated nft in one of the legs.
-        DuplicatedNFTId,
         /// Expected a different type of asset in a leg.
         InvalidLegAsset,
         /// The number of nfts being transferred in the instruction was exceeded.
         MaxNumberOfNFTsExceeded,
-        /// The number of nfts being transferred in one leg was exceeded.
+        /// The maximum number of nfts being transferred in one leg was exceeded.
         MaxNumberOfNFTsPerLegExceeded,
         /// The given number of nfts being transferred was underestimated.
         NumberOfTransferredNFTsUnderestimated,
@@ -1423,14 +1421,9 @@ impl<T: Config> Module<T> {
                     fungible_transfers += 1;
                 }
                 LegAsset::NonFungible(nfts) => {
-                    ensure!(nfts.len() > 0, Error::<T>::ZeroAmount);
-                    ensure!(
-                        nfts.len() <= (T::MaxNumberOfNFTsPerLeg::get() as usize),
-                        Error::<T>::MaxNumberOfNFTsPerLegExceeded
-                    );
+                    <Nft<T>>::ensure_within_nfts_transfer_limits(&nfts)?;
                     Self::ensure_venue_filtering(&mut tickers, nfts.ticker().clone(), &venue_id)?;
-                    <Nft<T>>::ensure_no_duplicate_nfts(&nfts)
-                        .map_err(|_| Error::<T>::DuplicatedNFTId)?;
+                    <Nft<T>>::ensure_no_duplicate_nfts(&nfts)?;
                     nfts_transfers += nfts.len();
                 }
             }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -74,8 +74,8 @@ use polymesh_common_utilities::{
     SystematicIssuers::Settlement as SettlementDID,
 };
 use polymesh_primitives::{
-    impl_checked_inc, storage_migration_ver, Balance, IdentityId, NFTId, NFTs, PortfolioId,
-    SecondaryKey, Ticker,
+    impl_checked_inc, storage_migration_ver, Balance, IdentityId, NFTs, PortfolioId, SecondaryKey,
+    Ticker,
 };
 use polymesh_primitives_derive::VecU8StrongTyped;
 use scale_info::TypeInfo;
@@ -1429,8 +1429,8 @@ impl<T: Config> Module<T> {
                         Error::<T>::MaxNumberOfNFTsPerLegExceeded
                     );
                     Self::ensure_venue_filtering(&mut tickers, nfts.ticker().clone(), &venue_id)?;
-                    let unique_nfts: BTreeSet<&NFTId> = nfts.ids().iter().collect();
-                    ensure!(unique_nfts.len() == nfts.len(), Error::<T>::DuplicatedNFTId);
+                    <Nft<T>>::ensure_no_duplicate_nfts(&nfts)
+                        .map_err(|_| Error::<T>::DuplicatedNFTId)?;
                     nfts_transfers += nfts.len();
                 }
             }

--- a/primitives/src/nft.rs
+++ b/primitives/src/nft.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::collections::btree_set::BTreeSet;
@@ -19,6 +22,7 @@ impl_checked_inc!(NFTCollectionId);
 #[derive(
     Clone, Copy, Debug, Decode, Default, Encode, Eq, Ord, PartialOrd, PartialEq, TypeInfo
 )]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct NFTId(pub u64);
 impl_checked_inc!(NFTId);
 
@@ -48,6 +52,7 @@ impl NFTCollection {
 
 /// Represent all NFT being transferred for a given `Ticker`.
 #[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct NFTs {
     ticker: Ticker,
     ids: Vec<NFTId>,

--- a/rpc/runtime-api/src/asset.rs
+++ b/rpc/runtime-api/src/asset.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Runtime API definition for Identity module.
+//! Runtime API definition for Asset module.
 
 use codec::Codec;
 use polymesh_primitives::{Balance, IdentityId, PortfolioId, Ticker};

--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -19,5 +19,6 @@
 pub mod asset;
 pub mod compliance_manager;
 pub mod identity;
+pub mod nft;
 pub mod pips;
 pub mod transaction_payment;

--- a/rpc/runtime-api/src/nft.rs
+++ b/rpc/runtime-api/src/nft.rs
@@ -26,6 +26,19 @@ sp_api::decl_runtime_apis! {
         /// In order for the transfer to be successfull, the following conditions must hold:
         /// The sender and receiver are not the same, both portfolios have valid balances, the sender owns the nft,
         /// all compliance rules are being respected, and no duplicate nfts being transferred.
+        /// 
+        /// ```ignore
+        /// curl http://localhost:9933 -H "Content-Type: application/json" -d '{
+        ///     "id":1, 
+        ///     "jsonrpc":"2.0",
+        ///     "method": "nft_validateNFTTransfer",
+        ///     "params":[
+        ///       { "did": "0x0100000000000000000000000000000000000000000000000000000000000000", "kind": "Default"},
+        ///       { "did": "0x0200000000000000000000000000000000000000000000000000000000000000", "kind": "Default"},
+        ///       { "ticker": "0x5449434B4552303030303031", "ids": [1]}
+        ///     ]
+        ///   }'
+        /// ```
         fn validate_nft_transfer(sender_portfolio: &PortfolioId, receiver_portfolio: &PortfolioId, nfts: &NFTs) -> DispatchResult;
     }
 }

--- a/rpc/runtime-api/src/nft.rs
+++ b/rpc/runtime-api/src/nft.rs
@@ -1,0 +1,31 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymeshAssociation/Polymesh).
+// Copyright (c) 2020 Polymath
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Runtime API definition for NFT module.
+
+use frame_support::dispatch::DispatchResult;
+
+use polymesh_primitives::{NFTs, PortfolioId};
+
+sp_api::decl_runtime_apis! {
+
+    pub trait NFTApi {
+        /// Verifies if the given NFTs can be transferred from `sender_portfolio` to `receiver_portfolio`.
+        /// In order for the transfer to be successfull, the following conditions must hold:
+        /// The sender and receiver are not the same, both portfolios have valid balances, the sender owns the nft,
+        /// all compliance rules are being respected, and no duplicate nfts being transferred.
+        fn validate_nft_transfer(sender_portfolio: &PortfolioId, receiver_portfolio: &PortfolioId, nfts: &NFTs) -> DispatchResult;
+    }
+}

--- a/rpc/runtime-api/src/nft.rs
+++ b/rpc/runtime-api/src/nft.rs
@@ -26,10 +26,10 @@ sp_api::decl_runtime_apis! {
         /// In order for the transfer to be successfull, the following conditions must hold:
         /// The sender and receiver are not the same, both portfolios have valid balances, the sender owns the nft,
         /// all compliance rules are being respected, and no duplicate nfts being transferred.
-        /// 
+        ///
         /// ```ignore
         /// curl http://localhost:9933 -H "Content-Type: application/json" -d '{
-        ///     "id":1, 
+        ///     "id":1,
         ///     "jsonrpc":"2.0",
         ///     "method": "nft_validateNFTTransfer",
         ///     "params":[

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -41,5 +41,6 @@ macro_rules! rpc_forward_call {
 pub mod asset;
 pub mod compliance_manager;
 pub mod identity;
+pub mod nft;
 pub mod pips;
 pub mod transaction_payment;

--- a/rpc/src/nft.rs
+++ b/rpc/src/nft.rs
@@ -1,0 +1,83 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymeshAssociation/Polymesh).
+// Copyright (c) 2020 Polymath
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use frame_support::dispatch::DispatchResult;
+use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
+use jsonrpc_derive::rpc;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::generic::BlockId;
+use sp_runtime::traits::Block as BlockT;
+
+use node_rpc_runtime_api::nft::NFTApi as NFTRuntimeApi;
+use polymesh_primitives::{NFTs, PortfolioId};
+
+#[rpc]
+pub trait NFTApi<BlockHash> {
+    #[rpc(name = "nft_validateNFTTransfer")]
+    fn validate_nft_transfer(
+        &self,
+        sender_portfolio: PortfolioId,
+        receiver_portfolio: PortfolioId,
+        nfts: NFTs,
+        at: Option<BlockHash>,
+    ) -> Result<DispatchResult>;
+}
+
+/// An implementation of NFT specific RPC methods.
+pub struct NFT<T, U> {
+    client: Arc<T>,
+    _marker: std::marker::PhantomData<U>,
+}
+
+impl<T, U> NFT<T, U> {
+    /// Creates a new `NFT` with the given reference to the client.
+    pub fn new(client: Arc<T>) -> Self {
+        Self {
+            client,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<T, Block> NFTApi<<Block as BlockT>::Hash> for NFT<T, Block>
+where
+    Block: BlockT,
+    T: Send + Sync + 'static,
+    T: ProvideRuntimeApi<Block>,
+    T: HeaderBackend<Block>,
+    T::Api: NFTRuntimeApi<Block>,
+{
+    fn validate_nft_transfer(
+        &self,
+        sender_portfolio: PortfolioId,
+        receiver_portfolio: PortfolioId,
+        nfts: NFTs,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> Result<DispatchResult> {
+        let api = self.client.runtime_api();
+        // If the block hash is not supplied assume the best block.
+        let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
+
+        api.validate_nft_transfer(&at, &sender_portfolio, &receiver_portfolio, &nfts)
+            .map_err(|e| RpcError {
+                code: ErrorCode::ServerError(crate::Error::RuntimeError as i64),
+                message: "Unable to call validate_nft_transfer runtime".into(),
+                data: Some(format!("{:?}", e).into()),
+            })
+    }
+}

--- a/rpc/src/nft.rs
+++ b/rpc/src/nft.rs
@@ -23,7 +23,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::Block as BlockT;
 
-use node_rpc_runtime_api::nft::NFTApi as NFTRuntimeApi;
+pub use node_rpc_runtime_api::nft::NFTApi as NFTRuntimeApi;
 use polymesh_primitives::{NFTs, PortfolioId};
 
 #[rpc]

--- a/src/service.rs
+++ b/src/service.rs
@@ -110,6 +110,7 @@ pub trait RuntimeApiCollection:
     + node_rpc_runtime_api::asset::AssetApi<Block, AccountId>
     + pallet_group_rpc_runtime_api::GroupApi<Block>
     + node_rpc_runtime_api::compliance_manager::ComplianceManagerApi<Block, AccountId>
+    + node_rpc_runtime_api::nft::NFTApi<Block>
 where
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
@@ -135,7 +136,8 @@ where
         + pallet_protocol_fee_rpc_runtime_api::ProtocolFeeApi<Block>
         + node_rpc_runtime_api::asset::AssetApi<Block, AccountId>
         + pallet_group_rpc_runtime_api::GroupApi<Block>
-        + node_rpc_runtime_api::compliance_manager::ComplianceManagerApi<Block, AccountId>,
+        + node_rpc_runtime_api::compliance_manager::ComplianceManagerApi<Block, AccountId>
+        + node_rpc_runtime_api::nft::NFTApi<Block>,
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }


### PR DESCRIPTION
Adds the `nft_validateNFTTransfer` rpc call

## changelog

### new features

- Adds `nft_validateNFTTransfer` rpc call

### modified API

- Adds the `InvalidNFTTransferCountOverflow`, `InvalidNFTTransferInsufficientCount`, `MaxNumberOfNFTsPerLegExceeded`, `ZeroCount`, `DuplicatedNFTId` error variants to the NFT pallet;
- Removes the `InvalidNFTTransferBalanceOverflow`, `InvalidNFTTransferNoBalance`, error variants from the NFT pallet;
- Removes `DuplicatedNFTId` error variant from the setlement pallet;
