### PR TITLE
MESH-2110/allow-sc-to-create-custodial-portfolios

### DIFF
--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -100,6 +100,9 @@ pub trait WeightInfo {
         Self::move_portfolio_funds(f, n)
     }
     fn move_portfolio_funds(f: u32, u: u32) -> Weight;
+    fn allow_identity_to_create_portfolios() -> Weight;
+    fn revoke_create_portfolios_permission() -> Weight;
+    fn create_custody_portfolio() -> Weight;
 }
 
 pub trait Config: CommonConfig + identity::Config + base::Config {

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -169,4 +169,21 @@ benchmarks! {
         Module::<T>::create_portfolio(alice.clone().origin().into(), PortfolioName(b"MyOwnPortfolio".to_vec())).unwrap();
         Module::<T>::pre_approve_portfolio(alice.clone().origin().into(), ticker, alice_custom_portfolio).unwrap();
     }: _(alice.origin, ticker, alice_custom_portfolio)
+
+    allow_identity_to_create_portfolios {
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+    }: _(alice.origin, bob.did())
+
+    revoke_create_portfolios_permission {
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+    }: _(alice.origin, bob.did())
+
+    create_custody_portfolio {
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let portfolio_name = PortfolioName("AliceOwnsBobControls".as_bytes().to_vec());
+        Module::<T>::allow_identity_to_create_portfolios(alice.clone().origin().into(), bob.did()).unwrap();
+    }: _(bob.origin, alice.did(), portfolio_name)
 }

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -867,6 +867,11 @@ impl<T: Config> Module<T> {
         Self::base_create_portfolio(portfolio_owner_id, portfolio_name)?;
         // Updates storage for taking ownership of a portfolio
         Self::unverified_take_portfolio_custody(&portfolio_id, &callers_did);
+        Self::deposit_event(Event::PortfolioCustodianChanged(
+            callers_did,
+            portfolio_id,
+            callers_did,
+        ));
         Ok(())
     }
 }

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -47,7 +47,7 @@ pub mod benchmarking;
 
 use codec::{Decode, Encode};
 use core::{iter, mem};
-use frame_support::dispatch::{DispatchError, DispatchResult, Weight};
+use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::{decl_error, decl_module, decl_storage, ensure};
 use sp_arithmetic::traits::Zero;
 use sp_std::collections::btree_set::BTreeSet;
@@ -58,9 +58,9 @@ pub use polymesh_common_utilities::portfolio::{Config, Event, WeightInfo};
 use polymesh_common_utilities::traits::asset::AssetFnTrait;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
 use polymesh_primitives::{
-    extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, Balance, Fund,
-    FundDescription, IdentityId, NFTId, PortfolioId, PortfolioKind, PortfolioName, PortfolioNumber,
-    SecondaryKey, Ticker,
+    extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, AuthorizationData,
+    Balance, Fund, FundDescription, IdentityId, NFTId, PortfolioId, PortfolioKind, PortfolioName,
+    PortfolioNumber, SecondaryKey, Signatory, Ticker,
 };
 
 type Identity<T> = pallet_identity::Module<T>;
@@ -119,6 +119,10 @@ decl_storage! {
         pub PreApprovedPortfolios get(fn pre_approved_portfolios):
             double_map hasher(twox_64_concat) PortfolioId, hasher(blake2_128_concat) Ticker => bool;
 
+        /// Custodians allowed to create and take custody of portfolios on an id's behalf.
+        pub AllowedCustodians get(fn allowed_custodians):
+            double_map hasher(identity) IdentityId, hasher(identity) IdentityId => bool;
+
         /// Storage version.
         StorageVersion get(fn storage_version) build(|_| Version::new(2)): Version;
     }
@@ -159,7 +163,9 @@ decl_error! {
         /// Locked NFTs can not be moved between portfolios.
         InvalidTransferNFTIsLocked,
         /// Trying to move an amount of zero assets.
-        EmptyTransfer
+        EmptyTransfer,
+        /// The caller doesn't have permission to create portfolios on the owner's behalf.
+        MissingOwnersPermission
     }
 }
 
