### PR TITLE
Improve settlement weight estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,7 +5035,6 @@ dependencies = [
  "log",
  "pallet-permissions",
  "pallet-timestamp",
- "pallet-transaction-payment",
  "parity-scale-codec 3.5.0",
  "polymesh-common-utilities",
  "polymesh-primitives",

--- a/pallets/balances/Cargo.toml
+++ b/pallets/balances/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 pallet-permissions = { path = "../permissions", default-features = false }
-pallet-transaction-payment = { path = "../transaction-payment", default-features = false }
 polymesh-common-utilities = { path = "../common", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
@@ -50,7 +49,6 @@ std = [
 	"pallet-timestamp/std",
 	"polymesh-common-utilities/std",
 	"polymesh-primitives/std",
-	"pallet-transaction-payment/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -146,6 +146,15 @@ macro_rules! misc_pallet_impls {
             }
         }
 
+        impl RuntimeCall {
+            fn get_actual_weight(&self) -> Option<Weight> {
+                match self {
+                    RuntimeCall::Settlement(x) => Settlement::get_actual_weight(x),
+                    _ => None,
+                }
+            }
+        }
+
         impl pallet_transaction_payment::Config for Runtime {
             type RuntimeEvent = RuntimeEvent;
             type Currency = Balances;
@@ -822,11 +831,13 @@ macro_rules! runtime_apis {
                 Block,
             > for Runtime {
                 fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-                    TransactionPayment::query_info(uxt, len)
+                    let actual = uxt.function.get_actual_weight();
+                    TransactionPayment::query_info(uxt, len, actual)
                 }
 
                 fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> pallet_transaction_payment::FeeDetails<Balance> {
-                    TransactionPayment::query_fee_details(uxt, len)
+                    let actual = uxt.function.get_actual_weight();
+                    TransactionPayment::query_fee_details(uxt, len, actual)
                 }
             }
 
@@ -834,10 +845,12 @@ macro_rules! runtime_apis {
                 for Runtime
             {
                 fn query_call_info(call: RuntimeCall, len: u32) -> RuntimeDispatchInfo<Balance> {
-                    TransactionPayment::query_call_info(call, len)
+                    let actual = call.get_actual_weight();
+                    TransactionPayment::query_call_info(call, len, actual)
                 }
                 fn query_call_fee_details(call: RuntimeCall, len: u32) -> pallet_transaction_payment::FeeDetails<Balance> {
-                    TransactionPayment::query_call_fee_details(call, len)
+                    let actual = call.get_actual_weight();
+                    TransactionPayment::query_call_fee_details(call, len, actual)
                 }
             }
 

--- a/pallets/runtime/tests/src/transaction_payment_test.rs
+++ b/pallets/runtime/tests/src/transaction_payment_test.rs
@@ -240,7 +240,7 @@ fn query_info_works() {
             TransactionPayment::put_next_fee_multiplier(Multiplier::saturating_from_rational(3, 2));
 
             assert_eq!(
-                TransactionPayment::query_info(xt, len),
+                TransactionPayment::query_info(xt, len, None),
                 RuntimeDispatchInfo {
                     weight: info.weight,
                     class: info.class,

--- a/pallets/transaction-payment/src/lib.rs
+++ b/pallets/transaction-payment/src/lib.rs
@@ -454,6 +454,7 @@ where
     pub fn query_info<Extrinsic: sp_runtime::traits::Extrinsic + GetDispatchInfo>(
         unchecked_extrinsic: Extrinsic,
         len: u32,
+        actual: Option<Weight>,
     ) -> RuntimeDispatchInfo<BalanceOf<T>>
     where
         T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
@@ -463,7 +464,11 @@ where
         // `Extra`. Alternatively, we could actually execute the tx's per-dispatch and record the
         // balance of the sender before and after the pipeline.. but this is way too much hassle for
         // a very very little potential gain in the future.
-        let dispatch_info = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+        let mut dispatch_info =
+            <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+        if let Some(weight) = actual {
+            dispatch_info.weight = weight;
+        }
 
         let partial_fee = if unchecked_extrinsic.is_signed().unwrap_or(false) {
             Self::compute_fee(len, &dispatch_info, 0u32.into())
@@ -485,11 +490,16 @@ where
     pub fn query_fee_details<Extrinsic: sp_runtime::traits::Extrinsic + GetDispatchInfo>(
         unchecked_extrinsic: Extrinsic,
         len: u32,
+        actual: Option<Weight>,
     ) -> FeeDetails<BalanceOf<T>>
     where
         T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
     {
-        let dispatch_info = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+        let mut dispatch_info =
+            <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
+        if let Some(weight) = actual {
+            dispatch_info.weight = weight;
+        }
 
         let tip = 0u32.into();
 
@@ -505,11 +515,18 @@ where
     }
 
     /// Query information of a dispatch class, weight, and fee of a given encoded `Call`.
-    pub fn query_call_info(call: T::RuntimeCall, len: u32) -> RuntimeDispatchInfo<BalanceOf<T>>
+    pub fn query_call_info(
+        call: T::RuntimeCall,
+        len: u32,
+        actual: Option<Weight>,
+    ) -> RuntimeDispatchInfo<BalanceOf<T>>
     where
         T::RuntimeCall: Dispatchable<Info = DispatchInfo> + GetDispatchInfo,
     {
-        let dispatch_info = <T::RuntimeCall as GetDispatchInfo>::get_dispatch_info(&call);
+        let mut dispatch_info = <T::RuntimeCall as GetDispatchInfo>::get_dispatch_info(&call);
+        if let Some(weight) = actual {
+            dispatch_info.weight = weight;
+        }
         let DispatchInfo { weight, class, .. } = dispatch_info;
 
         RuntimeDispatchInfo {
@@ -520,11 +537,18 @@ where
     }
 
     /// Query fee details of a given encoded `Call`.
-    pub fn query_call_fee_details(call: T::RuntimeCall, len: u32) -> FeeDetails<BalanceOf<T>>
+    pub fn query_call_fee_details(
+        call: T::RuntimeCall,
+        len: u32,
+        actual: Option<Weight>,
+    ) -> FeeDetails<BalanceOf<T>>
     where
         T::RuntimeCall: Dispatchable<Info = DispatchInfo> + GetDispatchInfo,
     {
-        let dispatch_info = <T::RuntimeCall as GetDispatchInfo>::get_dispatch_info(&call);
+        let mut dispatch_info = <T::RuntimeCall as GetDispatchInfo>::get_dispatch_info(&call);
+        if let Some(weight) = actual {
+            dispatch_info.weight = weight;
+        }
         let tip = 0u32.into();
 
         Self::compute_fee_details(len, &dispatch_info, tip)


### PR DESCRIPTION
## changelog

### modified logic

- The `transactionPaymentApi` and `transactionPaymentCallApi` Runtime API now check if the call is for the Settlement pallet and gets the actual weight for `affirmInstruction`, `affirmWithReceipts`, `rejectInstruction` and `withdrawAffirmation` calls.

