### PR TITLE
Merge three different Memo types into one.

### DIFF
--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -179,14 +179,14 @@ use frame_system::{self as system, ensure_root, ensure_signed};
 pub use polymesh_common_utilities::traits::balances::WeightInfo;
 use polymesh_common_utilities::{
     traits::{
-        balances::{AccountData, BalancesTrait, CheckCdd, Memo, RawEvent, Reasons},
+        balances::{AccountData, BalancesTrait, CheckCdd, RawEvent, Reasons},
         identity::IdentityFnTrait,
         NegativeImbalance, PositiveImbalance,
     },
     Context, SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::traits::BlockRewardsReserveCurrency;
-use polymesh_primitives::Balance;
+use polymesh_primitives::{Balance, Memo};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{AccountIdConversion, StaticLookup, Zero},

--- a/pallets/common/src/traits/balances.rs
+++ b/pallets/common/src/traits/balances.rs
@@ -24,15 +24,10 @@ use frame_support::{
     },
     weights::Weight,
 };
-use polymesh_primitives::{Balance, IdentityId};
-use polymesh_primitives_derive::SliceU8StrongTyped;
+use polymesh_primitives::{Balance, IdentityId, Memo};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 use sp_std::ops::BitOr;
-
-#[derive(Encode, Decode, TypeInfo, SliceU8StrongTyped)]
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Memo(pub [u8; 32]);
 
 // POLYMESH-NOTE: Make `AccountData` public to access it from the outside module.
 /// All balance information for an account.

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -17,14 +17,14 @@
 //!
 //! The interface allows to accept portfolio custody
 
-use crate::{asset::AssetFnTrait, balances::Memo, base, identity, CommonConfig};
+use crate::{asset::AssetFnTrait, base, identity, CommonConfig};
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::pallet_prelude::Get;
 use frame_support::weights::Weight;
 use polymesh_primitives::{
-    Balance, Fund, FundDescription, IdentityId, Memo as PortfolioMemo, NFTId, NFTs, PortfolioId,
-    PortfolioName, PortfolioNumber, SecondaryKey, Ticker,
+    Balance, Fund, FundDescription, IdentityId, Memo, NFTId, NFTs, PortfolioId, PortfolioName,
+    PortfolioNumber, SecondaryKey, Ticker,
 };
 use sp_std::vec::Vec;
 
@@ -172,7 +172,7 @@ decl_event! {
             PortfolioId,
             PortfolioId,
             NFTs,
-            Option<PortfolioMemo>
+            Option<Memo>
         ),
         /// A token amount has been moved from one portfolio to another.
         ///
@@ -188,7 +188,7 @@ decl_event! {
             PortfolioId,
             Ticker,
             Balance,
-            Option<PortfolioMemo>,
+            Option<Memo>,
         ),
     }
 }

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -4,10 +4,10 @@ use frame_support::weights::Weight;
 use sp_std::vec::Vec;
 
 use polymesh_primitives::settlement::{
-    InstructionId, InstructionMemo, Leg, LegId, LegV2, ReceiptMetadata, SettlementType,
-    TransferData, VenueDetails, VenueId, VenueType,
+    InstructionId, Leg, LegId, LegV2, ReceiptMetadata, SettlementType, TransferData, VenueDetails,
+    VenueId, VenueType,
 };
