### PR TITLE
Fix Circle CI build-arm64 task.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,69 +511,68 @@ workflows:
       - build-docker-arm64-rust-alpine
   commit:
     jobs:
+      - lint
+      - check-storage-version
+      - clippy
+      - test
+      - build
+      - build-ci
       - build-arm64
-        #      - lint
-        #      - check-storage-version
-        #      - clippy
-        #      - test
-        #      - build
-        #      - build-ci
-        #      - build-arm64
-        #      - benchmark-build
-        #      - coverage
-        #      - integration-test:
-        #          requires:
-        #            - build-ci
-        #      - benchmark:
-        #          requires:
-        #            - benchmark-build
-        #      - build-docker-debian:
-        #          requires:
-        #            - build
-        #          filters:
-        #            branches:
-        #              only:
-        #                - mainnet
-        #                - testnet
-        #                - staging
-        #                - develop
-        #      - build-docker-distroless:
-        #          requires:
-        #            - build
-        #          filters:
-        #            branches:
-        #              only:
-        #                - mainnet
-        #                - testnet
-        #                - staging
-        #                - develop
-        #      - build-docker-arm64-debian:
-        #          requires:
-        #            - build-arm64
-        #          filters:
-        #            branches:
-        #              only:
-        #                - mainnet
-        #                - testnet
-        #                - staging
-        #                - develop
-        #      - build-docker-arm64-distroless:
-        #          requires:
-        #            - build-arm64
-        #          filters:
-        #            branches:
-        #              only:
-        #                - mainnet
-        #                - testnet
-        #                - staging
-        #                - develop
-        #      - publish-github-release:
-        #          requires:
-        #            - build
-        #            - build-arm64
-        #          filters:
-        #            branches:
-        #              only:
-        #                - mainnet
-        #                - testnet
-        #                - staging
+      - benchmark-build
+      - coverage
+      - integration-test:
+          requires:
+            - build-ci
+      - benchmark:
+          requires:
+            - benchmark-build
+      - build-docker-debian:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - mainnet
+                - testnet
+                - staging
+                - develop
+      - build-docker-distroless:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - mainnet
+                - testnet
+                - staging
+                - develop
+      - build-docker-arm64-debian:
+          requires:
+            - build-arm64
+          filters:
+            branches:
+              only:
+                - mainnet
+                - testnet
+                - staging
+                - develop
+      - build-docker-arm64-distroless:
+          requires:
+            - build-arm64
+          filters:
+            branches:
+              only:
+                - mainnet
+                - testnet
+                - staging
+                - develop
+      - publish-github-release:
+          requires:
+            - build
+            - build-arm64
+          filters:
+            branches:
+              only:
+                - mainnet
+                - testnet
+                - staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,8 @@ jobs:
               -v ~/.cargo/registry:/usr/local/cargo/registry \
               -v ~/.cache/sccache:/.cache/sccache \
               -w /tmp/build polymeshassociation/rust-arm64:debian-$NIGHTLY \
-              cargo check --locked --no-default-features --features no_std \
-                --target=wasm32-unknown-unknown -p polymesh-runtime-develop
-          no_output_timeout: 1h
+              cargo fetch --locked --target=wasm32-unknown-unknown
+          no_output_timeout: 30m
       - run:
           name: Build arm64 release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Build release
           command: cargo build --locked --release
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - run:
           name: Create assets directory for releases
           command: mkdir ./assets
@@ -82,7 +82,7 @@ jobs:
       - run:
           name: Build ci-runtime
           command: cargo build --locked --release --features ci-runtime
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - run:
           name: Create assets directory for releases
           command: mkdir ./assets
@@ -138,7 +138,7 @@ jobs:
               -v ~/.cache/sccache:/.cache/sccache \
               -w /tmp/build polymeshassociation/rust-arm64:debian-$NIGHTLY \
               cargo build --locked --release
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - run:
           name: Create assets directory for releases
           command: mkdir -p ./assets
