### PR TITLE
Fix bug with Delegate call selectors.

### DIFF
--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-ink"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Polymesh Association"]
 edition = "2021"
 license = "Apache-2.0"

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-ink"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Polymesh Association"]
 edition = "2021"
 license = "Apache-2.0"

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-ink"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Polymesh Association"]
 edition = "2021"
 license = "Apache-2.0"

--- a/contracts/upgradeable-polymesh-ink/README.md
+++ b/contracts/upgradeable-polymesh-ink/README.md
@@ -42,7 +42,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.1", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "example_contract"

--- a/contracts/upgradeable-polymesh-ink/README.md
+++ b/contracts/upgradeable-polymesh-ink/README.md
@@ -42,7 +42,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.4", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "example_contract"

--- a/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.toml
@@ -16,7 +16,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.4", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "settlements"

--- a/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/examples/settlements/Cargo.toml
@@ -16,7 +16,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.2", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "settlements"

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
@@ -17,7 +17,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.2", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "test_polymesh_ink"

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
@@ -17,7 +17,7 @@ ink_lang_codegen = { version = "3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "0.5.3", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
+polymesh-ink = { version = "0.5.4", path = "../../", default-features = false, features = ["as-library", "tracker", "always-delegate"] }
 
 [lib]
 name = "test_polymesh_ink"

--- a/contracts/upgradeable-polymesh-ink/src/lib.rs
+++ b/contracts/upgradeable-polymesh-ink/src/lib.rs
@@ -211,6 +211,32 @@ upgradable_api! {
                 Ok(())
             }
 
+            /// Get portfolio balance.
+            #[ink(message)]
+            pub fn portfolio_asset_balances(
+                &self,
+                portfolio: PortfolioId,
+                ticker: Ticker
+            ) -> PolymeshResult<Balance> {
+                let api = Api::new();
+                let balance = api.query().portfolio().portfolio_asset_balances(portfolio, ticker).map(|v| v.into())?;
+                Ok(balance)
+            }
+
+            /// Check portfolios_in_custody.
+            #[ink(message)]
+            pub fn check_portfolios_in_custody(
+                &self,
+                did: IdentityId,
+                portfolio: PortfolioId
+            ) -> PolymeshResult<bool> {
+                let api = Api::new();
+                Ok(api
+                    .query()
+                    .portfolio()
+                    .portfolios_in_custody(did, portfolio)?)
+            }
+
             /// Create a Settlement Venue.
             #[ink(message)]
             pub fn create_venue(&self, details: VenueDetails, ty: VenueType) -> PolymeshResult<VenueId> {

--- a/contracts/upgradeable-polymesh-ink/src/lib.rs
+++ b/contracts/upgradeable-polymesh-ink/src/lib.rs
@@ -39,6 +39,61 @@ pub enum PolymeshError {
     MissingIdentity,
     /// Invalid portfolio authorization.
     InvalidPortfolioAuthorization,
+    /// Ink! Delegate call error.
+    InkDelegateCallError {
+      selector: [u8; 4],
+      err: Option<InkEnvError>,
+    },
+}
+
+/// Encodable `ink_env::Error`.
+#[derive(Debug, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum InkEnvError {
+    /// Error upon decoding an encoded value.
+    ScaleDecodeError,
+    /// The call to another contract has trapped.
+    CalleeTrapped,
+    /// The call to another contract has been reverted.
+    CalleeReverted,
+    /// The queried contract storage entry is missing.
+    KeyNotFound,
+    /// Transfer failed for other not further specified reason. Most probably
+    /// reserved or locked balance of the sender that was preventing the transfer.
+    TransferFailed,
+    /// Deprecated and no longer returned: Endowment is no longer required.
+    _EndowmentTooLow,
+    /// No code could be found at the supplied code hash.
+    CodeNotFound,
+    /// The account that was called is no contract, but a plain account.
+    NotCallable,
+    /// The call to `seal_debug_message` had no effect because debug message
+    /// recording was disabled.
+    LoggingDisabled,
+    /// ECDSA pubkey recovery failed. Most probably wrong recovery id or signature.
+    EcdsaRecoveryFailed,
+}
+
+impl PolymeshError {
+    pub fn from_delegate_error(err: ink_env::Error, selector: ink_env::call::Selector) -> Self {
+        use ink_env::Error::*;
+        Self::InkDelegateCallError {
+          selector: selector.to_bytes(),
+          err: match err {
+            Decode(_) => Some(InkEnvError::ScaleDecodeError),
+            CalleeTrapped => Some(InkEnvError::CalleeTrapped),
+            CalleeReverted => Some(InkEnvError::CalleeReverted),
+            KeyNotFound => Some(InkEnvError::KeyNotFound),
+            TransferFailed => Some(InkEnvError::TransferFailed),
+            _EndowmentTooLow => Some(InkEnvError::_EndowmentTooLow),
+            CodeNotFound => Some(InkEnvError::CodeNotFound),
+            NotCallable => Some(InkEnvError::NotCallable),
+            LoggingDisabled => Some(InkEnvError::LoggingDisabled),
+            EcdsaRecoveryFailed => Some(InkEnvError::EcdsaRecoveryFailed),
+            _ => None,
+          },
+        }
+    }
 }
 
 impl From<polymesh_api::ink::Error> for PolymeshError {

--- a/contracts/upgradeable-polymesh-ink/src/macros.rs
+++ b/contracts/upgradeable-polymesh-ink/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! upgradable_api {
             ///
             /// Contracts can use this to maintain support accross
             /// major Polymesh releases.
-            #[derive(Debug, Default, scale::Encode, scale::Decode)]
+            #[derive(Clone, Debug, Default, scale::Encode, scale::Decode)]
             #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
             #[derive(ink_storage::traits::SpreadLayout)]
             #[derive(ink_storage::traits::PackedLayout)]
@@ -160,7 +160,7 @@ macro_rules! upgradable_api {
             #[cfg(feature = "always-delegate")]
             let hash = Some($self.hash);
             if let Some(hash) = hash {
-                const FUNC: &str = stringify!($func);
+                const FUNC: &str = stringify!{$fn_name};
                 let selector: [u8; 4] = ::polymesh_api::ink::blake2_256(FUNC.as_bytes())[..4]
                   .try_into().unwrap();
                 let ret = ink_env::call::build_call::<ink_env::DefaultEnvironment>()

--- a/contracts/upgradeable-polymesh-ink/src/macros.rs
+++ b/contracts/upgradeable-polymesh-ink/src/macros.rs
@@ -122,9 +122,7 @@ macro_rules! upgradable_api {
                     }
                     Ok(())
                 }
-            }
 
-            impl $api_type {
                 $(
                     $crate::upgradable_api! {
                         @impl_api_func
@@ -160,19 +158,18 @@ macro_rules! upgradable_api {
             #[cfg(feature = "always-delegate")]
             let hash = Some($self.hash);
             if let Some(hash) = hash {
-                const FUNC: &str = stringify!{$fn_name};
-                let selector: [u8; 4] = ::polymesh_api::ink::blake2_256(FUNC.as_bytes())[..4]
-                  .try_into().unwrap();
-                let ret = ink_env::call::build_call::<ink_env::DefaultEnvironment>()
+                const FUNC: &'static str = stringify!{$fn_name};
+                let selector = Selector::new(::polymesh_api::ink::blake2_256(FUNC.as_bytes())[..4]
+                  .try_into().unwrap());
+                ink_env::call::build_call::<ink_env::DefaultEnvironment>()
                     .call_type(DelegateCall::new().code_hash(hash))
                     .exec_input(
-                        ExecutionInput::new(Selector::new(selector))
+                        ExecutionInput::new(selector)
                             .push_arg(($($param),*)),
                     )
                     .returns::<$fn_return>()
                     .fire()
-                    .unwrap_or_else(|err| panic!("delegate call to {:?} failed due to {:?}", hash, err))?;
-                Ok(ret)
+                    .map_err(|e| crate::PolymeshError::from_delegate_error(e, selector))?
             } else {
                 $( $fn_impl )*
             }


### PR DESCRIPTION
Fix a bug with encoding Delegate calls.

Note `stringify!` macro doesn't complain if the tokens passed to it exists or not.  The  wrong macro variable was pass to it, but didn't cause a compile-time error, it just stringified the non-existing macro variable name.

Also improved the error handling of delegate calls, before it would just panic, now it provides some details (the details are limited to keep code size down).