### PR TITLE
Fix GitHub workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       - run:
           name: Check formatting
           command: ./scripts/rustfmt.sh
+      - run:
+          name: Check runtime spec versions and polymesh crate version.
+          command: ./scripts/check_spec_and_cargo_version.sh
   check-storage-version:
     docker:
       - image: polymeshassociation/rust:debian-nightly-2022-11-02
@@ -40,7 +43,7 @@ jobs:
             - v7-release-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
           name: Build release
-          command: cargo build --release
+          command: cargo build --locked --release
           no_output_timeout: 1h
       - run:
           name: Create assets directory for releases
@@ -78,7 +81,7 @@ jobs:
             - v7-release-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
           name: Build ci-runtime
-          command: cargo build --release --features ci-runtime
+          command: cargo build --locked --release --features ci-runtime
           no_output_timeout: 1h
       - run:
           name: Create assets directory for releases

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
         target: wasm32-unknown-unknown
         override: true
         default: true
+    - name: Install protobuf-compiler
+      run: sudo apt-get install -y protobuf-compiler
     - name: Build docs
       run: BUILD_DUMMY_WASM_BINARY=1 cargo doc --no-deps --workspace --release --exclude node-bench --exclude node-executor --exclude node-testing --exclude crypto-cli
     - name: Add index file

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "5.4.1"
+version = "5.4.0"
 authors = ["Polymesh Association"]
 build = "build.rs"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "5.4.0"
+version = "5.4.1"
 authors = ["Polymesh Association"]
 build = "build.rs"
 edition = "2021"

--- a/scripts/check_spec_and_cargo_version.sh
+++ b/scripts/check_spec_and_cargo_version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+SPEC_COUNT=`grep -h -r ' spec_version: ' pallets/runtime/*/src/runtime.rs | sort -u | wc -l`
+if [ "$SPEC_COUNT" = "1" ]; then
+	echo "Spec count ok"
+else
+	echo "Multiple Spec versions."
+	exit 1
+fi
+POLYMESH_VERSION=`grep -h -r ' spec_version: ' pallets/runtime/*/src/runtime.rs | sort -u | sed -e 's/.*spec_version: \([0-9]\+\)_[0]*\([0-9]\+\)_[0]*\([0-9]\+\)[0-9],/\1.\2.\3/g'`
+
+if head Cargo.toml | grep -q $POLYMESH_VERSION; then
+	echo "Spec version matches Polymesh version."
+	exit 0
+else
+	echo "Spec version doesn't match Polymesh version."
+	exit 1
+fi


### PR DESCRIPTION
CI pipeline changes.

- Fix building of docs.
- Require that `Cargo.lock` is up to date when building.
- Add checks for runtime spec versions (the runtime must have the same spec) and crate version (must match spec version).