### PR TITLE
disable creation of assets with Investor Uniqueness on.

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -249,7 +249,7 @@ benchmarks! {
        let (origin, name, ticker, token, identifiers, fundr) = setup_create_asset::<T>(n, i , f, 0);
        let identifiers2 = identifiers.clone();
        let asset_type = token.asset_type.clone();
-    }: _(origin, name, ticker, token.divisible, asset_type, identifiers, fundr, false)
+    }: _(origin, name, ticker, token.divisible, asset_type, identifiers, fundr, true)
     verify {
         assert_eq!(Module::<T>::token_details(ticker), token);
         assert_eq!(Module::<T>::identifiers(ticker), identifiers2);
@@ -514,7 +514,7 @@ benchmarks! {
             AssetType::NonFungible(NonFungibleType::Derivative),
             Vec::new(),
             None,
-            false,
+            true,
         ).unwrap();
         // Creates two metadata keys, one that belong to the NFT collection and one that doesn't
         let asset_metadata_name = AssetMetadataName(b"mylocalkey".to_vec());
@@ -552,7 +552,7 @@ benchmarks! {
             AssetType::NonFungible(NonFungibleType::Derivative),
             Vec::new(),
             None,
-            false,
+            true,
         ).unwrap();
         // Creates one metadata key and set its value
         let asset_metadata_name = AssetMetadataName(b"mylocalkey".to_vec());

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1044,6 +1044,9 @@ impl<T: Config> AssetFnTrait<T::AccountId, T::RuntimeOrigin> for Module<T> {
     #[cfg(feature = "runtime-benchmarks")]
     /// Adds an artificial IU claim for benchmarks
     fn add_investor_uniqueness_claim(did: IdentityId, ticker: Ticker) {
+        if Self::disable_iu(ticker) {
+            return;
+        }
         use polymesh_primitives::{CddId, Claim, InvestorUid, Scope};
         Identity::<T>::unverified_add_claim_with_scope(
             did,

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -999,7 +999,9 @@ decl_error! {
         /// Attempt to delete a key that is needed for an NFT collection.
         AssetMetadataKeyBelongsToNFTCollection,
         /// Attempt to lock a metadata value that is empty.
-        AssetMetadataValueIsEmpty
+        AssetMetadataValueIsEmpty,
+        /// Investor Uniqueness not allowed.
+        InvestorUniquenessNotAllowed,
     }
 }
 
@@ -1801,6 +1803,8 @@ impl<T: Config> Module<T> {
         funding_round: Option<FundingRoundName>,
         disable_iu: bool,
     ) -> Result<IdentityId, DispatchError> {
+        ensure!(disable_iu, Error::<T>::InvestorUniquenessNotAllowed);
+
         Self::ensure_asset_name_bounded(&name)?;
         if let Some(fr) = &funding_round {
             Self::ensure_funding_round_name_bounded(fr)?;

--- a/pallets/common/src/benchs/asset.rs
+++ b/pallets/common/src/benchs/asset.rs
@@ -41,7 +41,7 @@ fn make_base_asset<T: Config>(owner: &User<T>, divisible: bool, name: Option<&[u
         AssetType::default(),
         vec![],
         None,
-        false,
+        true,
     )
     .expect("Asset cannot be created");
 

--- a/pallets/compliance-manager/src/benchmarking.rs
+++ b/pallets/compliance-manager/src/benchmarking.rs
@@ -136,7 +136,7 @@ pub fn make_token<T: Config>(owner: &User<T>, name: Vec<u8>) -> Ticker {
         token.asset_type.clone(),
         vec![],
         None,
-        false,
+        true,
     )
     .expect("Cannot create an asset");
 

--- a/pallets/corporate-actions/src/benchmarking.rs
+++ b/pallets/corporate-actions/src/benchmarking.rs
@@ -147,7 +147,7 @@ pub(crate) fn currency<T: Config>(owner: &User<T>) -> Ticker {
         <_>::default(),
         vec![],
         None,
-        false,
+        true,
     )
     .expect("Asset cannot be created");
     Asset::<T>::issue(owner.origin().into(), currency, 1_000_000u32.into())

--- a/pallets/identity/src/auth.rs
+++ b/pallets/identity/src/auth.rs
@@ -122,15 +122,6 @@ impl<T: Config> Module<T> {
         Self::deposit_event(event(id, acc, auth_id))
     }
 
-    /// Returns an iterator over all authorizations belonging to `signer` and authorized by `did`.
-    pub(crate) fn auths_of(
-        signer: &Signatory<T::AccountId>,
-        did: IdentityId,
-    ) -> impl Iterator<Item = u64> {
-        <Authorizations<T>>::iter_prefix_values(signer)
-            .filter_map(move |auth| (auth.authorized_by == did).then_some(auth.auth_id))
-    }
-
     /// Use to get the filtered authorization data for a given signatory
     /// - if auth_type is None then return authorizations data on the basis of the `allow_expired` boolean
     /// - if auth_type is Some(value) then return filtered authorizations on the value basis type in conjunction

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -442,13 +442,6 @@ impl<T: Config> Module<T> {
         for key in &keys {
             // Unlink the secondary account key.
             Self::remove_key_record(key, Some(did));
-
-            // All `auth_id`s for `signer` authorized by `did`.
-            let signer = Signatory::Account(key.clone());
-            for auth_id in Self::auths_of(&signer, did) {
-                // Remove authorizations.
-                Self::unsafe_remove_auth(&signer, auth_id, &did, true);
-            }
         }
 
         Self::deposit_event(RawEvent::SecondaryKeysRemoved(did, keys));

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -238,7 +238,7 @@ impl<T: Config> Module<T> {
                 AssetType::NonFungible(nft_type),
                 Vec::new(),
                 None,
-                false,
+                true,
             )?;
         }
 

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -156,7 +156,7 @@ fn asset_with_ids(
         token.asset_type.clone(),
         ids,
         None,
-        false,
+        true,
     )?;
     enable_investor_count(ticker, owner);
     Asset::issue(owner.origin(), ticker, token.total_supply)?;
@@ -266,7 +266,7 @@ fn issuers_can_create_and_rename_tokens() {
             token.asset_type.clone(),
             Vec::new(),
             Some(funding_round_name.clone()),
-            false,
+            true,
         ));
         enable_investor_count(ticker, owner);
 
@@ -937,7 +937,7 @@ fn frozen_secondary_keys_create_asset_we() {
         token_1.asset_type.clone(),
         vec![],
         None,
-        false,
+        true,
     ));
     assert_ok!(Asset::issue(bob.origin(), ticker_1, token_1.total_supply));
     assert_eq!(Asset::token_details(ticker_1), token_1);
@@ -1272,7 +1272,7 @@ fn classic_ticker_register_works() {
             <_>::default(),
             vec![],
             None,
-            false,
+            true,
         ));
         assert_noop!(
             Asset::reserve_classic_ticker(root(), classic, alice.did, config.clone()),
@@ -1534,7 +1534,7 @@ fn classic_ticker_claim_works() {
                 <_>::default(),
                 vec![],
                 None,
-                false,
+                true,
             );
             assert_balance(user.acc(), bal_after, 0);
             ret
@@ -1591,6 +1591,7 @@ fn generate_uid(entity_name: String) -> InvestorUid {
 }
 
 // Test for the validating the code for unique investors and aggregation of balances.
+#[ignore]
 #[test]
 fn check_unique_investor_count() {
     let cdd_provider = AccountKeyring::Charlie.to_account_id();
@@ -2083,7 +2084,7 @@ fn create_asset_errors(owner: AccountId, other: AccountId) {
             AssetType::default(),
             vec![],
             funding_name,
-            false,
+            true,
         )
     };
 

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -1456,7 +1456,7 @@ fn check_new_return_type_of_rpc() {
         assert_eq!(result.requirements[0], compliance_requirement);
         assert_eq!(result.result, true);
 
-        // Should fail txn as implicit requirements are active.
-        assert_invalid_transfer!(ticker, owner.did, receiver.did, 100);
+        // Transfer should be valid as there are no restrictions.
+        assert_valid_transfer!(ticker, owner.did, receiver.did, 100);
     });
 }

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -2026,8 +2026,14 @@ fn dist_claim_misc_bad() {
         ));
 
         // Resume compliance to cause transfer failure.
-        assert_ok!(ComplianceManager::resume_asset_compliance(owner.origin(), ticker2));
-        assert_ok!(ComplianceManager::reset_asset_compliance(owner.origin(), ticker2));
+        assert_ok!(ComplianceManager::resume_asset_compliance(
+            owner.origin(),
+            ticker2
+        ));
+        assert_ok!(ComplianceManager::reset_asset_compliance(
+            owner.origin(),
+            ticker2
+        ));
 
         // But it hasn't started yet.
         set_timestamp(4);

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -2012,17 +2012,22 @@ fn dist_claim_misc_bad() {
         // Dist doesn't exist yet.
         noop(DistError::NoSuchDistribution.into());
 
+        let ticker2 = create_asset(b"BETA", owner);
         // Now it does.
         assert_ok!(Dist::distribute(
             owner.origin(),
             id,
             None,
-            create_asset(b"BETA", owner),
+            ticker2,
             1,
             1,
             5,
             Some(6)
         ));
+
+        // Resume compliance to cause transfer failure.
+        assert_ok!(ComplianceManager::resume_asset_compliance(owner.origin(), ticker2));
+        assert_ok!(ComplianceManager::reset_asset_compliance(owner.origin(), ticker2));
 
         // But it hasn't started yet.
         set_timestamp(4);
@@ -2032,7 +2037,7 @@ fn dist_claim_misc_bad() {
         set_timestamp(6);
         noop(DistError::CannotClaimAfterExpiry.into());
 
-        // Travel back in time. Now dist is active, but no scope claims, so transfer fails.
+        // Travel back in time. Now dist is active, but compliance rules not met, so transfer fails.
         set_timestamp(5);
         noop(AssetError::InvalidTransfer.into());
     });

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -1900,6 +1900,7 @@ fn add_permission_with_secondary_key() {
         });
 }
 
