### PR TITLE
MESH-2101/Add as_derivative extrinsic in the utility pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,6 +5956,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances 0.1.0",
+ "pallet-identity",
  "pallet-permissions",
  "parity-scale-codec 3.5.0",
  "polymesh-common-utilities",

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -6,7 +6,7 @@ use frame_support::dispatch::{
 use frame_support::error::BadOrigin;
 use frame_support::traits::Contains;
 use frame_support::{
-    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, storage, StorageMap
+    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, storage, StorageMap,
 };
 use frame_system::{Call as SystemCall, EventRecord};
 use pallet_timestamp::Call as TimestampCall;
@@ -21,7 +21,7 @@ use pallet_utility::{
 use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
 use polymesh_primitives::{
     AccountId, Balance, PalletPermissions, Permissions, PortfolioName, PortfolioNumber,
-    SubsetRestriction, Ticker
+    SubsetRestriction, Ticker,
 };
 use sp_core::sr25519::Signature;
 use sp_keyring::AccountKeyring;
@@ -1022,12 +1022,19 @@ fn as_derivative() {
         let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
         let alice = User::new(AccountKeyring::Alice).balance(1_000_000);
         let derivative_alice_account = Utility::derivative_account_id(alice.acc(), 1).unwrap();
-        Identity::unsafe_join_identity(alice.did, Permissions::default(), derivative_alice_account.clone());
+        Identity::unsafe_join_identity(
+            alice.did,
+            Permissions::default(),
+            derivative_alice_account.clone(),
+        );
         let derivative_alice_id = Identity::get_identity(&derivative_alice_account).unwrap();
         Balances::transfer(alice.origin(), derivative_alice_account.into(), 1_000_000).unwrap();
 
         let call = RuntimeCall::Asset(pallet_asset::Call::register_ticker { ticker });
         assert_ok!(Utility::as_derivative(alice.origin(), 1, Box::new(call)));
-        assert_eq!(Tickers::<TestStorage>::get(ticker).unwrap().owner, derivative_alice_id);
+        assert_eq!(
+            Tickers::<TestStorage>::get(ticker).unwrap().owner,
+            derivative_alice_id
+        );
     });
 }

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -1,29 +1,17 @@
-use super::storage::example::Call as ExampleCall;
-use super::{
-    assert_event_doesnt_exist, assert_event_exists, assert_last_event,
-    committee_test::set_members,
-    pips_test::{assert_balance, assert_state, committee_proposal, community_proposal},
-    storage::{
-        add_secondary_key, get_secondary_keys, next_block, register_keyring_account_with_balance,
-        EventTest, Identity, Portfolio, RuntimeCall, RuntimeOrigin, System, TestBaseCallFilter,
-        TestStorage, User, Utility,
-    },
-    ExtBuilder,
-};
 use codec::Encode;
+use frame_support::dispatch::{
+    extract_actual_weight, DispatchError, DispatchErrorWithPostInfo, Dispatchable, GetDispatchInfo,
+    Pays, PostDispatchInfo, Weight,
+};
+use frame_support::error::BadOrigin;
+use frame_support::traits::Contains;
 use frame_support::{
-    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop,
-    dispatch::{
-        extract_actual_weight, DispatchError, DispatchErrorWithPostInfo, Dispatchable,
-        GetDispatchInfo, Pays, PostDispatchInfo, Weight,
-    },
-    error::BadOrigin,
-    storage,
-    traits::Contains,
+    assert_err_ignore_postinfo, assert_noop, assert_ok, assert_storage_noop, storage, StorageMap
 };
 use frame_system::{Call as SystemCall, EventRecord};
 use pallet_timestamp::Call as TimestampCall;
 
+use pallet_asset::Tickers;
 use pallet_balances::Call as BalancesCall;
 use pallet_pips::{ProposalState, SnapshotResult};
 use pallet_portfolio::Call as PortfolioCall;
