### PR TITLE
MESH-2053: Disallow "Except" for extrinsic permissions

### DIFF
--- a/errors_schema.json
+++ b/errors_schema.json
@@ -68,7 +68,15 @@
       "InvalidCDDId",
       "ClaimAndProofVersionsDoNotMatch",
       "AccountKeyIsBeingUsed",
-      "CustomScopeTooLong"
+      "CustomScopeTooLong",
+      "CustomClaimTypeAlreadyExists",
+      "CustomClaimTypeDoesNotExist",
+      "ClaimDoesNotExist",
+      "IsChildIdentity",
+      "NoParentIdentity",
+      "NotParentOrChildIdentity",
+      "DuplicateKey",
+      "ExceptNotAllowedForExtrinsics"
     ]
   },
   "CddServiceProvidersError": {

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -32,9 +32,8 @@ use frame_support::{
     Parameter,
 };
 use polymesh_primitives::{
-    secondary_key::SecondaryKey,
-    AuthorizationData, Balance, CustomClaimTypeId, IdentityClaim, IdentityId, Permissions,
-    Ticker,
+    secondary_key::SecondaryKey, AuthorizationData, Balance, CustomClaimTypeId, IdentityClaim,
+    IdentityId, Permissions, Ticker,
 };
 use scale_info::TypeInfo;
 use sp_core::H512;

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -32,14 +32,13 @@ use frame_support::{
     Parameter,
 };
 use polymesh_primitives::{
-    secondary_key::{v1, SecondaryKey},
+    secondary_key::SecondaryKey,
     AuthorizationData, Balance, CustomClaimTypeId, IdentityClaim, IdentityId, Permissions,
-    Signatory, Ticker,
+    Ticker,
 };
 use scale_info::TypeInfo;
 use sp_core::H512;
 use sp_runtime::traits::{Dispatchable, IdentifyAccount, Member, Verify};
-use sp_std::convert::TryFrom;
 use sp_std::vec::Vec;
 
 pub type AuthorizationNonce = u64;
@@ -72,32 +71,6 @@ pub struct SecondaryKeyWithAuth<AccountId> {
     pub secondary_key: SecondaryKey<AccountId>,
     /// Off-chain authorization signature.
     pub auth_signature: H512,
-}
-
-#[derive(Encode, Decode, TypeInfo)]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SecondaryKeyWithAuthV1<AccountId> {
-    secondary_key: v1::SecondaryKey<AccountId>,
-    auth_signature: H512,
-}
-
-impl<AccountId> TryFrom<SecondaryKeyWithAuthV1<AccountId>> for SecondaryKeyWithAuth<AccountId> {
-    type Error = ();
-    fn try_from(auth: SecondaryKeyWithAuthV1<AccountId>) -> Result<Self, Self::Error> {
-        match auth.secondary_key.signer {
-            Signatory::Account(key) => Ok(Self {
-                secondary_key: SecondaryKey {
-                    key,
-                    permissions: auth.secondary_key.permissions,
-                },
-                auth_signature: auth.auth_signature,
-            }),
-            _ => {
-                // Unsupported `Signatory::Identity`.
-                Err(())
-            }
-        }
-    }
 }
 
 /// Create a child identity using `key` as the primary key of the new child identity.
@@ -148,17 +121,6 @@ pub trait WeightInfo {
     fn add_investor_uniqueness_claim_v2() -> Weight;
     fn revoke_claim_by_index() -> Weight;
     fn register_custom_claim_type(n: u32) -> Weight;
-
-    /// Add complexity cost of Permissions to `add_secondary_keys_with_authorization` extrinsic.
-    fn add_secondary_keys_full_v1<AccountId>(
-        additional_keys: &[SecondaryKeyWithAuthV1<AccountId>],
-    ) -> Weight {
-        Self::add_secondary_keys_perms_cost(
-            additional_keys
-                .iter()
-                .map(|auth| &auth.secondary_key.permissions),
-        )
-    }
 
     /// Add complexity cost of Permissions to `add_secondary_keys_with_authorization` extrinsic.
     fn add_secondary_keys_full<AccountId>(

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -897,13 +897,11 @@ impl<T: Config> Module<T> {
             }
             SubsetRestriction::These(pallet_permissions) => {
                 for elem in pallet_permissions {
-                    match elem.dispatchable_names {
-                        SubsetRestriction::Except(_) => {
-                            return Err(Error::<T>::ExceptNotAllowedForExtrinsics.into());
-                        }
-                        _ => return Ok(()), // Matches Whole and These
+                    if let SubsetRestriction::Except(_) = elem.dispatchable_names {
+                        return Err(Error::<T>::ExceptNotAllowedForExtrinsics.into());
                     }
                 }
+                return Ok(());
             }
             SubsetRestriction::Whole => {
                 return Ok(());

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -907,7 +907,6 @@ impl<T: Config> Module<T> {
                 return Ok(());
             }
         };
-        Ok(())
     }
 
     /// Ensures length limits are enforced in `perms`.

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -905,7 +905,7 @@ impl<T: Config> Module<T> {
                     }
                 }
             }