@@ -172,14 +178,9 @@ decl_module! {
 
         /// Creates a portfolio with the given `name`.
         #[weight = <T as Config>::WeightInfo::create_portfolio()]
-        pub fn create_portfolio(origin, name: PortfolioName) {
-            let did = Identity::<T>::ensure_perms(origin)?;
-            Self::ensure_name_unique(&did, &name)?;
-
-            let num = Self::get_next_portfolio_number(&did);
-            NameToNumber::insert(&did, &name, num);
-            Portfolios::insert(&did, &num, name.clone());
-            Self::deposit_event(Event::PortfolioCreated(did, num, name));
+        pub fn create_portfolio(origin, name: PortfolioName) -> DispatchResult {
+            let callers_did = Identity::<T>::ensure_perms(origin)?;
+            Self::base_create_portfolio(callers_did, name)
         }
 
         /// Deletes a user portfolio. A portfolio can be deleted only if it has no funds.
@@ -360,34 +361,72 @@ decl_module! {
             Self::base_remove_portfolio_pre_approval(origin, &ticker, portfolio_id)
         }
 
-        fn on_runtime_upgrade() -> Weight {
-            use polymesh_primitives::storage_migrate_on;
+        /// Adds an identity that will be allowed to create and take custody of a portfolio under the caller's identity.
+        ///
+        /// # Arguments
+        /// * `trusted_identity` - the [`IdentityId`] that will be allowed to call `create_custody_portfolio`.
+        ///
+        #[weight = <T as Config>::WeightInfo::allow_identity_to_create_portfolios()]
+        pub fn allow_identity_to_create_portfolios(
+            origin,
+            trusted_identity: IdentityId
+        ) -> DispatchResult {
+            Self::base_allow_identity_to_create_portfolios(origin, trusted_identity)
+        }
 
-            // Remove old name to number mappings.
-            // In version 4.0.0 (first mainnet deployment) when a portfolio was removed
-            // the NameToNumber mapping was left out of date, this upgrade removes dangling
-            // NameToNumber mappings.
-            // https://github.com/PolymeshAssociation/Polymesh/pull/1200
-            storage_migrate_on!(StorageVersion, 1, {
-                NameToNumber::iter()
-                    .filter(|(identity, _, number)| !Portfolios::contains_key(identity, number))
-                    .for_each(|(identity, name, _)| NameToNumber::remove(identity, name));
-            });
-            storage_migrate_on!(StorageVersion, 2, {
-                Portfolios::iter()
-                    .filter(|(identity, number, name)| Some(number) == Self::name_to_number(identity, name).as_ref())
-                    .for_each(|(identity, number, name)| {
-                            NameToNumber::insert(identity, name, number);
-                    }
-                );
-            });
+        /// Removes permission of an identity to create and take custody of a portfolio under the caller's identity.
+        ///
+        /// # Arguments
+        /// * `identity` - the [`IdentityId`] that will have the permissions to call `create_custody_portfolio` revoked.
+        ///
+        #[weight = <T as Config>::WeightInfo::revoke_create_portfolios_permission()]
+        pub fn revoke_create_portfolios_permission(
+            origin,
+            identity: IdentityId
+        ) -> DispatchResult {
+            Self::base_revoke_create_portfolios_permission(origin, identity)
+        }
 
-            Weight::zero()
+        /// Creates a portfolio under the `portfolio_owner_id` identity and transfers its custody to the caller's identity.
+        ///
+        /// # Arguments
+        /// * `portfolio_owner_id` - the [`IdentityId`] that will own the new portfolio.
+        /// * `portfolio_name` - the [`PortfolioName`] of the new portfolio.
+        ///
+        #[weight =  <T as Config>::WeightInfo::create_custody_portfolio()]
+        pub fn create_custody_portfolio(
+            origin,
+            portfolio_owner_id: IdentityId,
+            portfolio_name: PortfolioName
+        ) -> DispatchResult {
+            Self::base_create_custody_portfolio(origin, portfolio_owner_id, portfolio_name)
         }
     }
 }
 
 impl<T: Config> Module<T> {
+    /// Creates a portfolio named `portfolio_name` owned by `portfolio_owner_id`.
+    fn base_create_portfolio(
+        portfolio_owner_id: IdentityId,
+        portfolio_name: PortfolioName,
+    ) -> DispatchResult {
+        Self::ensure_name_unique(&portfolio_owner_id, &portfolio_name)?;
+        let portfolio_number = Self::get_next_portfolio_number(&portfolio_owner_id);
+
+        NameToNumber::insert(&portfolio_owner_id, &portfolio_name, portfolio_number);
+        Portfolios::insert(
+            &portfolio_owner_id,
+            &portfolio_number,
+            portfolio_name.clone(),
+        );
+        Self::deposit_event(Event::PortfolioCreated(
+            portfolio_owner_id,
+            portfolio_number,
+            portfolio_name,
+        ));
+        Ok(())
+    }
+
     /// Returns the custodian of `pid`.
     fn custodian(pid: &PortfolioId) -> IdentityId {
         PortfolioCustodian::get(&pid).unwrap_or(pid.did)
@@ -779,6 +818,54 @@ impl<T: Config> Module<T> {
         )?;
 
         PreApprovedPortfolios::remove(&portfolio_id, ticker);
+        Ok(())
+    }
+
+    fn base_allow_identity_to_create_portfolios(
+        origin: T::RuntimeOrigin,
+        trusted_identity: IdentityId,
+    ) -> DispatchResult {
+        let callers_did = Identity::<T>::ensure_perms(origin)?;
+        AllowedCustodians::insert(callers_did, trusted_identity, true);
+        Ok(())
+    }
+
+    fn base_revoke_create_portfolios_permission(
+        origin: T::RuntimeOrigin,
+        identity: IdentityId,
+    ) -> DispatchResult {
+        let callers_did = Identity::<T>::ensure_perms(origin)?;
+        AllowedCustodians::remove(callers_did, identity);
+        Ok(())
+    }
+
+    fn base_create_custody_portfolio(
+        origin: T::RuntimeOrigin,
+        portfolio_owner_id: IdentityId,
+        portfolio_name: PortfolioName,
+    ) -> DispatchResult {
+        let callers_did = Identity::<T>::ensure_perms(origin.clone())?;
+        // Ensures that the caller is allowed to create portfolios on `portfolio_owner_id` behalf
+        ensure!(
+            AllowedCustodians::get(&portfolio_owner_id, &callers_did),
+            Error::<T>::MissingOwnersPermission
+        );
+        // Creates a new portfolio
+        let portfolio_number = NextPortfolioNumber::get(&portfolio_owner_id);
+        let portfolio_id = PortfolioId {
+            did: portfolio_owner_id,
+            kind: PortfolioKind::User(portfolio_number),
+        };
+        Self::base_create_portfolio(portfolio_owner_id, portfolio_name)?;
+        // Adds custody authorization to the new portfolio
+        let auth_id = Identity::<T>::add_auth(
+            portfolio_owner_id,
+            Signatory::from(callers_did),
+            AuthorizationData::PortfolioCustody(portfolio_id),
+            None,
+        );
+        // Accepts custody of the portfolio
+        Self::base_accept_portfolio_custody(origin, auth_id)?;
         Ok(())
     }
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -194,4 +194,50 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(3))
             .saturating_add(DbWeight::get().writes(1))
     }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio AllowedCustodians (r:0 w:1)