+#[ignore]
 #[test]
 fn add_investor_uniqueness_claim() {
     ExtBuilder::default()
@@ -1967,6 +1968,7 @@ fn do_add_investor_uniqueness_claim() {
     aggregate_balance(new_scope_id, asset_balance);
 }
 
+#[ignore]
 #[test]
 fn add_investor_uniqueness_claim_v2() {
     let user = AccountKeyring::Alice.to_account_id();

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -70,7 +70,7 @@ fn create_collection_invalid_asset_type() {
             AssetType::default(),
             Vec::new(),
             None,
-            false,
+            true,
         )
         .expect("failed to create an asset");
 
@@ -190,7 +190,7 @@ pub(crate) fn create_nft_collection(
         asset_type,
         Vec::new(),
         None,
-        false,
+        true,
     )
     .expect("failed to create an asset");
     for (i, _) in collection_keys.keys().iter().enumerate() {

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -2012,8 +2012,14 @@ fn reject_failed_instruction() {
         ));
 
         // Resume compliance to cause transfer failure.
-        assert_ok!(ComplianceManager::resume_asset_compliance(alice.origin(), TICKER));
-        assert_ok!(ComplianceManager::reset_asset_compliance(alice.origin(), TICKER));
+        assert_ok!(ComplianceManager::resume_asset_compliance(
+            alice.origin(),
+            TICKER
+        ));
+        assert_ok!(ComplianceManager::reset_asset_compliance(
+            alice.origin(),
+            TICKER
+        ));
 
         // Go to next block to have the scheduled execution run and ensure it has failed.
         next_block();

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -196,7 +196,7 @@ fn create_token(ticker: Ticker, user: User) {
         AssetType::default(),
         vec![],
         None,
-        false,
+        true,
     ));
     assert_ok!(Asset::issue(user.origin(), ticker, 100_000));
     allow_all_transfers(ticker, user);
@@ -2010,6 +2010,10 @@ fn reject_failed_instruction() {
             default_portfolio_vec(bob.did),
             1
         ));