@@ -173,7 +173,7 @@ jobs:
       - run:
           name: Build binary with runtime-benchmarks
           command: cargo build --locked --release --features=runtime-benchmarks,running-ci
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - run:
           name: Rename the benchmarks binary.
           command: mv ./target/release/polymesh ./polymesh-benchmarks
@@ -198,7 +198,7 @@ jobs:
       - run:
           name: Run benchmarks
           command: ./polymesh-benchmarks benchmark pallet -p=* -e=* -r 1 -s 2 --execution wasm --wasm-execution compiled --db-cache 512 --heap-pages=4096
-          no_output_timeout: 1h
+          no_output_timeout: 30m
   migration-tests:
     docker:
       - image: polymeshassociation/rust:debian-nightly-2022-11-02
@@ -218,7 +218,7 @@ jobs:
       - run:
           name: Run migration tests
           command:  cargo test -p migration-tests --lib -- --nocapture
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - save_cache:
           key: v2-migration-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
@@ -256,7 +256,7 @@ jobs:
             --package pallet-balances:0.1.0
             --package asset-metadata
             --features default_identity
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - save_cache:
           key: v12-test-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
@@ -279,7 +279,7 @@ jobs:
       - run:
           name: Coverage
           command: bash ./scripts/coverage.sh
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - save_cache:
           key: v7-coverage-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:
@@ -306,7 +306,7 @@ jobs:
           name: install and build integration tests
           command: yarn install && yarn build
           working_directory: ./scripts/cli
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - run:
           name: run integration tests
           command: yarn test
@@ -330,7 +330,7 @@ jobs:
       - run:
           name: run clippy
           command: cargo clippy -- -A clippy::all -W clippy::complexity -W clippy::perf
-          no_output_timeout: 1h
+          no_output_timeout: 30m
       - save_cache:
           key: v6-clippy-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,20 @@ jobs:
           keys:
             - v7-release-arm64-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
+          name: Pre-fetch wasm32 deps.
+          command: |
+            docker run --rm --user "$(id -u)":"$(id -g)" \
+              -e VERBOSE="$VERBOSE" \
+              -e RUSTFLAGS="$RUSTFLAGS" \
+              -e RUSTC_WRAPPER="$RUSTC_WRAPPER" \
+              -v "$PWD":/tmp/build \
+              -v ~/.cargo/git:/usr/local/cargo/git \
+              -v ~/.cargo/registry:/usr/local/cargo/registry \
+              -v ~/.cache/sccache:/.cache/sccache \
+              -w /tmp/build polymeshassociation/rust-arm64:debian-$NIGHTLY \
+              cargo check --locked --target=wasm32-unknown-unknown
+          no_output_timeout: 1h
+      - run:
           name: Build arm64 release
           command: |
             docker run --rm --user "$(id -u)":"$(id -g)" \
@@ -125,7 +139,7 @@ jobs:
               -v ~/.cargo/registry:/usr/local/cargo/registry \
               -v ~/.cache/sccache:/.cache/sccache \
               -w /tmp/build polymeshassociation/rust-arm64:debian-$NIGHTLY \
-              cargo build --release
+              cargo build --locked --release
           no_output_timeout: 1h
       - run:
           name: Create assets directory for releases
@@ -160,7 +174,7 @@ jobs:
             - v4-bench-cache-{{ checksum "./rust.version" }}-{{ checksum "./Cargo.lock" }}
       - run:
           name: Build binary with runtime-benchmarks
-          command: cargo build --release --features=runtime-benchmarks,running-ci
+          command: cargo build --locked --release --features=runtime-benchmarks,running-ci
           no_output_timeout: 1h
       - run:
           name: Rename the benchmarks binary.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,6 @@ jobs:
           name: Pre-fetch wasm32 deps.
           command: |
             docker run --rm --user "$(id -u)":"$(id -g)" \
