### PR TITLE
Mesh 2098/store tracker address

### DIFF
--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -578,10 +578,13 @@ benchmarks! {
     chain_extension_get_latest_api_upgrade {
         let r in 0 .. CHAIN_EXTENSION_BATCHES;
 
+        let current_spec_version = T::Version::get().spec_version;
+        let current_tx_version = T::Version::get().transaction_version;
+
         let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
-        let next_upgrade = NextUpgrade::new(ChainVersion::new(6_000_010, 4), api_code_hash.clone());
+        let next_upgrade = NextUpgrade::new(ChainVersion::new(current_spec_version, current_tx_version), api_code_hash.clone());
         let output_len: u32 = api_code_hash.hash.as_ref().len() as u32;
-        let api = Api::new(*b"POLY", 6_000_010);
+        let api = Api::new(*b"POLY", current_spec_version);
 
         Module::<T>::upgrade_api(
             RawOrigin::Root.into(),

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -579,7 +579,7 @@ benchmarks! {
         let r in 0 .. CHAIN_EXTENSION_BATCHES;
 
         let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
-        let next_upgrade = NextUpgrade::new(ChainVersion::new(6_000_010, 6000010), api_code_hash.clone());
+        let next_upgrade = NextUpgrade::new(ChainVersion::new(6_000_010, 4), api_code_hash.clone());
         let output_len: u32 = api_code_hash.hash.as_ref().len() as u32;
         let api = Api::new(*b"POLY", 6_000_010);
 

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -565,22 +565,20 @@ benchmarks! {
     }
 
     upgrade_api {
-        let alice_account_id: T::AccountId = UserBuilder::<T>::default().build("Alice").account();
         let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
         let chain_version = ChainVersion::new(6, 0);
         let api = Api::new(*b"POLY", 6);
-    }: _(RawOrigin::Root, alice_account_id.clone(), api.clone(), chain_version.clone(), api_code_hash.clone())
+    }: _(RawOrigin::Root, api.clone(), chain_version.clone(), api_code_hash.clone())
     verify {
         assert_eq!(
-            SupportedApiUpgrades::<T>::get(&alice_account_id, &api).get(&chain_version).unwrap(),
-            &api_code_hash
+            SupportedApiUpgrades::<T>::get(&api, &chain_version).unwrap(),
+            api_code_hash
         );
     }
 
     chain_extension_get_latest_api_upgrade {
         let r in 0 .. CHAIN_EXTENSION_BATCHES;
 
-        let alice_account_id: T::AccountId = UserBuilder::<T>::default().build("Alice").account();
         let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
         let output_len: u32 = api_code_hash.hash.as_ref().len() as u32;
         let api = Api::new(*b"POLY", 6);
@@ -588,7 +586,6 @@ benchmarks! {
         for i in 0..T::MaxApiUpgrades::get() {
             Module::<T>::upgrade_api(
                 RawOrigin::Root.into(),
-                alice_account_id.clone(),
                 api.clone(),
                 ChainVersion::new(i, 0),
                 api_code_hash.clone(),
@@ -597,9 +594,7 @@ benchmarks! {
 
         let encoded_input = (0..r * CHAIN_EXTENSION_BATCH_SIZE)
             .map(|_| {
-                let mut input = alice_account_id.encode();
-                input.append(&mut api.encode());
-                input
+                api.encode()
             })
             .collect::<Vec<_>>();
         let input_bytes =  encoded_input.iter().flat_map(|a| a.clone()).collect::<Vec<_>>();

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -563,4 +563,17 @@ benchmarks! {
     verify {
         assert_eq!(free_balance::<T>(&addr), ENDOWMENT + 1 as Balance);
     }
+
+    upgrade_api {
+        let alice_account_id: T::AccountId = UserBuilder::<T>::default().build("Alice").account();
+        let api: Api = (*b"POLY", 6);
+        let chain_version = ChainVersion::new(6, 0);
+        let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
+    }: _(RawOrigin::Root, alice_account_id.clone(), api.clone(), chain_version.clone(), api_code_hash.clone())
+    verify {
+        assert_eq!(
+            SupportedApiUpgrades::<T>::get(&alice_account_id, &api).get(&chain_version).unwrap(),
+            &api_code_hash
+        );
+    }
 }

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -595,11 +595,15 @@ benchmarks! {
             ).unwrap();
         }
 
-        let mut input_bytes = Vec::new();
-        for i in 0..r * CHAIN_EXTENSION_BATCH_SIZE {
-            input_bytes.append(&mut alice_account_id.encode());
-            input_bytes.append(&mut api.encode());
-        }
+        let encoded_input = (0..r * CHAIN_EXTENSION_BATCH_SIZE)
+            .map(|_| {
+                let mut input = alice_account_id.encode();
+                input.append(&mut api.encode());
+                input
+            })
+            .collect::<Vec<_>>();
+        let input_bytes =  encoded_input.iter().flat_map(|a| a.clone()).collect::<Vec<_>>();
+
         let contract = Contract::<T>::chain_extension(
             r * CHAIN_EXTENSION_BATCH_SIZE,
             FuncId::GetLatestApiUpgrade,

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -583,7 +583,7 @@ benchmarks! {
         let output_len: u32 = api_code_hash.hash.as_ref().len() as u32;
         let api = Api::new(*b"POLY", 6);
 
-        for i in 0..T::MaxApiUpgrades::get() {
+        for i in 0..r {
             Module::<T>::upgrade_api(
                 RawOrigin::Root.into(),
                 api.clone(),

--- a/pallets/contracts/src/benchmarking.rs
+++ b/pallets/contracts/src/benchmarking.rs
@@ -565,9 +565,11 @@ benchmarks! {
     }
 
     upgrade_api {
+        let current_spec_version = T::Version::get().spec_version;
+        let current_tx_version = T::Version::get().transaction_version;
         let api_code_hash: ApiCodeHash<T> = ApiCodeHash { hash: CodeHash::<T>::default() };
-        let chain_version = ChainVersion::new(7_000_000, 0);
-        let api = Api::new(*b"POLY", 7_000_000);
+        let chain_version = ChainVersion::new(current_spec_version, current_tx_version);
+        let api = Api::new(*b"POLY", current_spec_version);
         let next_upgrade = NextUpgrade::new(chain_version, api_code_hash);
     }: _(RawOrigin::Root, api.clone(), next_upgrade.clone())
     verify {

--- a/pallets/contracts/src/chain_extension.rs
+++ b/pallets/contracts/src/chain_extension.rs
@@ -424,9 +424,8 @@ where
         match next_upgrade {
             Some(next_upgrade) => {
                 if next_upgrade.chain_version <= current_chain_version {
-                    if Some(next_upgrade.api_hash.clone()) != current_api_hash {
-                        CurrentApiHash::<T>::insert(&api, &next_upgrade.api_hash);
-                    }
+                    CurrentApiHash::<T>::insert(&api, &next_upgrade.api_hash);
+                    ApiNextUpgrade::<T>::remove(&api);
                     Some(next_upgrade.api_hash)
                 } else {
                     current_api_hash

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -288,9 +288,6 @@ pub trait Config:
     /// Max value that can be returned from the ChainExtension.
     type MaxOutLen: Get<u32>;
 
-    /// Max number of upgrades allowed.
-    type MaxApiUpgrades: Get<u32>;
-
     /// The weight configuration for the pallet.
     type WeightInfo: WeightInfo;
 }

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -305,7 +305,7 @@ pub trait Config:
     IdentityConfig + BConfig<Currency = Self::Balances> + frame_system::Config
 {
     /// The overarching event type.
-    type RuntimeEvent: From<Event> + Into<<Self as frame_system::Config>::RuntimeEvent>;
+    type RuntimeEvent: From<Event<Self>> + Into<<Self as frame_system::Config>::RuntimeEvent>;
 
     /// Max value that `in_len` can take, that is,
     /// the length of the data sent from a contract when using the ChainExtension.
@@ -319,10 +319,13 @@ pub trait Config:
 }
 
 decl_event! {
-    pub enum Event {
+    pub enum Event<T>
+    where
+        Hash = CodeHash<T>,
+    {
         /// Emitted when a contract starts supporting a new API upgrade
         /// Contains the [`Api`], [`ChainVersion`], and the bytes for the code hash.
-        ApiHashUpdated(Api, ChainVersion, Vec<u8>)
+        ApiHashUpdated(Api, ChainVersion, Hash)
     }
 }
 
@@ -812,10 +815,10 @@ where
 
         ApiNextUpgrade::<T>::insert(&api, &next_upgrade);
 
-        Self::deposit_event(Event::ApiHashUpdated(
+        Self::deposit_event(Event::<T>::ApiHashUpdated(
             api,
             next_upgrade.chain_version,
-            next_upgrade.api_hash.hash.as_ref().to_vec(),
+            next_upgrade.api_hash.hash,
         ));
         Ok(())
     }

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -803,7 +803,7 @@ where
 
         let current_chain_version = ChainVersion::new(
             T::Version::get().spec_version,
-            T::Version::get().spec_version,
+            T::Version::get().transaction_version,
         );
 
         if next_upgrade.chain_version < current_chain_version {

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -98,10 +98,19 @@ impl<T: Config> sp_std::fmt::Debug for ApiCodeHash<T> {
     }
 }
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, Eq, Ord, PartialOrd, PartialEq, TypeInfo)]
 pub struct ChainVersion {
     spec_version: u32,
     tx_version: u32,
+}
+
+impl ChainVersion {
+    pub fn new(spec_version: u32, tx_version: u32) -> Self {
+        ChainVersion {
+            spec_version,
+            tx_version,
+        }
+    }
 }
 
 impl<T: Config> pallet_contracts::PolymeshHooks<T> for ContractPolymeshHooks
@@ -237,6 +246,10 @@ pub trait WeightInfo {
             .saturating_sub(Self::dummy_contract())
             .saturating_sub(Self::basic_runtime_call(in_len))
     }
+
+    fn get_latest_api_upgrade() -> Weight {
+        Weight::zero()
+    }
 }
 
 /// The `Config` trait for the smart contracts pallet.
@@ -285,7 +298,9 @@ decl_error! {
         /// The caller is not a primary key.
         CallerNotAPrimaryKey,
         /// Secondary key permissions are missing.
-        MissingKeyPermissions
+        MissingKeyPermissions,
+        /// There are no api upgrades supported for the contract.
+        NoUpgradesSupported
     }
 }
 

--- a/pallets/contracts/src/lib.rs
+++ b/pallets/contracts/src/lib.rs
@@ -196,6 +196,7 @@ pub trait WeightInfo {
     fn basic_runtime_call(n: u32) -> Weight;
     fn instantiate_with_code_as_primary_key(code_len: u32, salt_len: u32) -> Weight;
     fn instantiate_with_hash_as_primary_key(salt_len: u32) -> Weight;
+    fn upgrade_api() -> Weight;
 
     /// Computes the cost of instantiating where `code_len`
     /// and `salt_len` are specified in kilobytes.
@@ -547,7 +548,7 @@ decl_module! {
             )
         }
 
-        #[weight = 0]
+        #[weight =  <T as Config>::WeightInfo::upgrade_api()]
         pub fn upgrade_api(
             origin,
             contract_id: T::AccountId,

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -327,6 +327,7 @@ macro_rules! misc_pallet_impls {
             type RuntimeEvent = RuntimeEvent;
             type MaxInLen = MaxInLen;
             type MaxOutLen = MaxOutLen;
+            type MaxApiUpgrades = MaxApiUpgrades;
             type WeightInfo = polymesh_weights::polymesh_contracts::SubstrateWeight;
         }
 

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -327,7 +327,6 @@ macro_rules! misc_pallet_impls {
             type RuntimeEvent = RuntimeEvent;
             type MaxInLen = MaxInLen;
             type MaxOutLen = MaxOutLen;
-            type MaxApiUpgrades = MaxApiUpgrades;
             type WeightInfo = polymesh_weights::polymesh_contracts::SubstrateWeight;
         }
 

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -437,7 +437,7 @@ construct_runtime!(
 
         // Contracts
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>} = 46,
-        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event, Config},
+        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event<T>, Config},
 
         // Preimage register.  Used by `pallet_scheduler`.
         Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>},

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -131,6 +131,7 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
+    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -131,7 +131,6 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
-    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -363,7 +363,7 @@ construct_runtime!(
 
         // Contracts
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>} = 46,
-        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event, Config},
+        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event<T>, Config},
 
         // Preimage register.  Used by `pallet_scheduler`.
         Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>},

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -129,6 +129,7 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
+    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -129,7 +129,6 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
-    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -384,7 +384,7 @@ construct_runtime!(
 
         // Contracts
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>} = 46,
-        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event, Config},
+        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event<T>, Config},
 
         // Preimage register.  Used by `pallet_scheduler`.
         Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>},

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -135,7 +135,6 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
-    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -135,6 +135,7 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
+    pub MaxApiUpgrades: u32 = 10;
 
     // NFT:
     pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -229,7 +229,7 @@ fn deploy_as_child_identity() {
 fn upgrade_api_unauthorized_caller() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = User::new(AccountKeyring::Alice);
-        let api = (*b"POLY", 6);
+        let api = Api::new(*b"POLY", 6);
         let chain_version = ChainVersion::new(6, 0);
         let api_code_hash = ApiCodeHash {
             hash: CodeHash::default(),
@@ -252,7 +252,7 @@ fn upgrade_api_unauthorized_caller() {
 fn upgrade_api() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = User::new(AccountKeyring::Alice);
-        let api = (*b"POLY", 6);
+        let api = Api::new(*b"POLY", 6);
         let chain_version = ChainVersion::new(6, 0);
         let api_code_hash = ApiCodeHash {
             hash: CodeHash::default(),
@@ -279,7 +279,7 @@ fn upgrade_api() {
 fn upgrade_api_max_supported_api_exceeded() {
     ExtBuilder::default().build().execute_with(|| {
         let alice_account_id = User::new(AccountKeyring::Alice).acc();
-        let api = (*b"POLY", 6);
+        let api = Api::new(*b"POLY", 6);
         let api_code_hash = ApiCodeHash {
             hash: CodeHash::default(),
         };

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -1,10 +1,9 @@
 use codec::Encode;
 use frame_support::dispatch::{DispatchError, Weight};
 use frame_support::{
-    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, StorageDoubleMap,
-    StorageMap,
+    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, StorageMap,
 };
-use polymesh_contracts::{Api, ApiCodeHash, ChainVersion, SupportedApiUpgrades};
+use polymesh_contracts::{Api, ApiCodeHash, ApiNextUpgrade, ChainVersion, NextUpgrade};
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::Hash;
 
@@ -234,9 +233,10 @@ fn upgrade_api_unauthorized_caller() {
         let api_code_hash = ApiCodeHash {
             hash: CodeHash::default(),
         };
+        let next_upgrade = NextUpgrade::new(chain_version, api_code_hash);
 
         assert_noop!(
-            Contracts::upgrade_api(alice.origin(), api, chain_version, api_code_hash),
+            Contracts::upgrade_api(alice.origin(), api, next_upgrade),
             DispatchError::BadOrigin
         );
     })
@@ -250,17 +250,14 @@ fn upgrade_api() {
         let api_code_hash = ApiCodeHash {
             hash: CodeHash::default(),
         };
+        let next_upgrade = NextUpgrade::new(chain_version, api_code_hash);
 
         assert_ok!(Contracts::upgrade_api(
             root(),
             api.clone(),
-            chain_version.clone(),
-            api_code_hash.clone()
+            next_upgrade.clone()
         ));
 
-        assert_eq!(
-            SupportedApiUpgrades::get(&api, &chain_version).unwrap(),
-            api_code_hash
-        );
+        assert_eq!(ApiNextUpgrade::get(&api).unwrap(), next_upgrade);
     })
 }

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -236,13 +236,7 @@ fn upgrade_api_unauthorized_caller() {
         };
 
         assert_noop!(
-            Contracts::upgrade_api(
-                alice.origin(),
-                alice.acc(),
-                api,
-                chain_version,
-                api_code_hash
-            ),
+            Contracts::upgrade_api(alice.origin(), api, chain_version, api_code_hash),
             DispatchError::BadOrigin
         );
     })
@@ -251,7 +245,6 @@ fn upgrade_api_unauthorized_caller() {
 #[test]
 fn upgrade_api() {
     ExtBuilder::default().build().execute_with(|| {
-        let alice = User::new(AccountKeyring::Alice);
         let api = Api::new(*b"POLY", 6);
         let chain_version = ChainVersion::new(6, 0);
         let api_code_hash = ApiCodeHash {
@@ -260,56 +253,14 @@ fn upgrade_api() {
 
         assert_ok!(Contracts::upgrade_api(
             root(),
-            alice.acc(),
             api.clone(),
             chain_version.clone(),
             api_code_hash.clone()
         ));
 
         assert_eq!(
-            SupportedApiUpgrades::get(&alice.acc(), &api)
-                .get(&chain_version)
-                .unwrap(),
-            &api_code_hash
-        );
-    })
-}
-
-#[test]
-fn upgrade_api_max_supported_api_exceeded() {
-    ExtBuilder::default().build().execute_with(|| {
-        let alice_account_id = User::new(AccountKeyring::Alice).acc();
-        let api = Api::new(*b"POLY", 6);
-        let api_code_hash = ApiCodeHash {
-            hash: CodeHash::default(),
-        };
-
-        for i in 0..<TestStorage as polymesh_contracts::Config>::MaxApiUpgrades::get() {
-            let chain_version = ChainVersion::new(i, 0);
-            assert_ok!(Contracts::upgrade_api(
-                root(),
-                alice_account_id.clone(),
-                api.clone(),
-                chain_version.clone(),
-                api_code_hash.clone()
-            ));
-            assert_eq!(
-                SupportedApiUpgrades::get(&alice_account_id, &api)
-                    .get(&chain_version)
-                    .unwrap(),
-                &api_code_hash
-            );
-        }
-
-        assert_noop!(
-            Contracts::upgrade_api(
-                root(),
-                alice_account_id.clone(),
-                api,
-                ChainVersion::new(100, 0),
-                api_code_hash
-            ),
-            ContractsError::MaxNumberOfApiUpgradesExceeded
+            SupportedApiUpgrades::get(&api, &chain_version).unwrap(),
+            api_code_hash
         );
     })
 }

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -4,7 +4,7 @@ use frame_support::{
     assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, StorageDoubleMap,
     StorageMap,
 };
-use polymesh_contracts::{ApiCodeHash, ChainVersion, SupportedApiUpgrades};
+use polymesh_contracts::{Api, ApiCodeHash, ChainVersion, SupportedApiUpgrades};
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::Hash;
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -326,7 +326,7 @@ frame_support::construct_runtime!(
 
         // Contracts
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>} = 46,
-        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event, Config} = 47,
+        PolymeshContracts: polymesh_contracts::{Pallet, Call, Storage, Event<T>, Config} = 47,
 
         // Preimage register.  Used by `pallet_scheduler`.
         Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 48,

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -489,7 +489,6 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
-    pub MaxApiUpgrades: u32 = 10;
 }
 
 thread_local! {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -489,6 +489,7 @@ parameter_types! {
     pub DeletionQueueDepth: u32 = 1024;
     pub MaxInLen: u32 = 8 * 1024;
     pub MaxOutLen: u32 = 8 * 1024;
+    pub MaxApiUpgrades: u32 = 10;
 }
 
 thread_local! {

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -568,17 +568,17 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
     // Proof Skipped: Identity Claims (max_values: None, max_size: None, mode: Measured)
     // Storage: PolymeshContracts CurrentApiHash (r:1 w:1)
     // Proof Skipped: PolymeshContracts CurrentApiHash (max_values: None, max_size: None, mode: Measured)
-    // Storage: PolymeshContracts ApiNextUpgrade (r:1 w:0)
+    // Storage: PolymeshContracts ApiNextUpgrade (r:1 w:1)
     // Proof Skipped: PolymeshContracts ApiNextUpgrade (max_values: None, max_size: None, mode: Measured)
     // Storage: System EventTopics (r:2 w:2)
     // Proof Skipped: System EventTopics (max_values: None, max_size: None, mode: Measured)
     /// The range of component `r` is `[0, 20]`.
     fn chain_extension_get_latest_api_upgrade(r: u32) -> Weight {
-        // Minimum execution time: 475_244 nanoseconds.
-        Weight::from_ref_time(457_772_776)
-            // Standard Error: 469_206
-            .saturating_add(Weight::from_ref_time(439_654_151).saturating_mul(r.into()))
+        // Minimum execution time: 474_616 nanoseconds.
+        Weight::from_ref_time(526_554_207)
+            // Standard Error: 566_740
+            .saturating_add(Weight::from_ref_time(415_236_821).saturating_mul(r.into()))
             .saturating_add(DbWeight::get().reads(14))
-            .saturating_add(DbWeight::get().writes(4))
+            .saturating_add(DbWeight::get().writes(5))
     }
 }

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -554,7 +554,7 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(2))
             .saturating_add(DbWeight::get().writes(1))
     }
-    fn chain_extension_get_latest_api_upgrade(r: u32) -> Weight {
+    fn chain_extension_get_latest_api_upgrade(_r: u32) -> Weight {
         Weight::zero()
     }
 }

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -548,8 +548,7 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
     // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
     fn upgrade_api() -> Weight {
         // Minimum execution time: 20_304 nanoseconds.
-        Weight::from_ref_time(20_633_000)
-            .saturating_add(DbWeight::get().writes(1))
+        Weight::from_ref_time(20_633_000).saturating_add(DbWeight::get().writes(1))
     }
     // Storage: Identity KeyRecords (r:2 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
@@ -572,7 +571,7 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
     // Storage: System EventTopics (r:2 w:2)
     // Proof Skipped: System EventTopics (max_values: None, max_size: None, mode: Measured)
     /// The range of component `r` is `[0, 20]`.
-    fn chain_extension_get_latest_api_upgrade(r: u32, ) -> Weight {
+    fn chain_extension_get_latest_api_upgrade(r: u32) -> Weight {
         // Minimum execution time: 473_093 nanoseconds.
         Weight::from_ref_time(474_569_000)
             // Standard Error: 48_456_568

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -548,8 +548,7 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
     // Proof Skipped: PolymeshContracts ApiNextUpgrade (max_values: None, max_size: None, mode: Measured)
     fn upgrade_api() -> Weight {
         // Minimum execution time: 31_700 nanoseconds.
-        Weight::from_ref_time(32_030_000)
-            .saturating_add(DbWeight::get().writes(1))
+        Weight::from_ref_time(32_030_000).saturating_add(DbWeight::get().writes(1))
     }
     // Storage: Identity KeyRecords (r:2 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
@@ -567,18 +566,19 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
     // Proof Skipped: Instance2Group ActiveMembers (max_values: Some(1), max_size: None, mode: Measured)
     // Storage: Identity Claims (r:2 w:0)
     // Proof Skipped: Identity Claims (max_values: None, max_size: None, mode: Measured)
-    // Storage: PolymeshContracts SupportedApiUpgrades (r:22 w:0)
-    // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
+    // Storage: PolymeshContracts CurrentApiHash (r:1 w:1)
+    // Proof Skipped: PolymeshContracts CurrentApiHash (max_values: None, max_size: None, mode: Measured)
+    // Storage: PolymeshContracts ApiNextUpgrade (r:1 w:0)
+    // Proof Skipped: PolymeshContracts ApiNextUpgrade (max_values: None, max_size: None, mode: Measured)
     // Storage: System EventTopics (r:2 w:2)
     // Proof Skipped: System EventTopics (max_values: None, max_size: None, mode: Measured)
     /// The range of component `r` is `[0, 20]`.
     fn chain_extension_get_latest_api_upgrade(r: u32) -> Weight {
-        // Minimum execution time: 473_093 nanoseconds.
-        Weight::from_ref_time(474_569_000)
-            // Standard Error: 48_456_568
-            .saturating_add(Weight::from_ref_time(3_902_882_799).saturating_mul(r.into()))
+        // Minimum execution time: 475_244 nanoseconds.
+        Weight::from_ref_time(457_772_776)
+            // Standard Error: 469_206
+            .saturating_add(Weight::from_ref_time(439_654_151).saturating_mul(r.into()))
             .saturating_add(DbWeight::get().reads(14))
-            .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(r.into())))
-            .saturating_add(DbWeight::get().writes(3))
+            .saturating_add(DbWeight::get().writes(4))
     }
 }

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -544,4 +544,14 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(23))
             .saturating_add(DbWeight::get().writes(13))
     }
+    // Storage: PolymeshContracts SupportedApiUpgrades (r:1 w:1)
+    // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    fn upgrade_api() -> Weight {
+        // Minimum execution time: 36_436 nanoseconds.
+        Weight::from_ref_time(37_247_000)
+            .saturating_add(DbWeight::get().reads(2))
+            .saturating_add(DbWeight::get().writes(1))
+    }
 }

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -544,11 +544,12 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(23))
             .saturating_add(DbWeight::get().writes(13))
     }
-    // Storage: PolymeshContracts SupportedApiUpgrades (r:0 w:1)
-    // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
+    // Storage: PolymeshContracts ApiNextUpgrade (r:0 w:1)
+    // Proof Skipped: PolymeshContracts ApiNextUpgrade (max_values: None, max_size: None, mode: Measured)
     fn upgrade_api() -> Weight {
-        // Minimum execution time: 20_304 nanoseconds.
-        Weight::from_ref_time(20_633_000).saturating_add(DbWeight::get().writes(1))
+        // Minimum execution time: 31_700 nanoseconds.
+        Weight::from_ref_time(32_030_000)
+            .saturating_add(DbWeight::get().writes(1))
     }
     // Storage: Identity KeyRecords (r:2 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -554,4 +554,7 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(2))
             .saturating_add(DbWeight::get().writes(1))
     }
