### PR TITLE
MESH-2115: Adding new events for auto affirms

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -852,7 +852,7 @@ decl_module! {
         /// * Root
         #[weight = <T as Config>::WeightInfo::exempt_ticker_affirmation()]
         pub fn exempt_ticker_affirmation(origin, ticker: Ticker) -> DispatchResult {
-            Self::base_exempt_ticker_affirmation(origin, &ticker)
+            Self::base_exempt_ticker_affirmation(origin, ticker)
         }
 
         /// Removes the pre-approval of the asset for all identities.
@@ -865,7 +865,7 @@ decl_module! {
         /// * Root
         #[weight = <T as Config>::WeightInfo::remove_ticker_affirmation_exemption()]
         pub fn remove_ticker_affirmation_exemption(origin, ticker: Ticker) -> DispatchResult {
-            Self::base_remove_ticker_affirmation_exemption(origin, &ticker)
+            Self::base_remove_ticker_affirmation_exemption(origin, ticker)
         }
 
         /// Pre-approves the receivement of an asset.
@@ -878,7 +878,7 @@ decl_module! {
         /// * Asset
         #[weight = <T as Config>::WeightInfo::pre_approve_ticker()]
         pub fn pre_approve_ticker(origin, ticker: Ticker) -> DispatchResult {
-            Self::base_pre_approve_ticker(origin, &ticker)
+            Self::base_pre_approve_ticker(origin, ticker)
         }
 
         /// Removes the pre approval of an asset.
@@ -891,7 +891,7 @@ decl_module! {
         /// * Asset
         #[weight = <T as Config>::WeightInfo::remove_ticker_pre_approval()]
         pub fn remove_ticker_pre_approval(origin, ticker: Ticker) -> DispatchResult {
-            Self::base_remove_ticker_pre_approval(origin, &ticker)
+            Self::base_remove_ticker_pre_approval(origin, ticker)
         }
     }
 }
@@ -2477,36 +2477,37 @@ impl<T: Config> Module<T> {
     }
 
     /// Pre-approves the receivement of the asset for all identities.
-    fn base_exempt_ticker_affirmation(origin: T::RuntimeOrigin, ticker: &Ticker) -> DispatchResult {
+    fn base_exempt_ticker_affirmation(origin: T::RuntimeOrigin, ticker: Ticker) -> DispatchResult {
         ensure_root(origin)?;
-        TickersExemptFromAffirmation::insert(ticker, true);
+        TickersExemptFromAffirmation::insert(&ticker, true);
+        Self::deposit_event(RawEvent::AssetAffirmationExemption(ticker));
         Ok(())
     }
 
     /// Removes the pre-approval of the asset for all identities.
     fn base_remove_ticker_affirmation_exemption(
         origin: T::RuntimeOrigin,
-        ticker: &Ticker,
+        ticker: Ticker,
     ) -> DispatchResult {
         ensure_root(origin)?;
-        TickersExemptFromAffirmation::remove(ticker);
+        TickersExemptFromAffirmation::remove(&ticker);
+        Self::deposit_event(RawEvent::RemoveAssetAffirmationExemption(ticker));
         Ok(())
     }
 
     /// Pre-approves the receivement of an asset.
-    fn base_pre_approve_ticker(origin: T::RuntimeOrigin, ticker: &Ticker) -> DispatchResult {
+    fn base_pre_approve_ticker(origin: T::RuntimeOrigin, ticker: Ticker) -> DispatchResult {
         let caller_did = Identity::<T>::ensure_perms(origin)?;
-        PreApprovedTicker::insert(&caller_did, ticker, true);
+        PreApprovedTicker::insert(&caller_did, &ticker, true);
+        Self::deposit_event(RawEvent::PreApprovedAsset(caller_did, ticker));
         Ok(())
     }
 
     /// Removes the pre approval of an asset.
-    fn base_remove_ticker_pre_approval(
-        origin: T::RuntimeOrigin,
-        ticker: &Ticker,
-    ) -> DispatchResult {
+    fn base_remove_ticker_pre_approval(origin: T::RuntimeOrigin, ticker: Ticker) -> DispatchResult {
         let caller_did = Identity::<T>::ensure_perms(origin)?;
-        PreApprovedTicker::remove(&caller_did, ticker);
+        PreApprovedTicker::remove(&caller_did, &ticker);
+        Self::deposit_event(RawEvent::RemovePreApprovedAsset(caller_did, ticker));
         Ok(())
     }
 }

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -165,6 +165,18 @@ decl_event! {
             Option<PortfolioId>,
             PortfolioUpdateReason,
         ),
+        /// An asset has been added to the list of pre aprroved receivement (valid for all identities).
+        /// Parameters: [`Ticker`] of the pre approved asset.
+        AssetAffirmationExemption(Ticker),
+        /// An asset has been removed from the list of pre aprroved receivement (valid for all identities).
+        /// Parameters: [`Ticker`] of the asset.
+        RemoveAssetAffirmationExemption(Ticker),
+        /// An identity has added an asset to the list of pre aprroved receivement.
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the pre approved asset.
+        PreApprovedAsset(IdentityId, Ticker),
+        /// An identity has removed an asset to the list of pre aprroved receivement.
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
+        RemovePreApprovedAsset(IdentityId, Ticker),
     }
 }
 

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -165,6 +165,28 @@ decl_event! {
             PortfolioId,
             FundDescription,
             Option<Memo>
+        ),
+        /// A portfolio has pre approved the receivement of an asset.
+        ///
+        /// # Parameters
+        /// * [`IdentityId`] of the caller.
+        /// * [`PortfolioId`] that will receive assets without explicit affirmation.
+        /// * [`Ticker`] of the asset that has been exempt from explicit affirmation.
+        PreApprovedPortfolio(
+            IdentityId,
+            PortfolioId,
+            Ticker
+        ),
+        /// A portfolio has removed the approval of an asset.
+        ///
+        /// # Parameters
+        /// * [`IdentityId`] of the caller.
+        /// * [`PortfolioId`] that had its pre approval revoked.
+        /// * [`Ticker`] of the asset that had its pre approval revoked.
+        RevokePreApprovedPortfolio(
+            IdentityId,
+            PortfolioId,
+            Ticker
         )
     }
 }

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -74,6 +74,9 @@ decl_event!(
         ),
         /// Failed to execute instruction.
         FailedToExecuteInstruction(InstructionId, DispatchError),
