### PR TITLE
Fix upgradable polymesh api and tracker.

### DIFF
--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh_ink_upgrade_tracker"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -22,7 +22,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 polymesh-api = { version = "0.3.8", default-features = false, features = ["ink"] }
 
-upgrade_tracker = { package = "polymesh_ink_upgrade_tracker", version = "0.2.0", path = "./upgrade_tracker/", default-features = false, features = ["ink-as-dependency"], optional = true }
+upgrade_tracker = { package = "polymesh_ink_upgrade_tracker", version = "1.0.0", path = "./upgrade_tracker/", default-features = false, features = ["ink-as-dependency"], optional = true }
 paste = "1.0"
 
 [lib]

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-ink"
-version = "0.5.7"
+version = "0.5.8"
 authors = ["PolymeshAssociation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/contracts/upgradeable-polymesh-ink/src/macros.rs
+++ b/contracts/upgradeable-polymesh-ink/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! upgradable_api {
             impl $api_type {
                 $(
                     $(#[doc = $doc_attr])*
-                    $(#[ink($ink_attr)])*
+                    $(#[ink($ink_attr, payable)])*
                     $fn_vis fn $fn_name(&self $(, $param: $ty)*) -> $fn_return {
                         ::paste::paste! {
                             self.[<__impl_ $fn_name>]($($param),*)

--- a/contracts/upgradeable-polymesh-ink/upgrade_tracker/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/upgrade_tracker/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh_ink_upgrade_tracker"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/contracts/upgradeable-polymesh-ink/upgrade_tracker/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/upgrade_tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh_ink_upgrade_tracker"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["PolymeshAssociation"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
There is an issue with payable contract methods making `DelegateCall`s to the upgradable Polymesh Ink! api.  A work around is to make the API methods also payable.

Also the upgrade tracker contract was alway using the oldest version, not the newest.