### PR TITLE
Wrap some storage values in Option.

### DIFF
--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -55,8 +55,6 @@ std = [
     "pallet-base/std",
     "pallet-balances/std",
     "pallet-identity/std",
-    #"polymesh-contracts/std",
-    #"pallet-contracts/std",
     "pallet-portfolio/std",
     "pallet-session/std",
     "pallet-timestamp/std",

--- a/pallets/asset/src/checkpoint/mod.rs
+++ b/pallets/asset/src/checkpoint/mod.rs
@@ -572,7 +572,9 @@ impl<T: Config> Module<T> {
     /// - mapping the the ID to the `time`.
     fn create_at(actor: Option<EventDid>, ticker: Ticker, id: CheckpointId, at: Moment) {
         // Record total supply at checkpoint ID.
-        let supply = <Asset<T>>::token_details(ticker).total_supply;
+        let supply = <Asset<T>>::token_details(&ticker)
+            .map(|t| t.total_supply)
+            .unwrap_or_default();
         TotalSupply::insert(ticker, id, supply);
 
         // Relate Ticker -> ID -> time.

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -197,16 +197,16 @@ decl_storage! {
     trait Store for Module<T: Config> as Asset {
         /// Ticker registration details.
         /// (ticker) -> TickerRegistration
-        pub Tickers get(fn ticker_registration): map hasher(blake2_128_concat) Ticker => TickerRegistration<T::Moment>;
+        pub Tickers get(fn ticker_registration): map hasher(blake2_128_concat) Ticker => Option<TickerRegistration<T::Moment>>;
         /// Ticker registration config.
         /// (ticker) -> TickerRegistrationConfig
         pub TickerConfig get(fn ticker_registration_config) config(): TickerRegistrationConfig<T::Moment>;
         /// Details of the token corresponding to the token ticker.
         /// (ticker) -> SecurityToken details [returns SecurityToken struct]
-        pub Tokens get(fn token_details): map hasher(blake2_128_concat) Ticker => SecurityToken;
+        pub Tokens get(fn tokens): map hasher(blake2_128_concat) Ticker => Option<SecurityToken>;
         /// Asset name of the token corresponding to the token ticker.
         /// (ticker) -> `AssetName`
-        pub AssetNames get(fn asset_names): map hasher(blake2_128_concat) Ticker => AssetName;
+        pub AssetNames get(fn asset_names): map hasher(blake2_128_concat) Ticker => Option<AssetName>;
         /// The total asset ticker balance per identity.
         /// (ticker, DID) -> Balance
         // NB: It is safe to use `identity` hasher here because assets can not be distributed to non-existent identities.
@@ -221,7 +221,7 @@ decl_storage! {
         /// Maps custom asset type ids to the registered string contents.
         pub CustomTypes get(fn custom_types): map hasher(twox_64_concat) CustomAssetTypeId => Vec<u8>;
         /// Inverse map of `CustomTypes`, from registered string contents to custom asset type ids.
-        pub CustomTypesInverse get(fn custom_types_inverse): map hasher(blake2_128_concat) Vec<u8> => CustomAssetTypeId;
+        pub CustomTypesInverse get(fn custom_types_inverse): map hasher(blake2_128_concat) Vec<u8> => Option<CustomAssetTypeId>;
 
         /// The name of the current funding round.
         /// ticker -> funding round
@@ -239,7 +239,7 @@ decl_storage! {
         /// Documents attached to an Asset
         /// (ticker, doc_id) -> document
         pub AssetDocuments get(fn asset_documents):
-            double_map hasher(blake2_128_concat) Ticker, hasher(twox_64_concat) DocumentId => Document;
+            double_map hasher(blake2_128_concat) Ticker, hasher(twox_64_concat) DocumentId => Option<Document>;
         /// Per-ticker document ID counter.
         /// (ticker) -> doc_id
         pub AssetDocumentsIdSequence get(fn asset_documents_id_sequence): map hasher(blake2_128_concat) Ticker => DocumentId;
@@ -1104,7 +1104,7 @@ impl<T: Config> Module<T> {
     }
 
     fn maybe_ticker(ticker: &Ticker) -> Option<TickerRegistration<T::Moment>> {
-        <Tickers<T>>::contains_key(ticker).then(|| <Tickers<T>>::get(ticker))
+        <Tickers<T>>::get(ticker)
     }
 
     pub fn is_ticker_available(ticker: &Ticker) -> bool {
@@ -1221,7 +1221,9 @@ impl<T: Config> Module<T> {
 
     // Get the total supply of an asset `id`.
     pub fn total_supply(ticker: Ticker) -> Balance {
-        Self::token_details(ticker).total_supply
+        Self::token_details(&ticker)
+            .map(|t| t.total_supply)
+            .unwrap_or_default()
     }
 
     pub fn get_balance_at(ticker: Ticker, did: IdentityId, at: CheckpointId) -> Balance {
@@ -1283,9 +1285,10 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         Self::ensure_granular(ticker, value)?;
 
+        let token = Self::token_details(ticker)?;
         // Ensures the token is fungible
         ensure!(
-            Tokens::get(&ticker).asset_type.is_fungible(),
+            token.asset_type.is_fungible(),
             Error::<T>::UnexpectedNonFungibleToken
         );
 
@@ -1400,7 +1403,7 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         Self::ensure_granular(ticker, value)?;
         // Read the token details
-        let mut token = Self::token_details(ticker);
+        let mut token = Self::token_details(ticker)?;
         // Ensures the token is fungible
         ensure!(
             token.asset_type.is_fungible(),
@@ -1503,8 +1506,14 @@ impl<T: Config> Module<T> {
         value % ONE_UNIT == 0
     }
 
+    pub fn token_details(ticker: &Ticker) -> Result<SecurityToken, DispatchError> {
+        Ok(Tokens::try_get(ticker).or(Err(Error::<T>::NoSuchAsset))?)
+    }
+
     pub fn is_divisible(ticker: &Ticker) -> bool {
-        Self::token_details(ticker).divisible
+        Self::token_details(ticker)
+            .map(|t| t.divisible)
+            .unwrap_or_default()
     }
 
     /// Accepts and executes the ticker transfer.
@@ -1515,19 +1524,22 @@ impl<T: Config> Module<T> {
 
             Self::ensure_asset_fresh(&ticker)?;
 
-            let owner = Self::ticker_registration(&ticker).owner;
-            <Identity<T>>::ensure_auth_by(auth_by, owner)?;
+            let reg =
+                Self::ticker_registration(&ticker).ok_or(Error::<T>::TickerRegistrationExpired)?;
+            <Identity<T>>::ensure_auth_by(auth_by, reg.owner)?;
 
-            Self::transfer_ticker(ticker, to, owner);
+            Self::transfer_ticker(reg, ticker, to);
             Ok(())
         })
     }
 
-    /// Transfer the given `ticker`'s registration from `from` to `to`.
-    fn transfer_ticker(ticker: Ticker, to: IdentityId, from: IdentityId) {
+    /// Transfer the given `ticker`'s registration from `req.owner` to `to`.
+    fn transfer_ticker(mut reg: TickerRegistration<T::Moment>, ticker: Ticker, to: IdentityId) {
+        let from = reg.owner;
         AssetOwnershipRelations::remove(from, ticker);
         AssetOwnershipRelations::insert(to, ticker, AssetOwnershipRelation::TickerOwned);
-        <Tickers<T>>::mutate(&ticker, |tr| tr.owner = to);
+        reg.owner = to;
+        <Tickers<T>>::insert(&ticker, reg);
         Self::deposit_event(RawEvent::TickerTransferred(to, ticker, from));
     }
 
@@ -1537,15 +1549,24 @@ impl<T: Config> Module<T> {
         <Identity<T>>::accept_auth_with(&to.into(), id, |data, auth_by| {
             let ticker = extract_auth!(data, TransferAssetOwnership(t));
 
-            Self::ensure_asset_exists(&ticker)?;
+            // Get the token details and ensure it exists.
+            let mut token = Self::token_details(&ticker)?;
+
+            // Ensure the authorization was created by a permissioned agent.
             <ExternalAgents<T>>::ensure_agent_permissioned(ticker, auth_by)?;
 
-            let owner = Self::ticker_registration(&ticker).owner;
-            AssetOwnershipRelations::remove(owner, ticker);
+            // Get the ticker registration and ensure it exists.
+            let mut reg = Self::ticker_registration(&ticker).ok_or(Error::<T>::NoSuchAsset)?;
+            let old_owner = reg.owner;
+            AssetOwnershipRelations::remove(old_owner, ticker);
             AssetOwnershipRelations::insert(to, ticker, AssetOwnershipRelation::AssetOwned);
-            <Tickers<T>>::mutate(&ticker, |tr| tr.owner = to);
-            Tokens::mutate(&ticker, |tr| tr.owner_did = to);
-            Self::deposit_event(RawEvent::AssetOwnershipTransferred(to, ticker, owner));
+            // Update ticker registration.
+            reg.owner = to;
+            <Tickers<T>>::insert(&ticker, reg);
+            // Update token details.
+            token.owner_did = to;
+            Tokens::insert(&ticker, token);
+            Self::deposit_event(RawEvent::AssetOwnershipTransferred(to, ticker, old_owner));
             Ok(())
         })
     }
@@ -1761,7 +1782,11 @@ impl<T: Config> Module<T> {
             Self::unverified_register_ticker(&ticker, did, None);
         } else {
             // Ticker already registered by the user.
-            <Tickers<T>>::mutate(&ticker, |tr| tr.expiry = None);
+            <Tickers<T>>::mutate(&ticker, |tr| {
+                if let Some(tr) = tr {
+                    tr.expiry = None;
+                }
+            });
         }
 
         let token = SecurityToken {
@@ -1791,7 +1816,9 @@ impl<T: Config> Module<T> {
         ));
 
         // Add funding round name.
-        FundingRound::insert(ticker, funding_round.unwrap_or_default());
+        if let Some(funding_round) = funding_round {
+            FundingRound::insert(ticker, funding_round);
+        }
 
         Self::unverified_update_idents(did, ticker, identifiers);
 
@@ -1859,9 +1886,10 @@ impl<T: Config> Module<T> {
 
         Self::ensure_granular(&ticker, value)?;
 
+        let mut token = Self::token_details(&ticker)?;
         // Ensures the token is fungible
         ensure!(
-            Tokens::get(&ticker).asset_type.is_fungible(),
+            token.asset_type.is_fungible(),
             Error::<T>::UnexpectedNonFungibleToken
         );
 
@@ -1870,6 +1898,12 @@ impl<T: Config> Module<T> {
 
         with_transaction(|| {
             Portfolio::<T>::reduce_portfolio_balance(&portfolio, &ticker, value)?;
+
+            // Try updating the total supply.
+            token.total_supply = token
+                .total_supply
+                .checked_sub(value)
+                .ok_or(Error::<T>::TotalSupplyOverflow)?;
 
             <Checkpoint<T>>::advance_update_balances(
                 &ticker,
@@ -1881,7 +1915,7 @@ impl<T: Config> Module<T> {
 
         // Update identity balances and total supply
         BalanceOf::insert(ticker, &portfolio.did, updated_balance);
-        Tokens::mutate(ticker, |token| token.total_supply -= value);
+        Tokens::insert(ticker, token);
 
         // Update scope balances
         let scope_id = Self::scope_id(&ticker, &portfolio.did);
@@ -1922,6 +1956,7 @@ impl<T: Config> Module<T> {
         let did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
 
         Tokens::try_mutate(&ticker, |token| -> DispatchResult {
+            let mut token = token.as_mut().ok_or(Error::<T>::NoSuchAsset)?;
             // Ensures the token is fungible
             ensure!(
                 token.asset_type.is_fungible(),
@@ -2380,11 +2415,11 @@ impl<T: Config> Module<T> {
         from_did: &IdentityId,
         to_did: &IdentityId,
         ticker: &Ticker,
-    ) -> (ScopeId, ScopeId, SecurityToken) {
+    ) -> (ScopeId, ScopeId, Balance) {
         (
             Self::scope_id(ticker, &from_did),
             Self::scope_id(ticker, &to_did),
-            Tokens::get(ticker),
+            Self::total_supply(*ticker),
         )
     }
 
@@ -2395,7 +2430,7 @@ impl<T: Config> Module<T> {
         value: Balance,
         weight_meter: &mut WeightMeter,
     ) -> bool {
-        let (from_scope_id, to_scope_id, token) =
+        let (from_scope_id, to_scope_id, total_supply) =
             Self::setup_statistics_failures(from_did, to_did, ticker);
         Statistics::<T>::verify_transfer_restrictions(
             ticker,
@@ -2406,7 +2441,7 @@ impl<T: Config> Module<T> {
             Self::aggregate_balance_of(ticker, &from_scope_id),
             Self::aggregate_balance_of(ticker, &to_scope_id),
             value,
-            token.total_supply,
+            total_supply,
             weight_meter,
         )
         .is_err()
@@ -2419,7 +2454,7 @@ impl<T: Config> Module<T> {
         value: Balance,
         weight_meter: &mut WeightMeter,
     ) -> Result<Vec<TransferConditionResult>, DispatchError> {
-        let (from_scope_id, to_scope_id, token) =
+        let (from_scope_id, to_scope_id, total_supply) =
             Self::setup_statistics_failures(from_did, to_did, ticker);
         Statistics::<T>::get_transfer_restrictions_results(
             ticker,
@@ -2430,7 +2465,7 @@ impl<T: Config> Module<T> {
             Self::aggregate_balance_of(ticker, &from_scope_id),
             Self::aggregate_balance_of(ticker, &to_scope_id),
             value,
-            token.total_supply,
+            total_supply,
             weight_meter,
         )
     }
@@ -2473,6 +2508,7 @@ impl<T: Config> Module<T> {
         Self::ensure_asset_type_valid(asset_type)?;
         let did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         Tokens::try_mutate(&ticker, |token| -> DispatchResult {
+            let mut token = token.as_mut().ok_or(Error::<T>::NoSuchAsset)?;
             // Ensures that both parameters are non fungible types or if both are fungible types.
             ensure!(
                 token.asset_type.is_fungible() == asset_type.is_fungible(),

--- a/pallets/identity/src/claims.rs
+++ b/pallets/identity/src/claims.rs
@@ -261,7 +261,7 @@ impl<T: Config> Module<T> {
     ) -> Option<IdentityClaim> {
         let pk = Claim1stKey { target, claim_type };
         let sk = Claim2ndKey { issuer, scope };
-        Claims::contains_key(&pk, &sk).then(|| Claims::get(&pk, &sk))
+        Claims::get(&pk, &sk)
     }
 
     /// It adds a new claim without any previous security check.
@@ -452,11 +452,10 @@ impl<T: Config> Module<T> {
     ) -> DispatchResult {
         let (pk, sk) = Self::get_claim_keys(target, claim_type, issuer, scope);
         // Ensure that claim exists
-        let investor_unique_scope_id = match Claims::try_get(&pk, &sk)
-            .map_err(|_| Error::<T>::ClaimDoesNotExist)?
-            .claim
-        {
-            Claim::InvestorUniqueness(_, scope_id, _) => Some(scope_id),
+        let claim = Claims::take(&pk, &sk).ok_or(Error::<T>::ClaimDoesNotExist)?;
+
+        let investor_unique_scope_id = match &claim.claim {
+            Claim::InvestorUniqueness(_, scope_id, _) => Some(*scope_id),
             Claim::InvestorUniquenessV2(..) => match &sk.scope {
                 Some(Scope::Ticker(ticker)) => {
                     Some(T::AssetSubTraitTarget::scope_id(ticker, &target))
@@ -481,7 +480,6 @@ impl<T: Config> Module<T> {
             );
         }
 
-        let claim = Claims::take(&pk, &sk);
         Self::deposit_event(RawEvent::ClaimRevoked(target, claim));
         Ok(())
     }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -141,7 +141,7 @@ decl_storage! {
         pub CurrentPayer: Option<T::AccountId>;
 
         /// (Target ID, claim type) (issuer,scope) -> Associated claims
-        pub Claims: double_map hasher(twox_64_concat) Claim1stKey, hasher(blake2_128_concat) Claim2ndKey => IdentityClaim;
+        pub Claims: double_map hasher(twox_64_concat) Claim1stKey, hasher(blake2_128_concat) Claim2ndKey => Option<IdentityClaim>;
         /// CustomClaimTypeId -> String constant
         pub CustomClaims: map hasher(twox_64_concat) CustomClaimTypeId => Option<Vec<u8>>;
         /// String constant -> CustomClaimTypeId

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -140,9 +140,9 @@ decl_storage! {
         /// (Target ID, claim type) (issuer,scope) -> Associated claims
         pub Claims: double_map hasher(twox_64_concat) Claim1stKey, hasher(blake2_128_concat) Claim2ndKey => IdentityClaim;
         /// CustomClaimTypeId -> String constant
-        pub CustomClaims: map hasher(twox_64_concat) CustomClaimTypeId => Vec<u8>;
+        pub CustomClaims: map hasher(twox_64_concat) CustomClaimTypeId => Option<Vec<u8>>;
         /// String constant -> CustomClaimTypeId
-        pub CustomClaimsInverse: map hasher(blake2_128_concat) Vec<u8> => CustomClaimTypeId;
+        pub CustomClaimsInverse: map hasher(blake2_128_concat) Vec<u8> => Option<CustomClaimTypeId>;
         /// The next `CustomClaimTypeId`.
         pub CustomClaimIdSequence get(fn custom_claim_id_seq): CustomClaimTypeId;
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -101,8 +101,10 @@ use sp_std::convert::TryFrom;
 use sp_std::prelude::*;
 
 use frame_support::dispatch::DispatchClass::{Normal, Operational};
-use frame_support::dispatch::{DispatchResult, Pays};
-use frame_support::traits::{ChangeMembers, Currency, EnsureOrigin, Get, InitializeMembers};
+use frame_support::dispatch::{DispatchResult, Pays, Weight};
+use frame_support::traits::{
+    ChangeMembers, Currency, EnsureOrigin, Get, InitializeMembers, PalletInfoAccess,
+};
 use frame_support::{decl_error, decl_module, decl_storage};
 use polymesh_common_utilities::constants::did::SECURITY_TOKEN;
 use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee, ProtocolOp};
@@ -112,9 +114,10 @@ use polymesh_common_utilities::traits::identity::{
 };
 use polymesh_common_utilities::{SystematicIssuers, GC_DID};
 use polymesh_primitives::{
-    investor_zkproof_data::v1::InvestorZKProofData, storage_migration_ver, Authorization,
-    AuthorizationData, AuthorizationType, CddId, Claim, ClaimType, CustomClaimTypeId, DidRecord,
-    IdentityClaim, IdentityId, KeyRecord, Permissions, Scope, SecondaryKey, Signatory, Ticker,
+    investor_zkproof_data::v1::InvestorZKProofData, storage_migrate_on, storage_migration_ver,
+    Authorization, AuthorizationData, AuthorizationType, CddId, Claim, ClaimType,
+    CustomClaimTypeId, DidRecord, IdentityClaim, IdentityId, KeyRecord, Permissions, Scope,
+    SecondaryKey, Signatory, Ticker,
 };
 
 pub type Event<T> = polymesh_common_utilities::traits::identity::Event<T>;
@@ -167,10 +170,6 @@ decl_storage! {
         /// All authorizations that an identity has given. (Authorizer, auth_id -> authorized)
         pub AuthorizationsGiven: double_map hasher(identity)
             IdentityId, hasher(twox_64_concat) u64 => Signatory<T::AccountId>;
-
-        /// Obsoleted storage variable superceded by `CddAuthForPrimaryKeyRotation`. It is kept here
-        /// for the purpose of storage migration.
-        pub CddAuthForMasterKeyRotation get(fn cdd_auth_for_master_key_rotation): bool;
 
         /// A config flag that, if set, instructs an authorization from a CDD provider in order to
         /// change the primary key of an identity.
@@ -252,6 +251,13 @@ decl_module! {
         // Initializing events
         // this is needed only if you are using events in your module
         fn deposit_event() = default;
+
+        fn on_runtime_upgrade() -> Weight {
+            storage_migrate_on!(StorageVersion, 2, {
+                let _ = frame_support::storage::migration::clear_storage_prefix(<Pallet<T>>::name().as_bytes(), b"CddAuthForMasterKeyRotation", b"", None, None);
+            });
+            Weight::zero()
+        }
 
         const InitialPOLYX: <T::Balances as Currency<T::AccountId>>::Balance = T::InitialPOLYX::get();
 

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -70,7 +70,7 @@ benchmarks! {
         let next_portfolio_num = NextPortfolioNumber::get(&did);
     }: _(target.origin, portfolio_name.clone())
     verify {
-        assert_eq!(Portfolios::get(&did, &next_portfolio_num), portfolio_name);
+        assert_eq!(Portfolios::get(&did, &next_portfolio_num), Some(portfolio_name));
     }
 
     delete_portfolio {
@@ -79,7 +79,7 @@ benchmarks! {
         let portfolio_name = PortfolioName(vec![65u8; 5]);
         let next_portfolio_num = NextPortfolioNumber::get(&did);
         Module::<T>::create_portfolio(target.origin.clone().into(), portfolio_name.clone()).unwrap();
-        assert_eq!(Portfolios::get(&did, &next_portfolio_num), portfolio_name);
+        assert_eq!(Portfolios::get(&did, &next_portfolio_num), Some(portfolio_name));
     }: _(target.origin, next_portfolio_num.clone())
     verify {
         assert!(!Portfolios::contains_key(&did, &next_portfolio_num));
@@ -94,12 +94,12 @@ benchmarks! {
         let portfolio_name = PortfolioName(vec![65u8; i as usize]);
         let next_portfolio_num = NextPortfolioNumber::get(&did);
         Module::<T>::create_portfolio(target.origin.clone().into(), portfolio_name.clone()).unwrap();
-        assert_eq!(Portfolios::get(&did, &next_portfolio_num), portfolio_name);
+        assert_eq!(Portfolios::get(&did, &next_portfolio_num), Some(portfolio_name));
         let new_name = PortfolioName(vec![66u8; i as usize]);
 
     }: _(target.origin, next_portfolio_num.clone(), new_name.clone())
     verify {
-        assert_eq!(Portfolios::get(&did, &next_portfolio_num), new_name);
+        assert_eq!(Portfolios::get(&did, &next_portfolio_num), Some(new_name));
     }
 
     quit_portfolio_custody {

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -6,7 +6,7 @@ use super::{
     },
     ExtBuilder,
 };
-use crate::asset_test::{allow_all_transfers, basic_asset, set_timestamp, token};
+use crate::asset_test::{allow_all_transfers, basic_asset, set_timestamp, token, token_details};
 use core::iter;
 use frame_support::{
     assert_noop, assert_ok,
@@ -115,7 +115,7 @@ fn transfer(ticker: &Ticker, from: User, to: User) {
 fn create_asset(ticker: &[u8], owner: User) -> Ticker {
     let (ticker, token) = token(ticker, owner.did);
     assert_ok!(basic_asset(owner, ticker, &token));
-    assert_eq!(Asset::token_details(ticker).owner_did, owner.did);
+    assert_eq!(token_details(&ticker).owner_did, owner.did);
     allow_all_transfers(ticker, owner);
     ticker
 }
@@ -2157,7 +2157,11 @@ fn dist_claim_rounding_indivisible() {
 
         // Make `currency` indivisible.
         // This the crucial aspect different about this test.
-        Tokens::mutate(currency, |t| t.divisible = false);
+        Tokens::mutate(currency, |t| {
+            if let Some(t) = t {
+                t.divisible = false;
+            }
+        });
 
         // Endow shares to holders.
         let endow = |to, units| transfer_amount(&ticker, owner, to, units * ONE_UNIT);

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -2105,8 +2105,8 @@ fn custom_claim_type_works() {
             seq_is(id);
             let id = CustomClaimTypeId(id);
             let data = data.as_bytes();
-            assert_eq!(CustomClaims::get(id), data);
-            assert_eq!(CustomClaimsInverse::get(data), id);
+            assert_eq!(CustomClaims::get(id), Some(data));
+            assert_eq!(CustomClaimsInverse::get(data), Some(id));
         };
 
         // Nothing so far. Generator (G) at 0.

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -2104,8 +2104,8 @@ fn custom_claim_type_works() {
         let slot_has = |id, data: &str| {
             seq_is(id);
             let id = CustomClaimTypeId(id);
-            let data = data.as_bytes();
-            assert_eq!(CustomClaims::get(id), Some(data));
+            let data = data.as_bytes().to_vec();
+            assert_eq!(CustomClaims::get(id).as_ref(), Some(&data));
             assert_eq!(CustomClaimsInverse::get(data), Some(id));
         };
 

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -18,7 +18,7 @@ use polymesh_primitives::{
 };
 use test_client::AccountKeyring;
 
-use crate::asset_test::set_timestamp;
+use super::asset_test::{set_timestamp, token_details};
 use crate::ext_builder::ExtBuilder;
 use crate::storage::{TestStorage, User};
 
@@ -48,9 +48,9 @@ fn create_collection_unregistered_ticker() {
             Some(nft_type),
             collection_keys
         ));
-        assert_eq!(Asset::token_details(&ticker).divisible, false);
+        assert_eq!(token_details(&ticker).divisible, false);
         assert_eq!(
-            Asset::token_details(&ticker).asset_type,
+            token_details(&ticker).asset_type,
             AssetType::NonFungible(nft_type)
         );
     });

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -38,7 +38,7 @@ fn create_portfolio() -> (User, PortfolioNumber) {
     let num = Portfolio::next_portfolio_number(&owner.did);
     assert_eq!(num, PortfolioNumber(1));
     assert_ok!(Portfolio::create_portfolio(owner.origin(), name.clone()));
-    assert_eq!(Portfolio::portfolios(&owner.did, num), name);
+    assert_eq!(Portfolio::portfolios(&owner.did, num), Some(name));
     (owner, num)
 }
 
@@ -101,7 +101,7 @@ fn can_create_rename_delete_portfolio() {
     ExtBuilder::default().build().execute_with(|| {
         let (owner, num) = create_portfolio();
 
-        let name = || Portfolio::portfolios(owner.did, num);
+        let name = || Portfolio::portfolios(owner.did, num).unwrap();
         let num_of = |name| Portfolio::name_to_number(owner.did, name);
 
         let first_name = name();
@@ -128,7 +128,7 @@ fn can_delete_recreate_portfolio() {
     ExtBuilder::default().build().execute_with(|| {
         let (owner, num) = create_portfolio();
 
-        let name = || Portfolio::portfolios(owner.did, num);
+        let name = || Portfolio::portfolios(owner.did, num).unwrap();
         let num_of = |name| Portfolio::name_to_number(owner.did, name);
 
         let first_name = name();

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -16,7 +16,7 @@ use pallet_portfolio::{PortfolioLockedNFT, PortfolioNFT};
 use pallet_scheduler as scheduler;
 use pallet_settlement::{
     AffirmsReceived, InstructionAffirmsPending, InstructionLegs, InstructionMemos,
-    OffChainAffirmations, RawEvent, UserAffirmations, VenueInstructions,
+    OffChainAffirmations, RawEvent, UserAffirmations, UserVenues, VenueInstructions,
 };
 use polymesh_common_utilities::constants::currency::ONE_UNIT;
 use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
@@ -233,6 +233,14 @@ fn venue_instructions(id: VenueId) -> Vec<InstructionId> {
     VenueInstructions::iter_prefix(id).map(|(i, _)| i).collect()
 }
 
+fn user_venues(did: IdentityId) -> Vec<VenueId> {
+    let mut venues = UserVenues::iter_prefix(did)
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    venues.sort();
+    venues
+}
+
 #[test]
 fn venue_registration() {
     ExtBuilder::default().build().execute_with(|| {
@@ -252,7 +260,7 @@ fn venue_registration() {
             Settlement::venue_counter(),
             venue_counter.checked_inc().unwrap()
         );
-        assert_eq!(Settlement::user_venues(alice.did), [venue_counter]);
+        assert_eq!(user_venues(alice.did), [venue_counter]);
         assert_eq!(venue_info.creator, alice.did);
         assert_eq!(venue_instructions(venue_counter).len(), 0);
         assert_eq!(Settlement::details(venue_counter), VenueDetails::default());
@@ -275,7 +283,7 @@ fn venue_registration() {
             VenueType::Exchange
         ));
         assert_eq!(
-            Settlement::user_venues(alice.did),
+            user_venues(alice.did),
             [venue_counter, venue_counter.checked_inc().unwrap()]
         );
 

--- a/pallets/runtime/tests/src/sto_test.rs
+++ b/pallets/runtime/tests/src/sto_test.rs
@@ -223,7 +223,7 @@ fn raise_happy_path() {
     assert_eq!(Asset::balance_of(&raise_ticker, bob.did), bob_init_raise);
     assert_eq!(
         Sto::fundraiser_name(offering_ticker, fundraiser_id),
-        fundraiser_name
+        Some(fundraiser_name)
     );
     let sto_invest = |purchase_amount, max_price, err: Error| {
         exec_noop!(

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -324,7 +324,10 @@ fn batch_secondary_with_permissions() {
     let alice = User::new(AccountKeyring::Alice).balance(1_000);
     let bob = User::new_with(alice.did, AccountKeyring::Bob);
     let check_name = |name| {
-        assert_eq!(Portfolio::portfolios(&alice.did, &PortfolioNumber(1)), name);
+        assert_eq!(
+            Portfolio::portfolios(&alice.did, &PortfolioNumber(1)),
+            Some(name)
+        );
     };
 
     // Add Bob.

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -309,7 +309,7 @@ benchmarks! {
     }: _(origin, venue_details, signers, venue_type)
     verify {
         assert_eq!(Module::<T>::venue_counter(), VenueId(2), "Invalid venue counter");
-        assert!(UserVenues::<T>::contains_key(did.unwrap(), VenueId(1)), "Invalid venue id");
+        assert!(UserVenues::contains_key(did.unwrap(), VenueId(1)), "Invalid venue id");
         assert!(Module::<T>::venue_info(VenueId(1)).is_some(), "Incorrect venue info set");
     }
 

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -309,7 +309,7 @@ benchmarks! {
     }: _(origin, venue_details, signers, venue_type)
     verify {
         assert_eq!(Module::<T>::venue_counter(), VenueId(2), "Invalid venue counter");
-        assert_eq!(Module::<T>::user_venues(did.unwrap()).into_iter().last(), Some(VenueId(1)), "Invalid venue id");
+        assert!(UserVenues::<T>::contains_key(did.unwrap(), VenueId(1)), "Invalid venue id");
         assert!(Module::<T>::venue_info(VenueId(1)).is_some(), "Incorrect venue info set");
     }
 

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -248,7 +248,7 @@ decl_storage! {
         /// Only needed for the UI.
         ///
         /// identity -> venue_id ()
-        UserVenues get(fn user_venues):
+        pub UserVenues get(fn user_venues):
             double_map hasher(twox_64_concat) IdentityId,
                        hasher(twox_64_concat) VenueId
                     => ();

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -244,7 +244,14 @@ decl_storage! {
                        hasher(twox_64_concat) T::AccountId
                     => bool;
         /// Array of venues created by an identity. Only needed for the UI. IdentityId -> Vec<venue_id>
-        UserVenues get(fn user_venues): map hasher(twox_64_concat) IdentityId => Vec<VenueId>;
+        /// Venues create by an identity.
+        /// Only needed for the UI.
+        ///
+        /// identity -> venue_id ()
+        UserVenues get(fn user_venues):
+            double_map hasher(twox_64_concat) IdentityId,
+                       hasher(twox_64_concat) VenueId
+                    => ();
         /// Details about an instruction. instruction_id -> instruction_details
         pub InstructionDetails get(fn instruction_details):
             map hasher(twox_64_concat) InstructionId => Instruction<T::Moment, T::BlockNumber>;
@@ -321,7 +328,7 @@ decl_module! {
             for signer in signers {
                 <VenueSigners<T>>::insert(id, signer, true);
             }
-            UserVenues::append(did, id);
+            UserVenues::insert(did, id, ());
             Self::deposit_event(RawEvent::VenueCreated(did, id, details, typ));
         }
 
@@ -2051,6 +2058,7 @@ pub mod migration {
 
         decl_storage! {
             trait Store for Module<T: Config> as Settlement {
+                pub UserVenues get(fn user_venues): map hasher(twox_64_concat) IdentityId => Vec<VenueId>;
                 pub InstructionDetails get(fn instruction_details):
                     map hasher(twox_64_concat) InstructionId => Instruction<T::Moment, T::BlockNumber>;
                 pub InstructionLegs get(fn instruction_legs):
@@ -2068,9 +2076,24 @@ pub mod migration {
     pub fn migrate_to_v2<T: Config>() {
         RuntimeLogger::init();
         log::info!(" >>> Updating Settlement storage. Migrating Legs and Instructions.");
+        migrate_user_venues::<T>();
         migrate_legs::<T>();
         migrate_instruction_details::<T>();
-        log::info!(" >>> All legs and Instructions have been migrated.");
+        log::info!(" >>> All user_venues, legs and Instructions have been migrated.");
+    }
+
+    fn migrate_user_venues<T: Config>() {
+        // Need to fully drain the old storage.
+        let user_venues = v1::UserVenues::drain().collect::<Vec<(IdentityId, Vec<VenueId>)>>();
+        let mut count = 0;
+        // Convert to new double map.
+        for (did, venues) in user_venues {
+            count += venues.len();
+            for venue_id in venues {
+                UserVenues::insert(did, venue_id, ());
+            }
+        }
+        log::info!(" >>> {count} UserVenues have been migrated.");
     }
 
     fn migrate_legs<T: Config>() {

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -261,7 +261,7 @@ decl_storage! {
             double_map
                 hasher(blake2_128_concat) Ticker,
                 hasher(twox_64_concat) FundraiserId
-                => FundraiserName;
+                => Option<FundraiserName>;
     }
 }
 


### PR DESCRIPTION
## changelog

### modified API

- Add `Option` wrapper to `Asset.Tickers`, `Asset.Tokens`, `Asset.AssetNames`, `Asset.CustomTypesInverse`, `Asset.AssetDocuments`, `Portfolio.Portfolios`, `Identity.Claims`, `Identity.CustomClaims`, `Identity.CustomClaimsInverse` and `Sto.FundraiserNames`.
- Change storage of `Settlement.UserVenues` from a Vec to a double map.
- Removed unused `Identity.CddAuthForMasterKeyRotation` storage.
