### PR TITLE
MESH-2110/Add storage for tracking an NFT owner

### DIFF
--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -2,6 +2,7 @@
 
 use codec::{Decode, Encode};
 use frame_support::dispatch::DispatchResult;
+use frame_support::storage::StorageDoubleMap;
 use frame_support::traits::Get;
 use frame_support::weights::Weight;
 use frame_support::{decl_error, decl_module, decl_storage, ensure, require_transactional};
@@ -33,7 +34,7 @@ type Portfolio<T> = pallet_portfolio::Module<T>;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
-storage_migration_ver!(2);
+storage_migration_ver!(1);
 
 decl_storage!(
     trait Store for Module<T: Config> as NFT {
@@ -62,10 +63,10 @@ decl_storage!(
         pub NFTsInCollection get(fn nfts_in_collection): map hasher(blake2_128_concat) Ticker => NFTCount;
 
         /// Tracks the owner of an NFT
-        pub NFTOwner get(fn nft_owner): map hasher(blake2_128_concat) (Ticker, NFTId) => Option<IdentityId>;
+        pub NFTOwner get(fn nft_owner): double_map hasher(blake2_128_concat) Ticker, hasher(blake2_128_concat) NFTId => Option<IdentityId>;
 
         /// Storage version.
-        StorageVersion get(fn storage_version) build(|_| Version::new(2)): Version;
+        StorageVersion get(fn storage_version) build(|_| Version::new(1)): Version;
     }
 );
 
@@ -81,8 +82,8 @@ decl_module! {
         fn deposit_event() = default;
 
         fn on_runtime_upgrade() -> Weight {
-            storage_migrate_on!(StorageVersion, 2, {
-                migration::migrate_to_v2::<T>();
+            storage_migrate_on!(StorageVersion, 1, {
+                migration::migrate_to_v1::<T>();
             });
             Weight::zero()
         }
@@ -364,7 +365,7 @@ impl<T: Config> Module<T> {
             MetadataValue::insert((&collection_id, &nft_id), metadata_key, metadata_value);
         }
         PortfolioNFT::insert(caller_portfolio, (ticker, nft_id), true);
-        NFTOwner::insert((ticker, nft_id), caller_portfolio.did);
+        NFTOwner::insert(ticker, nft_id, caller_portfolio.did);
 
         Self::deposit_event(Event::NFTPortfolioUpdated(
             caller_portfolio.did,
@@ -414,7 +415,7 @@ impl<T: Config> Module<T> {
         PortfolioNFT::remove(&caller_portfolio, (&ticker, &nft_id));
         #[allow(deprecated)]
         MetadataValue::remove_prefix((&collection_id, &nft_id), None);
-        NFTOwner::remove((ticker, nft_id));
+        NFTOwner::remove(ticker, nft_id);
 
         Self::deposit_event(Event::NFTPortfolioUpdated(
             caller_portfolio.did,
@@ -558,7 +559,7 @@ impl<T: Config> Module<T> {
         for nft_id in nfts.ids() {
             PortfolioNFT::remove(sender_portfolio, (nfts.ticker(), nft_id));
             PortfolioNFT::insert(receiver_portfolio, (nfts.ticker(), nft_id), true);
-            NFTOwner::insert((nfts.ticker(), nft_id), receiver_portfolio.did);
+            NFTOwner::insert(nfts.ticker(), nft_id, receiver_portfolio.did);
         }
     }
 
@@ -616,21 +617,28 @@ impl<T: Config> NFTTrait<T::RuntimeOrigin> for Module<T> {
 
 pub mod migration {
     use crate::sp_api_hidden_includes_decl_storage::hidden_include::IterableStorageDoubleMap;
-    use crate::{Config, NFTOwner};
-    use frame_support::storage::StorageMap;
+    use crate::{Config, NFTOwner, NFTsInCollection, NumberOfNFTs};
+    use frame_support::storage::{StorageDoubleMap, StorageMap};
     use pallet_portfolio::PortfolioNFT;
     use sp_runtime::runtime_logger::RuntimeLogger;
 
-    pub fn migrate_to_v2<T: Config>() {
+    pub fn migrate_to_v1<T: Config>() {
         RuntimeLogger::init();
-        log::info!(">>> Initializing NFTOwner Storage");
+        log::info!(">>> Initializing NFTsInCollection and NFTOwner Storage");
+        initialize_nfts_in_collection::<T>();
         initialize_nft_owner::<T>();
-        log::info!(">>> NFTOwner was successfully updated");
+        log::info!(">>> NFTsInCollection and NFTOwner were successfully updated");
+    }
+
+    fn initialize_nfts_in_collection<T: Config>() {
+        for (ticker, _, id_count) in NumberOfNFTs::iter() {
+            NFTsInCollection::mutate(ticker, |collection_count| *collection_count += id_count);
+        }
     }
 
     fn initialize_nft_owner<T: Config>() {
         for (portfolio_id, (ticker, nft_id), _) in PortfolioNFT::iter() {
-            NFTOwner::insert((ticker, nft_id), portfolio_id.did);
+            NFTOwner::insert(ticker, nft_id, portfolio_id.did);
         }
     }
 }

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -65,7 +65,7 @@ decl_storage!(
         pub NFTOwner get(fn nft_owner): map hasher(blake2_128_concat) (Ticker, NFTId) => Option<IdentityId>;
 
         /// Storage version.
-        StorageVersion get(fn storage_version) build(|_| Version::new(1)): Version;
+        StorageVersion get(fn storage_version) build(|_| Version::new(2)): Version;
     }
 );
 

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -433,7 +433,7 @@ fn mint_nft_successfully() {
             ),
             true
         );
-        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(alice.did));
+        assert_eq!(NFTOwner::get(ticker, NFTId(1)), Some(alice.did));
     });
 }
 
@@ -584,7 +584,7 @@ fn burn_nft() {
             PortfolioId::default_portfolio(alice.did),
             (&ticker, NFTId(1))
         ),);
-        assert_eq!(NFTOwner::get((ticker, NFTId(1))), None);
+        assert_eq!(NFTOwner::get(ticker, NFTId(1)), None);
     });
 }
 
@@ -909,7 +909,7 @@ fn transfer_nft() {
             PortfolioNFT::get(PortfolioId::default_portfolio(bob.did), (&ticker, NFTId(1))),
             true
         );
-        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(bob.did));
+        assert_eq!(NFTOwner::get(ticker, NFTId(1)), Some(bob.did));
         assert_eq!(
             super::storage::EventTest::Nft(Event::NFTPortfolioUpdated(
                 IdentityId::default(),
@@ -1002,7 +1002,7 @@ fn controller_transfer() {
             alice_portfolio,
             (ticker, NFTId(1))
         ));
-        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(alice.did));
+        assert_eq!(NFTOwner::get(ticker, NFTId(1)), Some(alice.did));
         assert_eq!(
             super::storage::EventTest::Nft(Event::NFTPortfolioUpdated(
                 alice.did,

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -1,7 +1,9 @@
 use chrono::prelude::Utc;
 use frame_support::{assert_noop, assert_ok, StorageDoubleMap, StorageMap};
 
-use pallet_nft::{Collection, CollectionKeys, MetadataValue, NFTsInCollection, NumberOfNFTs};
+use pallet_nft::{
+    Collection, CollectionKeys, MetadataValue, NFTOwner, NFTsInCollection, NumberOfNFTs,
+};
 use pallet_portfolio::PortfolioNFT;
 use polymesh_common_utilities::traits::nft::Event;
 use polymesh_common_utilities::with_transaction;
@@ -431,6 +433,7 @@ fn mint_nft_successfully() {
             ),
             true
         );
+        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(alice.did));
     });
 }
 