+    // Proof Skipped: Portfolio AllowedCustodians (max_values: None, max_size: None, mode: Measured)
+    fn allow_identity_to_create_portfolios() -> Weight {
+        // Minimum execution time: 23_275 nanoseconds.
+        Weight::from_ref_time(23_598_000)
+            .saturating_add(DbWeight::get().reads(1))
+            .saturating_add(DbWeight::get().writes(1))
+    }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio AllowedCustodians (r:0 w:1)
+    // Proof Skipped: Portfolio AllowedCustodians (max_values: None, max_size: None, mode: Measured)
+    fn revoke_create_portfolios_permission() -> Weight {
+        // Minimum execution time: 23_458 nanoseconds.
+        Weight::from_ref_time(23_605_000)
+            .saturating_add(DbWeight::get().reads(1))
+            .saturating_add(DbWeight::get().writes(1))
+    }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio AllowedCustodians (r:1 w:0)
+    // Proof Skipped: Portfolio AllowedCustodians (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio NextPortfolioNumber (r:1 w:1)
+    // Proof Skipped: Portfolio NextPortfolioNumber (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio NameToNumber (r:1 w:1)
+    // Proof Skipped: Portfolio NameToNumber (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity MultiPurposeNonce (r:1 w:1)
+    // Proof Skipped: Identity MultiPurposeNonce (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Portfolio PortfolioCustodian (r:1 w:1)
+    // Proof Skipped: Portfolio PortfolioCustodian (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio PortfoliosInCustody (r:0 w:2)
+    // Proof Skipped: Portfolio PortfoliosInCustody (max_values: None, max_size: None, mode: Measured)
+    // Storage: Portfolio Portfolios (r:0 w:1)
+    // Proof Skipped: Portfolio Portfolios (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity AuthorizationsGiven (r:0 w:1)
+    // Proof Skipped: Identity AuthorizationsGiven (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity Authorizations (r:0 w:1)
+    // Proof Skipped: Identity Authorizations (max_values: None, max_size: None, mode: Measured)
+    fn create_custody_portfolio() -> Weight {
+        // Minimum execution time: 111_162 nanoseconds.
+        Weight::from_ref_time(115_980_000)
+            .saturating_add(DbWeight::get().reads(6))
+            .saturating_add(DbWeight::get().writes(9))
+    }
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -222,22 +222,16 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
     // Proof Skipped: Portfolio NextPortfolioNumber (max_values: None, max_size: None, mode: Measured)
     // Storage: Portfolio NameToNumber (r:1 w:1)
     // Proof Skipped: Portfolio NameToNumber (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity MultiPurposeNonce (r:1 w:1)
