### PR TITLE
Fixes docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - fix_docs
 
 jobs:
   docs:
@@ -22,7 +23,7 @@ jobs:
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2022-11-02
         target: wasm32-unknown-unknown
         override: true
         default: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2022-11-05
+        toolchain: nightly-2022-11-16
         target: wasm32-unknown-unknown
         override: true
         default: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - fix_docs
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2022-11-02
+        toolchain: nightly-2022-11-05
         target: wasm32-unknown-unknown
         override: true
         default: true


### PR DESCRIPTION
Note - nightly-2022-11-02 has a regression on docs linking, so we need a later version than the one referenced in rust_toolchain.toml.