@@ -581,6 +584,7 @@ fn burn_nft() {
             PortfolioId::default_portfolio(alice.did),
             (&ticker, NFTId(1))
         ),);
+        assert_eq!(NFTOwner::get((ticker, NFTId(1))), None);
     });
 }
 
@@ -905,6 +909,7 @@ fn transfer_nft() {
             PortfolioNFT::get(PortfolioId::default_portfolio(bob.did), (&ticker, NFTId(1))),
             true
         );
+        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(bob.did));
         assert_eq!(
             super::storage::EventTest::Nft(Event::NFTPortfolioUpdated(
                 IdentityId::default(),
@@ -997,6 +1002,7 @@ fn controller_transfer() {
             alice_portfolio,
             (ticker, NFTId(1))
         ));
+        assert_eq!(NFTOwner::get((ticker, NFTId(1))), Some(alice.did));
         assert_eq!(
             super::storage::EventTest::Nft(Event::NFTPortfolioUpdated(
                 alice.did,

--- a/pallets/weights/src/pallet_nft.rs
+++ b/pallets/weights/src/pallet_nft.rs
@@ -125,6 +125,8 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof Skipped: Portfolio PortfolioNFT (max_values: None, max_size: None, mode: Measured)
     // Storage: NFT MetadataValue (r:0 w:255)
     // Proof Skipped: NFT MetadataValue (max_values: None, max_size: None, mode: Measured)
+    // Storage: NFT NFTOwner (r:0 w:1)
+    // Proof Skipped: NFT NFTOwner (max_values: None, max_size: None, mode: Measured)
     /// The range of component `n` is `[1, 255]`.
     fn issue_nft(n: u32) -> Weight {
         // Minimum execution time: 93_094 nanoseconds.
@@ -132,7 +134,7 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
             // Standard Error: 74_707
             .saturating_add(Weight::from_ref_time(5_216_435).saturating_mul(n.into()))
             .saturating_add(DbWeight::get().reads(9))
-            .saturating_add(DbWeight::get().writes(4))
+            .saturating_add(DbWeight::get().writes(5))
             .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
     }
     // Storage: NFT CollectionTicker (r:1 w:0)
@@ -155,6 +157,8 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof Skipped: NFT NumberOfNFTs (max_values: None, max_size: None, mode: Measured)
     // Storage: NFT MetadataValue (r:255 w:255)
     // Proof Skipped: NFT MetadataValue (max_values: None, max_size: None, mode: Measured)
+    // Storage: NFT NFTOwner (r:0 w:1)
+    // Proof Skipped: NFT NFTOwner (max_values: None, max_size: None, mode: Measured)
     /// The range of component `n` is `[1, 255]`.
     fn redeem_nft(n: u32) -> Weight {
         // Minimum execution time: 107_301 nanoseconds.
@@ -163,7 +167,7 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
             .saturating_add(Weight::from_ref_time(2_129_048).saturating_mul(n.into()))
             .saturating_add(DbWeight::get().reads(9))
             .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(n.into())))
-            .saturating_add(DbWeight::get().writes(3))
+            .saturating_add(DbWeight::get().writes(4))
             .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
     }
     // Storage: NFT CollectionTicker (r:1 w:0)
@@ -176,6 +180,8 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof Skipped: Portfolio PortfolioNFT (max_values: None, max_size: None, mode: Measured)
     // Storage: ComplianceManager AssetCompliances (r:1 w:0)
     // Proof Skipped: ComplianceManager AssetCompliances (max_values: None, max_size: None, mode: Measured)
+    // Storage: NFT NFTOwner (r:0 w:10)
+    // Proof Skipped: NFT NFTOwner (max_values: None, max_size: None, mode: Measured)
     /// The range of component `n` is `[1, 10]`.
     fn base_nft_transfer(n: u32) -> Weight {
         // Minimum execution time: 146_785 nanoseconds.
@@ -185,7 +191,7 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(5))
             .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(n.into())))
             .saturating_add(DbWeight::get().writes(2))
-            .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
     }
     // Storage: Identity KeyRecords (r:1 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
@@ -205,6 +211,8 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof Skipped: NFT NumberOfNFTs (max_values: None, max_size: None, mode: Measured)
     // Storage: Portfolio PortfolioNFT (r:10 w:20)
     // Proof Skipped: Portfolio PortfolioNFT (max_values: None, max_size: None, mode: Measured)
+    // Storage: NFT NFTOwner (r:0 w:10)
+    // Proof Skipped: NFT NFTOwner (max_values: None, max_size: None, mode: Measured)
     /// The range of component `n` is `[1, 10]`.
     fn controller_transfer(n: u32) -> Weight {
         // Minimum execution time: 99_105 nanoseconds.
@@ -214,6 +222,6 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(9))
             .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(n.into())))
             .saturating_add(DbWeight::get().writes(2))
-            .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
     }
 }


### PR DESCRIPTION
Adds a storage for tracking the owner of an NFT. 

## changelog

### data migration

- Initializes the new storage with data that already lives on chain.