+        /// An instruction has been automatically affirmed.
+        /// Parameters: [`IdentityId`] of the caller, [`PortfolioId`] of the receiver, and [`InstructionId`] of the instruction.
+        InstructionAutomaticallyAffirmed(IdentityId, PortfolioId, InstructionId),
     }
 );
 

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -809,6 +809,11 @@ impl<T: Config> Module<T> {
         )?;
 
         PreApprovedPortfolios::insert(&portfolio_id, ticker, true);
+        Self::deposit_event(Event::PreApprovedPortfolio(
+            origin_data.primary_did,
+            portfolio_id,
+            *ticker,
+        ));
         Ok(())
     }
 
@@ -826,6 +831,11 @@ impl<T: Config> Module<T> {
         )?;
 
         PreApprovedPortfolios::remove(&portfolio_id, ticker);
+        Self::deposit_event(Event::RevokePreApprovedPortfolio(
+            origin_data.primary_did,
+            portfolio_id,
+            *ticker,
+        ));
         Ok(())
     }
 

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -829,6 +829,11 @@ impl<T: Config> Module<T> {
         for portfolio_id in instruction_info.portfolios_pre_approved_difference() {
             UserAffirmations::insert(portfolio_id, instruction_id, AffirmationStatus::Affirmed);
             AffirmsReceived::insert(instruction_id, portfolio_id, AffirmationStatus::Affirmed);
+            Self::deposit_event(RawEvent::InstructionAutomaticallyAffirmed(
+                did,
+                *portfolio_id,
+                instruction_id,
+            ));
         }
         InstructionAffirmsPending::insert(
             instruction_id,


### PR DESCRIPTION
Add event for instructions automatically affirmed; 
Add events for exempting/revoking pre-approval of assets or portfolios;

## changelog

### modified API

- Adds the following events: `RemoveAssetAffirmationExemption`, `AssetAffirmationExemption`, `PreApprovedAsset`, `RemovePreApprovedAsset`,  `PreApprovedPortfolio`, `RevokePreApprovedPortfolio`, `InstructionAutomaticallyAffirmed`;