-use polymesh_primitives::{IdentityId, PortfolioId, Ticker};
+use polymesh_primitives::{IdentityId, Memo, PortfolioId, Ticker};
 
 decl_event!(
     pub enum Event<T>
@@ -32,7 +32,7 @@ decl_event!(
             Option<Moment>,
             Option<Moment>,
             Vec<Leg>,
-            Option<InstructionMemo>,
+            Option<Memo>,
         ),
         /// An instruction has been affirmed (did, portfolio, instruction_id)
         InstructionAffirmed(IdentityId, PortfolioId, InstructionId),
@@ -86,7 +86,7 @@ decl_event!(
             Option<Moment>,
             Option<Moment>,
             Vec<LegV2>,
-            Option<InstructionMemo>,
+            Option<Memo>,
         ),
         /// Failed to execute instruction.
         FailedToExecuteInstruction(InstructionId, DispatchError),

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -53,7 +53,6 @@ use frame_support::{
     ensure,
 };
 use pallet_identity::{self as identity, PermissionedCallOriginData};
-use polymesh_common_utilities::traits::balances::Memo;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
 pub use polymesh_common_utilities::traits::{
     asset::AssetFnTrait,
@@ -61,8 +60,8 @@ pub use polymesh_common_utilities::traits::{
 };
 use polymesh_primitives::{
     extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, Balance, Fund,
-    FundDescription, IdentityId, NFTId, PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber,
-    SecondaryKey, Ticker,
+    FundDescription, IdentityId, Memo, NFTId, PortfolioId, PortfolioKind, PortfolioName,
+    PortfolioNumber, SecondaryKey, Ticker,
 };
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::Zero;

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -32,7 +32,6 @@ use pallet_statistics as statistics;
 use polymesh_common_utilities::{
     constants::*,
     protocol_fee::ProtocolOp,
-    traits::balances::Memo,
     traits::checkpoint::{ScheduleId, StoredSchedule},
     traits::CddAndFeeDetails as _,
     SystematicIssuers,
@@ -50,7 +49,7 @@ use polymesh_primitives::{
     },
     statistics::StatType,
     AccountId, AssetIdentifier, AssetPermissions, AuthorizationData, AuthorizationError, Document,
-    DocumentId, IdentityId, InvestorUid, Moment, NFTCollectionKeys, Permissions, PortfolioId,
+    DocumentId, IdentityId, InvestorUid, Memo, Moment, NFTCollectionKeys, Permissions, PortfolioId,
     PortfolioKind, PortfolioName, SecondaryKey, Signatory, Ticker, WeightMeter,
 };
 use rand::Rng;

--- a/pallets/runtime/tests/src/balances_test.rs
+++ b/pallets/runtime/tests/src/balances_test.rs
@@ -5,7 +5,7 @@ use super::{
 use pallet_balances as balances;
 use pallet_identity as identity;
 use pallet_test_utils as test_utils;
-use polymesh_common_utilities::traits::balances::{Memo, RawEvent as BalancesRawEvent};
+use polymesh_common_utilities::traits::balances::RawEvent as BalancesRawEvent;
 use polymesh_runtime_develop::{runtime, Runtime};
 
 use frame_support::{
@@ -15,7 +15,7 @@ use frame_support::{
 };
 use frame_system::{EventRecord, Phase};
 use pallet_transaction_payment::ChargeTransactionPayment;
-use polymesh_primitives::{traits::BlockRewardsReserveCurrency, InvestorUid};
+use polymesh_primitives::{traits::BlockRewardsReserveCurrency, InvestorUid, Memo};
 use sp_runtime::traits::SignedExtension;
 use test_client::AccountKeyring;
 

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -5,15 +5,14 @@ use frame_system::EventRecord;
 use pallet_portfolio::{
     Event, MovePortfolioItem, NameToNumber, PortfolioAssetBalances, PortfolioNFT,
 };
-use polymesh_common_utilities::balances::Memo;
 use polymesh_common_utilities::portfolio::PortfolioSubTrait;
 use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataValue,
 };
-use polymesh_primitives::settlement::{InstructionMemo, LegAsset, LegV2, SettlementType};
+use polymesh_primitives::settlement::{LegAsset, LegV2, SettlementType};
 use polymesh_primitives::{
-    AuthorizationData, AuthorizationError, Fund, FundDescription, NFTCollectionKeys, NFTId,
+    AuthorizationData, AuthorizationError, Fund, FundDescription, Memo, NFTCollectionKeys, NFTId,
     NFTMetadataAttribute, NFTs, PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber,
     Signatory, Ticker,
 };
@@ -673,7 +672,7 @@ fn delete_portfolio_with_locked_nfts() {
             None,
             legs,
             vec![PortfolioId::user_portfolio(alice.did, PortfolioNumber(1))],
-            Some(InstructionMemo::default()),
+            Some(Memo::default()),
         ));
 
         assert_noop!(

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -19,12 +19,12 @@ use polymesh_primitives::asset_metadata::{
 };
 use polymesh_primitives::checked_inc::CheckedInc;
 use polymesh_primitives::settlement::{
-    AffirmationStatus, Instruction, InstructionId, InstructionMemo, InstructionStatus, Leg,
-    LegAsset, LegId, LegStatus, LegV2, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
-    VenueDetails, VenueId, VenueType,
+    AffirmationStatus, Instruction, InstructionId, InstructionStatus, Leg, LegAsset, LegId,
+    LegStatus, LegV2, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType, VenueDetails,
+    VenueId, VenueType,
 };
 use polymesh_primitives::{
-    AccountId, AuthorizationData, Balance, Claim, Condition, ConditionType, IdentityId,
+    AccountId, AuthorizationData, Balance, Claim, Condition, ConditionType, IdentityId, Memo,
     NFTCollectionKeys, NFTId, NFTMetadataAttribute, NFTs, PortfolioId, PortfolioKind,
     PortfolioName, PortfolioNumber, Signatory, Ticker, WeightMeter,
 };
@@ -2241,16 +2241,13 @@ fn basic_settlement_with_memo() {
                 asset: TICKER,
                 amount: amount
             }],
-            Some(InstructionMemo::default()),
+            Some(Memo::default()),
         ));
         alice.assert_all_balances_unchanged();
         bob.assert_all_balances_unchanged();
 
         // check that the memo was stored correctly