-    // Proof Skipped: Identity MultiPurposeNonce (max_values: Some(1), max_size: None, mode: Measured)
-    // Storage: Portfolio PortfolioCustodian (r:1 w:1)
+    // Storage: Portfolio PortfolioCustodian (r:0 w:1)
     // Proof Skipped: Portfolio PortfolioCustodian (max_values: None, max_size: None, mode: Measured)
-    // Storage: Portfolio PortfoliosInCustody (r:0 w:2)
+    // Storage: Portfolio PortfoliosInCustody (r:0 w:1)
     // Proof Skipped: Portfolio PortfoliosInCustody (max_values: None, max_size: None, mode: Measured)
     // Storage: Portfolio Portfolios (r:0 w:1)
     // Proof Skipped: Portfolio Portfolios (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity AuthorizationsGiven (r:0 w:1)
-    // Proof Skipped: Identity AuthorizationsGiven (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity Authorizations (r:0 w:1)
-    // Proof Skipped: Identity Authorizations (max_values: None, max_size: None, mode: Measured)
     fn create_custody_portfolio() -> Weight {
-        // Minimum execution time: 111_162 nanoseconds.
-        Weight::from_ref_time(115_980_000)
-            .saturating_add(DbWeight::get().reads(6))
-            .saturating_add(DbWeight::get().writes(9))
+        // Minimum execution time: 59_601 nanoseconds.
+        Weight::from_ref_time(60_400_000)
+            .saturating_add(DbWeight::get().reads(4))
+            .saturating_add(DbWeight::get().writes(5))
     }
 }


### PR DESCRIPTION
Adds extrisincs for allowing a smart contract to create and take custody of user portfolios on behalf of an identity.

## changelog

### new features

- Adds the following extrisincs: `allow_identity_to_create_portfolios`, `revoke_create_portfolios_permission`, `create_custody_portfolio`;