@@ -33,10 +21,20 @@ use pallet_utility::{
 use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
 use polymesh_primitives::{
     AccountId, Balance, PalletPermissions, Permissions, PortfolioName, PortfolioNumber,
-    SubsetRestriction,
+    SubsetRestriction, Ticker
 };
 use sp_core::sr25519::Signature;
 use sp_keyring::AccountKeyring;
+
+use super::committee_test::set_members;
+use super::pips_test::{assert_balance, assert_state, committee_proposal, community_proposal};
+use super::storage::example::Call as ExampleCall;
+use super::storage::{
+    add_secondary_key, get_secondary_keys, next_block, register_keyring_account_with_balance,
+    EventTest, Identity, Portfolio, RuntimeCall, RuntimeOrigin, System, TestBaseCallFilter,
+    TestStorage, User, Utility,
+};
+use super::{assert_event_doesnt_exist, assert_event_exists, assert_last_event, ExtBuilder};
 
 type Error = utility::Error<TestStorage>;
 
@@ -1016,4 +1014,20 @@ fn sub_with_weight_works() {
             frame_support::dispatch::DispatchClass::Operational
         );
     })
+}
+
+#[test]
+fn as_derivative() {
+    new_test_ext().execute_with(|| {
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
+        let alice = User::new(AccountKeyring::Alice).balance(1_000_000);
+        let derivative_alice_account = Utility::derivative_account_id(alice.acc(), 1).unwrap();
+        Identity::unsafe_join_identity(alice.did, Permissions::default(), derivative_alice_account.clone());
+        let derivative_alice_id = Identity::get_identity(&derivative_alice_account).unwrap();
+        Balances::transfer(alice.origin(), derivative_alice_account.into(), 1_000_000).unwrap();
+
+        let call = RuntimeCall::Asset(pallet_asset::Call::register_ticker { ticker });
+        assert_ok!(Utility::as_derivative(alice.origin(), 1, Box::new(call)));
+        assert_eq!(Tickers::<TestStorage>::get(ticker).unwrap().owner, derivative_alice_id);
+    });
 }

--- a/pallets/utility/Cargo.toml
+++ b/pallets/utility/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 pallet-balances = { path = "../balances", default-features = false }
 pallet-permissions = { path = "../permissions", default-features = false }
 polymesh-common-utilities = { path = "../common", default-features = false }
+pallet-identity = { path = "../identity", default-features = false }
 polymesh-primitives = { path = "../../primitives", default-features = false }
 
 # Substrate

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -19,17 +19,16 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use super::*;
 use frame_benchmarking::v1::{account, benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
-
-// POLYMESH:
-use polymesh_common_utilities::{
-    benchs::{AccountIdOf, User, UserBuilder},
-    traits::TestUtilsFn,
-};
 use sp_core::sr25519::Signature;
 use sp_runtime::MultiSignature;
+
+use polymesh_common_utilities::benchs::{user, AccountIdOf, User, UserBuilder};
+use polymesh_common_utilities::traits::TestUtilsFn;
+use polymesh_primitives::Permissions;
+
+use super::*;
 
 // POLYMESH:
 const MAX_CALLS: u32 = 30;
@@ -191,4 +190,15 @@ benchmarks! {
     verify {
         // NB see comment at `batch` verify section.
     }
+
+    // POLYMESH:
+    as_derivative {
+        let parent_user = user::<T>("parent", 0);
+        let child_account = account::<T::AccountId>("child", 0, SEED);
+        Identity::<T>::unsafe_join_identity(parent_user.did(), Permissions::default(), child_account.clone());
+        Identity::<T>::create_child_identity(parent_user.origin().into(), child_account.clone()).unwrap();
+        let child_identity = Identity::<T>::get_identity(&child_account).unwrap();
+
+        let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
+    }: _(parent_user.origin, child_identity, call)
 }

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -193,12 +193,8 @@ benchmarks! {
 
     // POLYMESH:
     as_derivative {
+        let index = 1
         let parent_user = user::<T>("parent", 0);
-        let child_account = account::<T::AccountId>("child", 0, SEED);
-        Identity::<T>::unsafe_join_identity(parent_user.did(), Permissions::default(), child_account.clone());
-        Identity::<T>::create_child_identity(parent_user.origin().into(), child_account.clone()).unwrap();
-        let child_identity = Identity::<T>::get_identity(&child_account).unwrap();
-
         let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
-    }: _(parent_user.origin, child_identity, call)
+    }: _(parent_user.origin, index, call)
 }

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -26,7 +26,6 @@ use sp_runtime::MultiSignature;
 
 use polymesh_common_utilities::benchs::{user, AccountIdOf, User, UserBuilder};
 use polymesh_common_utilities::traits::TestUtilsFn;
