### PR TITLE
Transaction fee paid fix

### DIFF
--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -4,10 +4,7 @@ use crate::constants::time::*;
 use codec::Encode;
 use core::convert::TryFrom;
 use frame_support::{
-    construct_runtime,
-    dispatch::DispatchResult,
-    parameter_types,
-    traits::KeyOwnerProofSystem,
+    construct_runtime, dispatch::DispatchResult, parameter_types, traits::KeyOwnerProofSystem,
     weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -7,7 +7,7 @@ use frame_support::{
     construct_runtime,
     dispatch::DispatchResult,
     parameter_types,
-    traits::{tokens::imbalance::SplitTwoWays, KeyOwnerProofSystem},
+    traits::KeyOwnerProofSystem,
     weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -24,7 +24,7 @@ use polymesh_runtime_common::{
     impls::Author,
     merge_active_and_inactive,
     runtime::{GovernanceCommittee, BENCHMARK_MAX_INCREASE, VMO},
-    AvailableBlockRatio, MaximumBlockWeight, NegativeImbalance,
+    AvailableBlockRatio, MaximumBlockWeight,
 };
 use sp_runtime::transaction_validity::TransactionPriority;
 use sp_runtime::{
@@ -143,15 +143,8 @@ parameter_types! {
     pub const MaxNumberOfNFTsMoves: u32 = 100;
 }
 
-/// Splits fees 80/20 between treasury and block author.
-pub type DealWithFees = SplitTwoWays<
-    Balance,
-    NegativeImbalance<Runtime>,
-    Treasury,        // 4 parts (80%) goes to the treasury.
-    Author<Runtime>, // 1 part (20%) goes to the block author.
-    4,
-    1,
->;
+/// 100% goes to the block author.
+pub type DealWithFees = Author<Runtime>;
 
 // Staking:
 pallet_staking_reward_curve::build! {

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -21,7 +21,7 @@ use polymesh_runtime_common::{
     impls::Author,
     merge_active_and_inactive,
     runtime::{GovernanceCommittee, BENCHMARK_MAX_INCREASE, VMO},
-    AvailableBlockRatio, MaximumBlockWeight, NegativeImbalance,
+    AvailableBlockRatio, MaximumBlockWeight,
 };
 use sp_runtime::transaction_validity::TransactionPriority;
 use sp_runtime::{
@@ -140,15 +140,8 @@ parameter_types! {
     pub const MaxNumberOfNFTsMoves: u32 = 100;
 }
 
-/// Splits fees 80/20 between treasury and block author.
-pub type DealWithFees = SplitTwoWays<
-    Balance,
-    NegativeImbalance<Runtime>,
-    Treasury,        // 4 parts (80%) goes to the treasury.
-    Author<Runtime>, // 1 part (20%) goes to the block author.
-    4,
-    1,
->;
+/// 100% goes to the block author.
+pub type DealWithFees = Author<Runtime>;
 
 // Staking:
 pallet_staking_reward_curve::build! {

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -4,7 +4,7 @@ use crate::constants::time::*;
 use codec::Encode;
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{tokens::imbalance::SplitTwoWays, KeyOwnerProofSystem},
+    traits::KeyOwnerProofSystem,
     weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -3,9 +3,7 @@
 use crate::constants::time::*;
 use codec::Encode;
 use frame_support::{
-    construct_runtime, parameter_types,
-    traits::KeyOwnerProofSystem,
-    weights::Weight,
+    construct_runtime, parameter_types, traits::KeyOwnerProofSystem, weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;
 use pallet_corporate_actions::ballot as pallet_corporate_ballot;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -26,7 +26,7 @@ use polymesh_runtime_common::{
     impls::Author,
     merge_active_and_inactive,
     runtime::{GovernanceCommittee, BENCHMARK_MAX_INCREASE, VMO},
-    AvailableBlockRatio, MaximumBlockWeight, NegativeImbalance,
+    AvailableBlockRatio, MaximumBlockWeight,
 };
 use sp_runtime::transaction_validity::TransactionPriority;
 use sp_runtime::{
@@ -146,15 +146,8 @@ parameter_types! {
     pub const MaxNumberOfNFTsMoves: u32 = 100;
 }
 
-/// Splits fees 80/20 between treasury and block author.
-pub type DealWithFees = SplitTwoWays<
-    Balance,
-    NegativeImbalance<Runtime>,
-    Treasury,        // 4 parts (80%) goes to the treasury.
-    Author<Runtime>, // 1 part (20%) goes to the block author.
-    4,
-    1,
->;
+/// 100% goes to the block author.
+pub type DealWithFees = Author<Runtime>;
 
 // Staking:
 pallet_staking_reward_curve::build! {

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -8,9 +8,7 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 use core::convert::TryFrom;
 use frame_support::{
-    construct_runtime, parameter_types,
-    traits::KeyOwnerProofSystem,
-    weights::Weight,
+    construct_runtime, parameter_types, traits::KeyOwnerProofSystem, weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;
 use pallet_corporate_actions::ballot as pallet_corporate_ballot;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -9,7 +9,7 @@ use frame_support::traits::OnRuntimeUpgrade;
 use core::convert::TryFrom;
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{tokens::imbalance::SplitTwoWays, KeyOwnerProofSystem},
+    traits::KeyOwnerProofSystem,
     weights::Weight,
 };
 use pallet_asset::checkpoint as pallet_checkpoint;

--- a/pallets/transaction-payment/src/lib.rs
+++ b/pallets/transaction-payment/src/lib.rs
@@ -854,7 +854,7 @@ where
             &fee_key, info, post_info, actual_fee, tip, imbalance,
         )?;
         Module::<T>::deposit_event(Event::<T>::TransactionFeePaid {
-            who,
+            who: fee_key,
             actual_fee,
             tip,
         });


### PR DESCRIPTION
## changelog

### modified logic

- Use the paying account id in the `TransactionFeePaid` event, instead of the caller account.
- Remove the 80/20 split between treasury/author.  The block author gets 100% of transaction/protocol fees.