+
+        // Resume compliance to cause transfer failure.
+        assert_ok!(ComplianceManager::resume_asset_compliance(alice.origin(), TICKER));
+        assert_ok!(ComplianceManager::reset_asset_compliance(alice.origin(), TICKER));
 
         // Go to next block to have the scheduled execution run and ensure it has failed.
         next_block();

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -80,7 +80,7 @@ pub fn create_asset(origin: Origin, ticker: Ticker, supply: u128) {
         AssetType::default(),
         vec![],
         None,
-        false,
+        true,
     ));
     assert_ok!(Asset::issue(origin, ticker, supply));
 }

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -934,13 +934,15 @@ pub fn provide_scope_claim(
 }
 
 pub fn add_investor_uniqueness_claim(
-    _claim_to: IdentityId,
-    _scope: Ticker,
-    _scope_id: ScopeId,
-    _cdd_id: CddId,
-    _proof: InvestorZKProofData,
+    claim_to: IdentityId,
+    scope: Ticker,
+    scope_id: ScopeId,
+    cdd_id: CddId,
+    proof: InvestorZKProofData,
 ) -> DispatchResult {
-    /*
+    if Asset::disable_iu(scope) {
+        return Ok(());
+    }
     let signed_claim_to = RuntimeOrigin::signed(get_primary_key(claim_to));
 
     // Provide the InvestorUniqueness.
@@ -951,8 +953,6 @@ pub fn add_investor_uniqueness_claim(
         proof,
         None,
     )
-    */
-    Ok(())
 }
 
 pub fn provide_scope_claim_to_multiple_parties<'a>(

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -930,16 +930,17 @@ pub fn provide_scope_claim(
     assert_ok!(add_investor_uniqueness_claim(
         claim_to, scope, scope_id, cdd_id, proof
     ));
-    (scope_id, cdd_id)
+    (claim_to.into(), cdd_id)
 }
 
 pub fn add_investor_uniqueness_claim(
-    claim_to: IdentityId,
-    scope: Ticker,
-    scope_id: ScopeId,
-    cdd_id: CddId,
-    proof: InvestorZKProofData,
+    _claim_to: IdentityId,
+    _scope: Ticker,
+    _scope_id: ScopeId,
+    _cdd_id: CddId,
+    _proof: InvestorZKProofData,
 ) -> DispatchResult {
+    /*
     let signed_claim_to = RuntimeOrigin::signed(get_primary_key(claim_to));
 
     // Provide the InvestorUniqueness.
@@ -950,6 +951,8 @@ pub fn add_investor_uniqueness_claim(
         proof,
         None,
     )
+    */
+    Ok(())
 }
 
 pub fn provide_scope_claim_to_multiple_parties<'a>(

