### PR TITLE
Mesh 2063 disable investor uniqueness migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,6 +4576,7 @@ dependencies = [
  "frame-system",
  "hex-literal 0.2.2",
  "libsecp256k1 0.6.0",
+ "log",
  "pallet-balances 0.1.0",
  "pallet-base",
  "pallet-external-agents",
@@ -6089,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "chrono",
  "clap 4.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "5.4.1"
+version = "5.4.2"
 authors = ["Polymesh Association"]
 build = "build.rs"
 edition = "2021"

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.48"
 rustc-hex = { version = "2.1.0", default-features = false }
 hex-literal = "0.2.1"
 arrayvec = { version = "0.7.1", default-features = false }
+log = "0.4"
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -53,7 +53,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 5_004_001,
+    spec_version: 5_004_002,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -51,7 +51,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 5_004_001,
+    spec_version: 5_004_002,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -56,7 +56,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 5_004_001,
+    spec_version: 5_004_002,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION

## changelog

### data migration

- Migrate Investor Uniqueness assets to non-investor Uniqueness assets.
- Remove all `Asset.ClassicTickers`.