+    fn chain_extension_get_latest_api_upgrade(r: u32) -> Weight {
+        Weight::zero()
+    }
 }

--- a/pallets/weights/src/polymesh_contracts.rs
+++ b/pallets/weights/src/polymesh_contracts.rs
@@ -544,17 +544,41 @@ impl polymesh_contracts::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(23))
             .saturating_add(DbWeight::get().writes(13))
     }
-    // Storage: PolymeshContracts SupportedApiUpgrades (r:1 w:1)
+    // Storage: PolymeshContracts SupportedApiUpgrades (r:0 w:1)
     // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity KeyRecords (r:1 w:0)
-    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
     fn upgrade_api() -> Weight {
-        // Minimum execution time: 36_436 nanoseconds.
-        Weight::from_ref_time(37_247_000)
-            .saturating_add(DbWeight::get().reads(2))
+        // Minimum execution time: 20_304 nanoseconds.
+        Weight::from_ref_time(20_633_000)
             .saturating_add(DbWeight::get().writes(1))
     }
-    fn chain_extension_get_latest_api_upgrade(_r: u32) -> Weight {
-        Weight::zero()
+    // Storage: Identity KeyRecords (r:2 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: System Account (r:1 w:0)
+    // Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
+    // Storage: Contracts ContractInfoOf (r:1 w:1)
+    // Proof: Contracts ContractInfoOf (max_values: None, max_size: Some(290), added: 2765, mode: MaxEncodedLen)
+    // Storage: Contracts CodeStorage (r:1 w:0)
+    // Proof: Contracts CodeStorage (max_values: None, max_size: Some(126001), added: 128476, mode: MaxEncodedLen)
+    // Storage: Timestamp Now (r:1 w:0)
+    // Proof: Timestamp Now (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+    // Storage: Identity IsDidFrozen (r:1 w:0)
+    // Proof Skipped: Identity IsDidFrozen (max_values: None, max_size: None, mode: Measured)
+    // Storage: Instance2Group ActiveMembers (r:1 w:0)
+    // Proof Skipped: Instance2Group ActiveMembers (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Identity Claims (r:2 w:0)
+    // Proof Skipped: Identity Claims (max_values: None, max_size: None, mode: Measured)
+    // Storage: PolymeshContracts SupportedApiUpgrades (r:22 w:0)
+    // Proof Skipped: PolymeshContracts SupportedApiUpgrades (max_values: None, max_size: None, mode: Measured)
+    // Storage: System EventTopics (r:2 w:2)
+    // Proof Skipped: System EventTopics (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `r` is `[0, 20]`.
+    fn chain_extension_get_latest_api_upgrade(r: u32, ) -> Weight {
+        // Minimum execution time: 473_093 nanoseconds.
+        Weight::from_ref_time(474_569_000)
+            // Standard Error: 48_456_568
+            .saturating_add(Weight::from_ref_time(3_902_882_799).saturating_mul(r.into()))
+            .saturating_add(DbWeight::get().reads(14))
+            .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(r.into())))
+            .saturating_add(DbWeight::get().writes(3))
     }
 }


### PR DESCRIPTION
Stores api upgrades on `polymesh_contracts` storage.

## changelog

### new features

- Adds the `upgrade_api` extrinsic;
- Adds the `GetLatestApiUpgrade` chain extension call;

### modified API

- Adds the `ApiHashUpdated` event; 