-              -e VERBOSE="$VERBOSE" \
-              -e RUSTFLAGS="$RUSTFLAGS" \
               -e RUSTC_WRAPPER="$RUSTC_WRAPPER" \
               -v "$PWD":/tmp/build \
               -v ~/.cargo/git:/usr/local/cargo/git \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,8 @@ jobs:
               -v ~/.cargo/registry:/usr/local/cargo/registry \
               -v ~/.cache/sccache:/.cache/sccache \
               -w /tmp/build polymeshassociation/rust-arm64:debian-$NIGHTLY \
-              cargo check --locked --target=wasm32-unknown-unknown
+              cargo check --locked --no-default-features --features no_std \
+                --target=wasm32-unknown-unknown -p polymesh-runtime-develop
           no_output_timeout: 1h
       - run:
           name: Build arm64 release
@@ -513,68 +514,69 @@ workflows:
       - build-docker-arm64-rust-alpine
   commit:
     jobs:
-      - lint
-      - check-storage-version
-      - clippy
-      - test
-      - build
-      - build-ci
       - build-arm64
-      - benchmark-build
-      - coverage
-      - integration-test:
-          requires:
-            - build-ci
-      - benchmark:
-          requires:
-            - benchmark-build
-      - build-docker-debian:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - mainnet
-                - testnet
-                - staging
-                - develop
-      - build-docker-distroless:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - mainnet
-                - testnet
-                - staging
-                - develop
-      - build-docker-arm64-debian:
-          requires:
-            - build-arm64
-          filters:
-            branches:
-              only:
-                - mainnet
-                - testnet
-                - staging
-                - develop
-      - build-docker-arm64-distroless:
-          requires:
-            - build-arm64
-          filters:
-            branches:
-              only:
-                - mainnet
-                - testnet
-                - staging
-                - develop
-      - publish-github-release:
-          requires:
-            - build
-            - build-arm64
-          filters:
-            branches:
-              only:
-                - mainnet
-                - testnet
-                - staging
+        #      - lint
+        #      - check-storage-version
+        #      - clippy
+        #      - test
+        #      - build
+        #      - build-ci
+        #      - build-arm64
+        #      - benchmark-build
+        #      - coverage
+        #      - integration-test:
+        #          requires:
+        #            - build-ci
+        #      - benchmark:
+        #          requires:
+        #            - benchmark-build
+        #      - build-docker-debian:
+        #          requires:
+        #            - build
+        #          filters:
+        #            branches:
+        #              only:
+        #                - mainnet
+        #                - testnet
+        #                - staging
+        #                - develop
+        #      - build-docker-distroless:
+        #          requires:
+        #            - build
+        #          filters:
+        #            branches:
+        #              only:
+        #                - mainnet
+        #                - testnet
+        #                - staging
+        #                - develop
+        #      - build-docker-arm64-debian:
+        #          requires:
+        #            - build-arm64
+        #          filters:
+        #            branches:
+        #              only:
+        #                - mainnet
+        #                - testnet
+        #                - staging
+        #                - develop
+        #      - build-docker-arm64-distroless:
+        #          requires:
+        #            - build-arm64
+        #          filters:
+        #            branches:
+        #              only:
+        #                - mainnet
+        #                - testnet
+        #                - staging
+        #                - develop
+        #      - publish-github-release:
+        #          requires:
+        #            - build
+        #            - build-arm64
+        #          filters:
+        #            branches:
+        #              only:
+        #                - mainnet
+        #                - testnet
+        #                - staging


### PR DESCRIPTION
The `build-arm64` task was failing during the wasm runtime builds.  We build 3 runtimes (develop, testnet, mainnet), which uses a `build.rs` script to build the runtimes for target `wasm32-unknown-unknown`.  For some reason those 3 builds don't play nicely together when downloading packages from crates.io, so they conflict and fail.

This PR uses `cargo fetch` to pre-fetch all packages needed for the wasm builds.

Also changed the timeouts from 1 hour to 30 minutes.  If a task takes more than that to run, then it has issues.