-            SubsetRestriction::Whole(_) => {
+            SubsetRestriction::Whole => {
                 return Ok(());
             }
         };

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -40,7 +40,7 @@ use polymesh_common_utilities::traits::{
 use polymesh_common_utilities::{Context, SystematicIssuers};
 use polymesh_primitives::{
     extract_auth, AuthorizationData, DidRecord, DispatchableName, ExtrinsicPermissions, IdentityId,
-    KeyRecord, PalletName, Permissions, SecondaryKey, Signatory,
+    KeyRecord, PalletName, Permissions, SecondaryKey, Signatory, SubsetRestriction,
 };
 use sp_core::sr25519::Signature;
 use sp_io::hashing::blake2_256;
@@ -884,7 +884,20 @@ impl<T: Config> Module<T> {
         ensure_custom_length_ok::<T>(perms.complexity(), MAX_PERMISSION_COMPLEXITY)?;
         ensure_custom_length_ok::<T>(perms.asset.complexity(), MAX_ASSETS)?;
         ensure_custom_length_ok::<T>(perms.portfolio.complexity(), MAX_PORTFOLIOS)?;
+        Self::ensure_no_except_perms(&perms.extrinsic)?;
         Self::ensure_extrinsic_perms_length_limited(&perms.extrinsic)
+    }
+
+    // Ensures that extrinsic permissions do not use the Except variant
+    // This is considered unsafe since extrinsic names can change or be replaced with newer versions
+    pub fn ensure_no_except_perms(perms: &ExtrinsicPermissions) -> DispatchResult {
+        let is_not_except = match perms {
+            SubsetRestriction::Whole => true,
+            SubsetRestriction::These(_) => true,
+            SubsetRestriction::Except(_) => false,
+        };
+        ensure!(is_not_except, Error::<T>::ExceptNotAllowedForExtrinsics);
+        Ok(())
     }
 
     /// Ensures length limits are enforced in `perms`.

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -360,11 +360,6 @@ decl_module! {
             Self::base_revoke_claim(target, claim_type, issuer, scope)
         }
 
-        /// Placeholder for removed `legacy_set_permission_to_signer`.
-        #[weight = 1_000]
-        pub fn placeholder_legacy_set_permission_to_signer(_origin) {
-        }
-
         /// It disables all secondary keys at `did` identity.
         ///
         /// # Errors

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -108,7 +108,7 @@ use polymesh_common_utilities::constants::did::SECURITY_TOKEN;
 use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee, ProtocolOp};
 use polymesh_common_utilities::traits::identity::{
     AuthorizationNonce, Config, CreateChildIdentityWithAuth, IdentityFnTrait, RawEvent,
-    SecondaryKeyWithAuth, SecondaryKeyWithAuthV1,
+    SecondaryKeyWithAuth,
 };
 use polymesh_common_utilities::{SystematicIssuers, GC_DID};
 use polymesh_primitives::{
@@ -286,18 +286,6 @@ decl_module! {
             Self::base_invalidate_cdd_claims(origin, cdd, disable_from, expiry)?;
         }
 
-        /// Deprecated. Use `remove_secondary_keys` instead.
-        #[weight = <T as Config>::WeightInfo::remove_secondary_keys(keys_to_remove.len() as u32)]
-        pub fn remove_secondary_keys_old(origin, keys_to_remove: Vec<Signatory<T::AccountId>>) {
-            let keys_to_remove = keys_to_remove.into_iter()
-                .map(|key| match key {
-                    Signatory::Account(key) => Ok(key),
-                    _ => Err(Error::<T>::NotASigner),
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Self::base_remove_secondary_keys(origin, keys_to_remove)?;
-        }
-
         /// Call this with the new primary key. By invoking this method, caller accepts authorization
         /// to become the new primary key of the issuing identity. If a CDD service provider approved
         /// this change (or this is not required), primary key of the DID is updated.
@@ -372,15 +360,6 @@ decl_module! {
             Self::base_revoke_claim(target, claim_type, issuer, scope)
         }
 
-        /// Deprecated. Use `set_secondary_key_permissions` instead.
-        #[weight = <T as Config>::WeightInfo::set_secondary_key_permissions_full(&perms)]
-        pub fn set_permission_to_signer(origin, key: Signatory<T::AccountId>, perms: Permissions) {
-            match key {
-                Signatory::Account(key) => Self::base_set_secondary_key_permissions(origin, key, perms)?,
-                _ => Err(Error::<T>::NotASigner)?,
-            }
-        }
-
         /// Placeholder for removed `legacy_set_permission_to_signer`.
         #[weight = 1_000]
         pub fn placeholder_legacy_set_permission_to_signer(_origin) {
@@ -423,20 +402,6 @@ decl_module! {
             _auth_issuer_pays: bool,
         ) {
             Self::base_remove_authorization(origin, target, auth_id)?;
-        }
-
-        /// Deprecated. Use `add_secondary_keys_with_authorization` instead.
-        #[weight = <T as Config>::WeightInfo::add_secondary_keys_full_v1::<T::AccountId>(&additional_keys)]
-        pub fn add_secondary_keys_with_authorization_old(
-            origin,
-            additional_keys: Vec<SecondaryKeyWithAuthV1<T::AccountId>>,
-            expires_at: T::Moment
-        ) {
-            let additional_keys = additional_keys.into_iter()
-                .map(SecondaryKeyWithAuth::<T::AccountId>::try_from)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| Error::<T>::NotASigner)?;
-            Self::base_add_secondary_keys_with_authorization(origin, additional_keys, expires_at)?;
         }
 
         /// Add `Claim::InvestorUniqueness` claim for a given target identity.
@@ -732,6 +697,8 @@ decl_error! {
         NotParentOrChildIdentity,
         /// The same key was included multiple times.
         DuplicateKey,
+        /// Cannot use Except when specifying extrinsic permissions.
+        ExceptNotAllowedForExtrinsics,
     }
 }
 

--- a/pallets/identity/src/types.rs
+++ b/pallets/identity/src/types.rs
@@ -30,43 +30,6 @@ pub enum RpcDidRecords<AccountId> {
     IdNotFound,
 }
 
-impl<AccountId> From<v1::RpcDidRecords<AccountId>> for RpcDidRecords<AccountId> {
-    fn from(old: v1::RpcDidRecords<AccountId>) -> Self {
-        match old {
-            v1::RpcDidRecords::Success {
-                primary_key,
-                secondary_keys,
-            } => Self::Success {
-                primary_key,
-                secondary_keys: secondary_keys
-                    .into_iter()
-                    .filter_map(SecondaryKey::from_v1)
-                    .collect(),
-            },
-            v1::RpcDidRecords::IdNotFound => Self::IdNotFound,
-        }
-    }
-}
-
-pub mod v1 {
-    use super::*;
-    use polymesh_primitives::secondary_key::v1;
-
-    /// A result of execution of get_votes.
-    #[derive(Eq, PartialEq, Encode, Decode)]
-    #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-    #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-    pub enum RpcDidRecords<AccountId> {
-        /// Id was found and has the following primary key and secondary keys.
-        Success {
-            primary_key: AccountId,
-            secondary_keys: Vec<v1::SecondaryKey<AccountId>>,
-        },
-        /// Error.
-        IdNotFound,
-    }
-}
-
 #[derive(Encode, Decode, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub enum DidStatus {

--- a/primitives/src/secondary_key.rs
+++ b/primitives/src/secondary_key.rs
@@ -384,17 +384,6 @@ impl<AccountId> SecondaryKey<AccountId> {
         Self { key, permissions }
     }
 
-    /// Convert from v1 `SecondaryKey`.
-    pub fn from_v1(old: v1::SecondaryKey<AccountId>) -> Option<Self> {
-        match old.signer {
-            Signatory::Account(key) => Some(Self {
-                key,
-                permissions: old.permissions,
-            }),
-            _ => None,
-        }
-    }
-
     /// Creates a [`SecondaryKey`] with no permissions from an `AccountId`.
     pub fn from_account_id(key: AccountId) -> Self {
         Self {
@@ -442,33 +431,6 @@ impl<AccountId> SecondaryKey<AccountId> {
     /// Make a `KeyRecord` for this SecondaryKey.
     pub fn make_key_record(&self, did: IdentityId) -> KeyRecord<AccountId> {
         KeyRecord::SecondaryKey(did, self.permissions.clone())
-    }
-}
-
-/// Old v1 `SecondaryKey` type.
-pub mod v1 {
-    use super::*;
-
-    /// Old v1 secondary key.
-    #[derive(Encode, Decode, TypeInfo)]
-    #[derive(Clone, Debug, Default, PartialEq, Eq)]
-    #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    pub struct SecondaryKey<AccountId> {
-        /// Signer.
-        pub signer: Signatory<AccountId>,
-        /// Permissions.
-        pub permissions: Permissions,
-    }
-
-    impl<AccountId> SecondaryKey<AccountId> {
-        /// Convert old `SecondaryKey` into `KeyRecord`.
-        pub fn into_key_record(self, did: IdentityId) -> Option<(AccountId, KeyRecord<AccountId>)> {
-            if let Signatory::Account(key) = self.signer {
-                Some((key, KeyRecord::SecondaryKey(did, self.permissions)))
-            } else {
-                None
-            }
-        }
     }
 }
 

--- a/rpc/runtime-api/src/identity.rs
+++ b/rpc/runtime-api/src/identity.rs
@@ -21,14 +21,7 @@ sp_api::decl_runtime_apis! {
         fn get_asset_did(ticker: Ticker) -> AssetDidResult;
 
         /// Retrieve DidRecord for a given `did`.
-        #[deprecated]
         fn get_did_records(did: IdentityId) -> RpcDidRecords<AccountId>;
-
-        /// Retrieve DidRecord for a given `did`.
-        ///
-        /// Old v1 call for `Signatory` based secondary keys.
-        #[changed_in(2)]
-        fn get_did_records(did: IdentityId) -> pallet_identity::types::v1::RpcDidRecords<AccountId>;
 
         /// Retrieve list of a authorization for a given signatory
         fn get_filtered_authorizations(

--- a/rpc/src/identity.rs
+++ b/rpc/src/identity.rs
@@ -12,9 +12,9 @@ use codec::Codec;
 use jsonrpsee::{
     core::RpcResult,
     proc_macros::rpc,
-    types::error::{CallError, ErrorCode, ErrorObject},
+    types::error::{CallError, ErrorObject},
 };
-use sp_api::{ApiExt, ApiRef, ProvideRuntimeApi};
+use sp_api::{ApiRef, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::{Block as BlockT, Zero};
 

--- a/rpc/src/identity.rs
+++ b/rpc/src/identity.rs
@@ -151,40 +151,7 @@ where
     ) -> RpcResult<RpcDidRecords<AccountId>> {
         let api = self.client.runtime_api();
         let at_hash = at.unwrap_or_else(|| self.client.info().best_hash);
-        let api_version = api
-            .api_version::<dyn IdentityRuntimeApi<Block, IdentityId, Ticker, AccountId, Moment>>(
-                at_hash,
-            )
-            .map_err(|e| {
-                CallError::Custom(ErrorObject::owned(
-                    Error::RuntimeError.into(),
-                    "Unable to fetch DID records",
-                    Some(e.to_string()),
-                ))
-            })?;
-
-        match api_version {
-            Some(version) if version >= 2 =>
-            {
-                #[allow(deprecated)]
-                api.get_did_records(at_hash, did)
-            }
-            Some(1) =>
-            {
-                #[allow(deprecated)]
-                api.get_did_records_before_version_2(at_hash, did)
-                    .map(|rec| rec.into())
-            }
-            _ => {
-                return Err(CallError::Custom(ErrorObject::owned(
-                    ErrorCode::MethodNotFound.code(),
-                    format!("Cannot find `IdentityApi` for block {:?}", at),
-                    None::<()>,
-                ))
-                .into());
-            }
-        }
-        .map_err(|e| {
+        api.get_did_records(at_hash, did).map_err(|e| {
             CallError::Custom(ErrorObject::owned(
                 Error::RuntimeError.into(),
                 "Unable to fetch DID records",


### PR DESCRIPTION
## changelog

### modified API

- Removes depreciated old `get_did_records` for V1 records

### modified logic

- Returns an error if a user uses `Except` permissions on secondary keys for extrinsics 