### PR TITLE
Bump tx version.

### DIFF
--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -56,7 +56,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 6_000_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
     state_version: 1,
 };
 

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -54,7 +54,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 6_000_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
     state_version: 1,
 };
 

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 6_000_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
     state_version: 1,
 };
 


### PR DESCRIPTION
Because v6.0 is a major breaking release, we need to bump the chain `transaction_version`.