-use polymesh_primitives::Permissions;
 
 use super::*;
 

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -193,8 +193,8 @@ benchmarks! {
 
     // POLYMESH:
     as_derivative {
-        let index = 1
-        let parent_user = user::<T>("parent", 0);
+        let index = 1;
+        let alice = user::<T>("Alice", 0);
         let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
-    }: _(parent_user.origin, index, call)
+    }: _(alice.origin, index, call)
 }

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -988,11 +988,13 @@ impl<T: Config> Pallet<T> {
         Context::set_current_payer::<Identity<T>>(account_id);
         // dispatch the call
         let call_result = {
-            if bypass_filter {
-                call.dispatch_bypass_filter(origin)
-            } else {
-                call.dispatch(origin)
-            }
+            with_call_metadata(call.get_call_metadata(), || {
+                if bypass_filter {
+                    call.dispatch_bypass_filter(origin)
+                } else {
+                    call.dispatch(origin)
+                }
+            })
         };
         // Restore the original payer and identity
         Context::set_current_payer::<Identity<T>>(original_payer);

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -966,7 +966,7 @@ impl<T: Config> Pallet<T> {
         origin_account_id: T::AccountId,
         index: u16,
     ) -> Result<T::AccountId, DispatchError> {
-        let entropy = (origin_account_id, index).using_encoded(blake2_256);
+        let entropy = (b"modlpy/utilisuba", origin_account_id, index).using_encoded(blake2_256);
         Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
             .map_err(|_| Error::<T>::UnableToDeriveAccountId.into())
     }

--- a/pallets/weights/src/pallet_utility.rs
+++ b/pallets/weights/src/pallet_utility.rs
@@ -79,9 +79,17 @@ impl pallet_utility::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(2))
             .saturating_add(DbWeight::get().writes(2))
     }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity CurrentPayer (r:1 w:1)
+    // Proof Skipped: Identity CurrentPayer (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Identity CurrentDid (r:1 w:1)
+    // Proof Skipped: Identity CurrentDid (max_values: Some(1), max_size: None, mode: Measured)
     fn dispatch_as() -> Weight {
-        // Minimum execution time: 16_591 nanoseconds.
-        Weight::from_ref_time(17_633_000)
+        // Minimum execution time: 34_525 nanoseconds.
+        Weight::from_ref_time(35_193_000)
+            .saturating_add(DbWeight::get().reads(3))
+            .saturating_add(DbWeight::get().writes(2))
     }
     // Storage: Permissions CurrentPalletName (r:1 w:1)
     // Proof Skipped: Permissions CurrentPalletName (max_values: Some(1), max_size: None, mode: Measured)
@@ -161,12 +169,14 @@ impl pallet_utility::WeightInfo for SubstrateWeight {
     }
     // Storage: Identity KeyRecords (r:1 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity ParentDid (r:1 w:0)
-    // Proof Skipped: Identity ParentDid (max_values: None, max_size: None, mode: Measured)
-    // Storage: Identity DidRecords (r:1 w:0)
-    // Proof Skipped: Identity DidRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity CurrentPayer (r:1 w:1)
+    // Proof Skipped: Identity CurrentPayer (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Identity CurrentDid (r:1 w:1)
+    // Proof Skipped: Identity CurrentDid (max_values: Some(1), max_size: None, mode: Measured)
     fn as_derivative() -> Weight {
-        // Minimum execution time: 32_727 nanoseconds.
-        Weight::from_ref_time(32_884_000).saturating_add(DbWeight::get().reads(3))
+        // Minimum execution time: 28_913 nanoseconds.
+        Weight::from_ref_time(29_369_000)
+            .saturating_add(DbWeight::get().reads(3))
+            .saturating_add(DbWeight::get().writes(2))
     }
 }

--- a/pallets/weights/src/pallet_utility.rs
+++ b/pallets/weights/src/pallet_utility.rs
@@ -159,4 +159,14 @@ impl pallet_utility::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(2))
             .saturating_add(DbWeight::get().writes(2))
     }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity ParentDid (r:1 w:0)
+    // Proof Skipped: Identity ParentDid (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity DidRecords (r:1 w:0)
+    // Proof Skipped: Identity DidRecords (max_values: None, max_size: None, mode: Measured)
+    fn as_derivative() -> Weight {
+        // Minimum execution time: 32_727 nanoseconds.
+        Weight::from_ref_time(32_884_000).saturating_add(DbWeight::get().reads(3))
+    }
 }


### PR DESCRIPTION

## changelog

### new features

- Add `as_derivative` in the utility pallet;

### modified logic
- `dispatch_as` temporarily sets current_did and current_payer to the identity and account from `as_origin`.