--- a/pallets/runtime/tests/src/transfer_compliance_test.rs
+++ b/pallets/runtime/tests/src/transfer_compliance_test.rs
@@ -155,7 +155,7 @@ struct AssetTracker {
 
 impl AssetTracker {
     pub fn new() -> Self {
-        Self::new_full(0, "ACME", false)
+        Self::new_full(0, "ACME", true)
     }
 
     pub fn new_full(owner_id: u64, name: &str, disable_iu: bool) -> Self {
@@ -828,14 +828,6 @@ fn claim_count_rule_no_investor_uniqueness() {
         .cdd_providers(vec![CDD_PROVIDER.to_account_id()])
         .build()
         .execute_with(|| claim_count_rule_with_ext(true));
-}
-
-#[test]
-fn claim_count_rule_with_investor_uniqueness() {
-    ExtBuilder::default()
-        .cdd_providers(vec![CDD_PROVIDER.to_account_id()])
-        .build()
-        .execute_with(|| claim_count_rule_with_ext(false));
 }
 
 fn claim_count_rule_with_ext(disable_iu: bool) {

--- a/pallets/runtime/tests/src/transfer_compliance_test.rs
+++ b/pallets/runtime/tests/src/transfer_compliance_test.rs
@@ -57,8 +57,12 @@ impl InvestorState {
         create_investor_uid(self.acc.clone())
     }
 
-    pub fn scope_id(&self, ticker: Ticker) -> ScopeId {
-        InvestorZKProofData::make_scope_id(&ticker.as_slice(), &self.uid())
+    pub fn scope_id(&self, disable_iu: bool, ticker: Ticker) -> ScopeId {
+        if disable_iu {
+            self.did
+        } else {
+            InvestorZKProofData::make_scope_id(&ticker.as_slice(), &self.uid())
+        }
     }
 
     pub fn provide_scope_claim(&self, ticker: Ticker) -> (ScopeId, CddId) {
@@ -135,6 +139,7 @@ struct AssetTracker {
     name: String,
     asset: Ticker,
     total_supply: Balance,
+    disable_iu: bool,
     pub asset_scope: AssetScope,
 
     issuers: HashMap<IdentityId, IssuerState>,
@@ -150,16 +155,17 @@ struct AssetTracker {
 
 impl AssetTracker {
     pub fn new() -> Self {
-        Self::new_full(0, "ACME")
+        Self::new_full(0, "ACME", false)
     }
 
-    pub fn new_full(owner_id: u64, name: &str) -> Self {
+    pub fn new_full(owner_id: u64, name: &str, disable_iu: bool) -> Self {
         let asset = Ticker::from_slice_truncated(name.as_bytes());
         let investor_start_id = owner_id + 1000;
         let mut tracker = Self {
             name: name.into(),
             asset,
             total_supply: 0,
+            disable_iu,
             asset_scope: AssetScope::from(asset),
 
             issuers: HashMap::new(),
@@ -189,7 +195,7 @@ impl AssetTracker {
             AssetType::default(),
             vec![],
             None,
-            true,
+            self.disable_iu,
         ));
 
         self.allow_all_transfers();
@@ -279,7 +285,7 @@ impl AssetTracker {
         println!("ids = {:?}", ids);
         let investors = ids
             .into_iter()
-            .map(|id| self.investor(*id).scope_id(self.asset))
+            .map(|id| self.investor(*id).scope_id(self.disable_iu, self.asset))
             .collect::<Vec<_>>();
         println!("investors = {:?}", investors);
         for condition in &self.transfer_conditions {
@@ -425,7 +431,9 @@ impl AssetTracker {
 
     fn create_investor(&mut self, id: u64) {
         let investor = InvestorState::new(id);
-        investor.provide_scope_claim(self.asset);
+        if !self.disable_iu {
+            investor.provide_scope_claim(self.asset);
+        }
         assert!(self.investors.insert(id, investor).is_none());
     }
 
@@ -815,16 +823,24 @@ fn max_investor_ownership_rule_with_ext() {
 }
 
 #[test]
-fn claim_count_rule() {
+fn claim_count_rule_no_investor_uniqueness() {
     ExtBuilder::default()
         .cdd_providers(vec![CDD_PROVIDER.to_account_id()])
         .build()
-        .execute_with(claim_count_rule_with_ext);
+        .execute_with(|| claim_count_rule_with_ext(true));
 }
 
-fn claim_count_rule_with_ext() {
+#[test]
+fn claim_count_rule_with_investor_uniqueness() {
+    ExtBuilder::default()
+        .cdd_providers(vec![CDD_PROVIDER.to_account_id()])
+        .build()
+        .execute_with(|| claim_count_rule_with_ext(false));
+}
+
+fn claim_count_rule_with_ext(disable_iu: bool) {
     // Create an asset.
-    let mut tracker = AssetTracker::new();
+    let mut tracker = AssetTracker::new_full(0, "ACME", disable_iu);
 
     let issuer = User::new(AccountKeyring::Dave);
     let claim_types = vec![ClaimType::Accredited];

--- a/pallets/runtime/tests/src/transfer_compliance_test.rs
+++ b/pallets/runtime/tests/src/transfer_compliance_test.rs
@@ -135,7 +135,6 @@ struct AssetTracker {
     name: String,
     asset: Ticker,
     total_supply: Balance,
-    disable_iu: bool,
     pub asset_scope: AssetScope,
 
     issuers: HashMap<IdentityId, IssuerState>,
@@ -161,7 +160,6 @@ impl AssetTracker {
             name: name.into(),
             asset,
             total_supply: 0,
-            disable_iu: false,
             asset_scope: AssetScope::from(asset),
 
             issuers: HashMap::new(),
@@ -191,7 +189,7 @@ impl AssetTracker {
             AssetType::default(),
             vec![],
             None,
-            self.disable_iu,
+            true,
         ));
 
         self.allow_all_transfers();


### PR DESCRIPTION
## changelog

### modified logic

- Throw error `InvestorUniquenessNotAllowed` if `Asset.create_asset` is called with `disable_iu: false`.