-        assert_eq!(
-            Settlement::memo(instruction_id).unwrap(),
-            InstructionMemo::default()
-        );
+        assert_eq!(Settlement::memo(instruction_id).unwrap(), Memo::default());
 
         assert_affirm_instruction_with_one_leg!(alice.origin(), instruction_id, alice.did);
 
@@ -2512,7 +2509,7 @@ fn add_nft_instruction_with_duplicated_nfts() {
                 None,
                 None,
                 legs,
-                Some(InstructionMemo::default()),
+                Some(Memo::default()),
             ),
             NFTError::DuplicatedNFTId
         );
@@ -2556,7 +2553,7 @@ fn add_nft_instruction_exceeding_nfts() {
                 None,
                 None,
                 legs,
-                Some(InstructionMemo::default()),
+                Some(Memo::default()),
             ),
             NFTError::MaxNumberOfNFTsPerLegExceeded
         );
@@ -2584,7 +2581,7 @@ fn add_nft_instruction() {
             None,
             None,
             legs,
-            Some(InstructionMemo::default()),
+            Some(Memo::default()),
         ));
     });
 }
@@ -2628,7 +2625,7 @@ fn add_and_affirm_nft_instruction() {
             None,
             legs,
             default_portfolio_vec(alice.did),
-            Some(InstructionMemo::default()),
+            Some(Memo::default()),
         ));
 
         // Before bob accepts the transaction balances must not be changed and the NFT must be locked.
@@ -2721,7 +2718,7 @@ fn add_and_affirm_nft_not_owned() {
                 None,
                 legs,
                 default_portfolio_vec(alice.did),
-                Some(InstructionMemo::default()),
+                Some(Memo::default()),
             ),
             PortfolioError::NFTNotFoundInPortfolio
         );
@@ -2778,7 +2775,7 @@ fn add_same_nft_different_legs() {
                 None,
                 legs,
                 default_portfolio_vec(alice.did),
-                Some(InstructionMemo::default()),
+                Some(Memo::default()),
             ),
             PortfolioError::NFTAlreadyLocked
         );
