### PR TITLE
MESH-2071: Update contracts storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,6 +6569,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-base",
  "pallet-contracts",
  "pallet-contracts-primitives",

--- a/pallets/contracts/Cargo.toml
+++ b/pallets/contracts/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.104", default-features = false }
+log = "0.4.8"
 
 wasm-instrument = { version = "0.3", default-features = false, optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -53,7 +53,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_000_000,
+    spec_version: 6_000_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -51,7 +51,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_000_000,
+    spec_version: 6_000_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -56,7 +56,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_000_000,
+    spec_version: 6_000_001,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,


### PR DESCRIPTION
## changelog

Updates spec_version to `6_000_001`

### data migration

- Updates `PolymeshContracts` storage to be under the `PolymeshContracts` root, rather than `Contracts
- Removes any existing `CallRuntimeWhitelist` under the old storage root (`Contracts`)