@@ -2820,7 +2817,7 @@ fn add_and_affirm_with_receipts_nfts() {
             None,
             None,
             legs,
-            Some(InstructionMemo::default()),
+            Some(Memo::default()),
         ));
         assert_noop!(
             Settlement::affirm_with_receipts(

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -73,7 +73,7 @@ pub struct BaseV2Parameters<T: Config> {
     pub sender_portfolios: Vec<PortfolioId>,
     pub settlement_type: SettlementType<T::BlockNumber>,
     pub date: Option<T::Moment>,
-    pub memo: Option<InstructionMemo>,
+    pub memo: Option<Memo>,
 }
 
 fn set_block_number<T: Config>(new_block_no: u64) {
@@ -649,7 +649,7 @@ where
 
     let settlement_type = SettlementType::SettleOnBlock(100u32.into());
     let date = Some(99999999u32.into());
-    let memo = Some(InstructionMemo::default());
+    let memo = Some(Memo::default());
 
     BaseV2Parameters::<T> {
         sender: alice,
@@ -1035,9 +1035,9 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , _, _, _ ) = emulate_add_instruction::<T>(l, false, true).unwrap();
 
-    }: add_instruction_with_memo(origin, venue_id, settlement_type, Some(99999999u32.into()), Some(99999999u32.into()), legs, Some(InstructionMemo::default()))
+    }: add_instruction_with_memo(origin, venue_id, settlement_type, Some(99999999u32.into()), Some(99999999u32.into()), legs, Some(Memo::default()))
     verify {
-        assert_eq!(Module::<T>::memo(instruction_id).unwrap(), InstructionMemo::default());
+        assert_eq!(Module::<T>::memo(instruction_id).unwrap(), Memo::default());
     }
 
     add_and_affirm_instruction_with_memo_and_settle_on_block_type {
@@ -1049,10 +1049,10 @@ benchmarks! {
         // Emulate the add instruction and get all the necessary arguments.
         let (legs, venue_id, origin, did , portfolios, _, _) = emulate_add_instruction::<T>(l, true, true).unwrap();
         let s_portfolios = portfolios.clone();
-    }: add_and_affirm_instruction_with_memo(origin, venue_id, settlement_type, Some(99999999u32.into()), Some(99999999u32.into()), legs, s_portfolios, Some(InstructionMemo::default()))
+    }: add_and_affirm_instruction_with_memo(origin, venue_id, settlement_type, Some(99999999u32.into()), Some(99999999u32.into()), legs, s_portfolios, Some(Memo::default()))
     verify {
         verify_add_and_affirm_instruction::<T>(venue_id, settlement_type, portfolios).unwrap();
-        assert_eq!(Module::<T>::memo(instruction_id).unwrap(), InstructionMemo::default());
+        assert_eq!(Module::<T>::memo(instruction_id).unwrap(), Memo::default());
     }
 
     execute_manual_instruction {

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -78,11 +78,11 @@ use polymesh_common_utilities::with_transaction;
 use polymesh_common_utilities::SystematicIssuers::Settlement as SettlementDID;
 use polymesh_primitives::settlement::{
     AffirmationStatus, ExecuteInstructionInfo, Instruction, InstructionId, InstructionInfo,
-    InstructionMemo, InstructionStatus, Leg, LegAsset, LegId, LegStatus, LegV2, Receipt,
-    ReceiptDetails, SettlementType, TransferData, Venue, VenueDetails, VenueId, VenueType,
+    InstructionStatus, Leg, LegAsset, LegId, LegStatus, LegV2, Receipt, ReceiptDetails,
+    SettlementType, TransferData, Venue, VenueDetails, VenueId, VenueType,
 };
 use polymesh_primitives::{
-    storage_migrate_on, storage_migration_ver, IdentityId, PortfolioId, SecondaryKey, Ticker,
+    storage_migrate_on, storage_migration_ver, IdentityId, Memo, PortfolioId, SecondaryKey, Ticker,
     WeightMeter,
 };
 
@@ -271,7 +271,7 @@ decl_storage! {
         /// Storage version.
         StorageVersion get(fn storage_version) build(|_| Version::new(1)): Version;
         /// Instruction memo
-        InstructionMemos get(fn memo): map hasher(twox_64_concat) InstructionId => Option<InstructionMemo>;
+        InstructionMemos get(fn memo): map hasher(twox_64_concat) InstructionId => Option<Memo>;
         /// Instruction statuses. instruction_id -> InstructionStatus
         InstructionStatuses get(fn instruction_status):
             map hasher(twox_64_concat) InstructionId => InstructionStatus<T::BlockNumber>;
@@ -645,7 +645,7 @@ decl_module! {
             trade_date: Option<T::Moment>,
             value_date: Option<T::Moment>,
             legs: Vec<Leg>,
-            instruction_memo: Option<InstructionMemo>,
+            instruction_memo: Option<Memo>,
         ) {
             let did = Identity::<T>::ensure_perms(origin)?;
             let legs: Vec<LegV2> = legs.into_iter().map(|leg| leg.into()).collect();
@@ -678,7 +678,7 @@ decl_module! {
             value_date: Option<T::Moment>,
             legs: Vec<Leg>,
             portfolios: Vec<PortfolioId>,
-            instruction_memo: Option<InstructionMemo>,
+            instruction_memo: Option<Memo>,
         ) -> DispatchResult {
             let did = Identity::<T>::ensure_perms(origin.clone())?;
             let legs: Vec<LegV2> = legs.into_iter().map(|leg| leg.into()).collect();
@@ -741,7 +741,7 @@ decl_module! {
             trade_date: Option<T::Moment>,
             value_date: Option<T::Moment>,
             legs: Vec<LegV2>,
-            instruction_memo: Option<InstructionMemo>,
+            instruction_memo: Option<Memo>,
         ) {
             let did = Identity::<T>::ensure_perms(origin)?;
             Self::base_add_instruction(did, venue_id, settlement_type, trade_date, value_date, legs, instruction_memo, false)?;
@@ -773,7 +773,7 @@ decl_module! {
             value_date: Option<T::Moment>,
             legs: Vec<LegV2>,
             portfolios: Vec<PortfolioId>,
-            instruction_memo: Option<InstructionMemo>,
+            instruction_memo: Option<Memo>,
         ) -> DispatchResult {
             let did = Identity::<T>::ensure_perms(origin.clone())?;
             with_transaction(|| {
@@ -951,7 +951,7 @@ impl<T: Config> Module<T> {
         trade_date: Option<T::Moment>,
         value_date: Option<T::Moment>,
         legs: Vec<LegV2>,
-        memo: Option<InstructionMemo>,
+        memo: Option<Memo>,
         emit_deprecated_event: bool,
     ) -> Result<InstructionId, DispatchError> {
         // Verifies if the block number is in the future so that `T::Scheduler::schedule_named` doesn't fail.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -22,7 +22,7 @@ use blake2::{Blake2b, Digest};
 use codec::{Decode, Encode};
 use confidential_identity_v1::Scalar as ScalarV1;
 use frame_support::weights::Weight;
-use polymesh_primitives_derive::VecU8StrongTyped;
+use polymesh_primitives_derive::{SliceU8StrongTyped, VecU8StrongTyped};
 use scale_info::TypeInfo;
 use sp_runtime::{generic, traits::BlakeTwo256, MultiSignature};
 #[cfg(feature = "std")]
@@ -233,7 +233,7 @@ pub use nft::{NFTCollectionId, NFTCollectionKeys, NFTId, NFTMetadataAttribute, N
 
 /// Portfolio type definitions.
 pub mod portfolio;
-pub use portfolio::{Fund, FundDescription, Memo};
+pub use portfolio::{Fund, FundDescription};
 
 /// Custom WeightMeter definitions.
 pub mod weight_meter;
@@ -268,6 +268,11 @@ pub struct Beneficiary<Balance> {
     /// Amount requested to this beneficiary.
     pub amount: Balance,
 }
+
+/// A short on-chain memo for POLYX transfer, asset transfer and portfolio moves.
+#[derive(Decode, Encode, TypeInfo, SliceU8StrongTyped)]
+#[derive(Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Memo(pub [u8; 32]);
 
 /// Url for linking to off-chain resources.
 #[derive(Decode, Encode, TypeInfo, VecU8StrongTyped)]

--- a/primitives/src/portfolio.rs
+++ b/primitives/src/portfolio.rs
@@ -16,7 +16,7 @@
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
-use crate::{Balance, NFTs, Ticker};
+use crate::{Balance, Memo, NFTs, Ticker};
 
 /// Describes what should be moved between portfolios. It can be either fungible or non-fungible tokens.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
@@ -40,7 +40,3 @@ pub enum FundDescription {
     /// Fungible token.
     NonFungible(NFTs),
 }
-
-/// A memo describing the transfer.
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
-pub struct Memo(pub [u8; 32]);

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -155,11 +155,6 @@ impl InstructionId {
     }
 }
 
-/// A wrapper for InstructionMemo
-#[derive(Encode, Decode, TypeInfo)]
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct InstructionMemo(pub [u8; 32]);
-
 /// Details about an instruction.
 #[derive(Encode, Decode, TypeInfo)]
 #[derive(Default, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]


### PR DESCRIPTION
We had 3 different types for `Memo` (POLYX balance, settlement, portfolio moves).  They are all compatible (32 bytes).  It is better to just use one type.

## changelog

### modified API

- The memo type for settlements `InstructionMemo` now uses the common `polymesh_primitives::Memo`.
- `polymesh_common_utilities::traits::balances::Memo` changed to `polymesh_primitives::Memo`
- `polymesh_primitives::portfolio::Memo` moved to `polymesh_primitives::Memo`.
