### PR TITLE
Move funds additional write

### DIFF
--- a/pallets/common/src/traits/nft.rs
+++ b/pallets/common/src/traits/nft.rs
@@ -11,7 +11,7 @@ use frame_support::weights::Weight;
 use polymesh_primitives::asset_metadata::AssetMetadataKey;
 use polymesh_primitives::nft::{NFTCollectionId, NFTs};
 use polymesh_primitives::ticker::Ticker;
-use polymesh_primitives::{IdentityId, PortfolioId, PortfolioUpdateReason};
+use polymesh_primitives::{IdentityId, NFTId, PortfolioId, PortfolioUpdateReason};
 
 use crate::compliance_manager::ComplianceFnConfig;
 use crate::{asset, base, identity, portfolio};
@@ -58,6 +58,8 @@ pub trait WeightInfo {
 pub trait NFTTrait<Origin> {
     /// Returns `true` if the given `metadata_key` is a mandatory key for the ticker's NFT collection.
     fn is_collection_key(ticker: &Ticker, metadata_key: &AssetMetadataKey) -> bool;
+    /// Updates the NFTOwner storage after moving funds.
+    fn move_portfolio_owner(ticker: Ticker, nft_id: NFTId, new_owner_portfolio: PortfolioId);
 
     #[cfg(feature = "runtime-benchmarks")]
     fn create_nft_collection(

--- a/pallets/common/src/traits/portfolio.rs
+++ b/pallets/common/src/traits/portfolio.rs
@@ -17,7 +17,7 @@
 //!
 //! The interface allows to accept portfolio custody
 
-use crate::{asset::AssetFnTrait, base, identity, CommonConfig};
+use crate::{asset::AssetFnTrait, base, identity, nft::NFTTrait, CommonConfig};
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::pallet_prelude::Get;
@@ -114,6 +114,8 @@ pub trait Config: CommonConfig + identity::Config + base::Config {
     type MaxNumberOfFungibleMoves: Get<u32>;
     /// Maximum number of NFTs that can be moved in a single transfer call.
     type MaxNumberOfNFTsMoves: Get<u32>;
+    /// NFT module - required for updating the ownership of an NFT.
+    type NFT: NFTTrait<Self::RuntimeOrigin>;
 }
 
 decl_event! {

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -34,7 +34,7 @@ type Portfolio<T> = pallet_portfolio::Module<T>;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
-storage_migration_ver!(1);
+storage_migration_ver!(2);
 
 decl_storage!(
     trait Store for Module<T: Config> as NFT {
@@ -66,7 +66,7 @@ decl_storage!(
         pub NFTOwner get(fn nft_owner): double_map hasher(blake2_128_concat) Ticker, hasher(blake2_128_concat) NFTId => Option<PortfolioId>;
 
         /// Storage version.
-        StorageVersion get(fn storage_version) build(|_| Version::new(1)): Version;
+        StorageVersion get(fn storage_version) build(|_| Version::new(2)): Version;
     }
 );
 
@@ -82,8 +82,8 @@ decl_module! {
         fn deposit_event() = default;
 
         fn on_runtime_upgrade() -> Weight {
-            storage_migrate_on!(StorageVersion, 1, {
-                migration::migrate_to_v1::<T>();
+            storage_migrate_on!(StorageVersion, 2, {
+                migration::migrate_to_v2::<T>();
             });
             Weight::zero()
         }
@@ -621,23 +621,16 @@ impl<T: Config> NFTTrait<T::RuntimeOrigin> for Module<T> {
 
 pub mod migration {
     use crate::sp_api_hidden_includes_decl_storage::hidden_include::IterableStorageDoubleMap;
-    use crate::{Config, NFTOwner, NFTsInCollection, NumberOfNFTs};
-    use frame_support::storage::{StorageDoubleMap, StorageMap};
+    use crate::{Config, NFTOwner};
+    use frame_support::storage::StorageDoubleMap;
     use pallet_portfolio::PortfolioNFT;
     use sp_runtime::runtime_logger::RuntimeLogger;
 
-    pub fn migrate_to_v1<T: Config>() {
+    pub fn migrate_to_v2<T: Config>() {
         RuntimeLogger::init();
-        log::info!(">>> Initializing NFTsInCollection and NFTOwner Storage");
-        initialize_nfts_in_collection::<T>();
+        log::info!(">>> Updating NFTOwner Storage");
         initialize_nft_owner::<T>();
-        log::info!(">>> NFTsInCollection and NFTOwner were successfully updated");
-    }
-
-    fn initialize_nfts_in_collection<T: Config>() {
-        for (ticker, _, id_count) in NumberOfNFTs::iter() {
-            NFTsInCollection::mutate(ticker, |collection_count| *collection_count += id_count);
-        }
+        log::info!(">>> NFTOwner was successfully updated");
     }
 
     fn initialize_nft_owner<T: Config>() {

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -604,6 +604,10 @@ impl<T: Config> NFTTrait<T::RuntimeOrigin> for Module<T> {
         }
     }
 
+    fn move_portfolio_owner(ticker: Ticker, nft_id: NFTId, new_owner_portfolio: PortfolioId) {
+        NFTOwner::insert(ticker, nft_id, new_owner_portfolio);
+    }
+
     #[cfg(feature = "runtime-benchmarks")]
     fn create_nft_collection(
         origin: T::RuntimeOrigin,

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -56,6 +56,7 @@ use sp_std::prelude::*;
 use pallet_identity::PermissionedCallOriginData;
 pub use polymesh_common_utilities::portfolio::{Config, Event, WeightInfo};
 use polymesh_common_utilities::traits::asset::AssetFnTrait;
+use polymesh_common_utilities::traits::nft::NFTTrait;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
 use polymesh_primitives::{
     extract_auth, identity_id::PortfolioValidityResult, storage_migration_ver, Balance, Fund,
@@ -782,6 +783,7 @@ impl<T: Config> Module<T> {
                     for nft_id in nfts.ids() {
                         PortfolioNFT::remove(&sender_portfolio, (nfts.ticker(), nft_id));
                         PortfolioNFT::insert(&receiver_portfolio, (nfts.ticker(), nft_id), true);
+                        T::NFT::move_portfolio_owner(*nfts.ticker(), *nft_id, receiver_portfolio);
                     }
                     Self::deposit_event(Event::FundsMovedBetweenPortfolios(
                         origin_did,

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -295,6 +295,7 @@ macro_rules! misc_pallet_impls {
             type WeightInfo = polymesh_weights::pallet_portfolio::SubstrateWeight;
             type MaxNumberOfFungibleMoves = MaxNumberOfFungibleMoves;
             type MaxNumberOfNFTsMoves = MaxNumberOfNFTsMoves;
+            type NFT = pallet_nft::Module<Runtime>;
         }
 
         impl pallet_external_agents::Config for Runtime {

--- a/pallets/runtime/tests/src/portfolio.rs
+++ b/pallets/runtime/tests/src/portfolio.rs
@@ -1,6 +1,7 @@
 use frame_support::storage::StorageDoubleMap;
 use frame_support::{assert_noop, assert_ok, StorageMap};
 
+use pallet_nft::NFTOwner;
 use pallet_portfolio::{
     AllowedCustodians, Event, NameToNumber, PortfolioAssetBalances, PortfolioCustodian,
     PortfolioNFT, Portfolios, PreApprovedPortfolios,
@@ -818,6 +819,14 @@ fn move_portfolio_nfts() {
         assert_eq!(
             PortfolioNFT::get(alice_custom_portfolio, (TICKER, NFTId(2))),
             true
+        );
+        assert_eq!(
+            NFTOwner::get(TICKER, NFTId(1)),
+            Some(alice_custom_portfolio)
+        );
+        assert_eq!(
+            NFTOwner::get(TICKER, NFTId(2)),
+            Some(alice_custom_portfolio)
         );
     });
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -150,6 +150,8 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
     // Proof Skipped: Portfolio PortfolioLockedAssets (max_values: None, max_size: None, mode: Measured)
     // Storage: Portfolio PortfolioAssetCount (r:1 w:1)
     // Proof Skipped: Portfolio PortfolioAssetCount (max_values: None, max_size: None, mode: Measured)
+    // Storage: NFT NFTOwner (r:0 w:100)
+    // Proof Skipped: NFT NFTOwner (max_values: None, max_size: None, mode: Measured)
     /// The range of component `f` is `[1, 10]`.
     /// The range of component `n` is `[1, 100]`.
     fn move_portfolio_funds(f: u32, n: u32) -> Weight {
@@ -164,7 +166,7 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads((2_u64).saturating_mul(n.into())))
             .saturating_add(DbWeight::get().writes(1))
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(f.into())))
-            .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
     }
     // Storage: Identity KeyRecords (r:1 w:0)
     // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)


### PR DESCRIPTION
Add write to `NFTOwner` storage when moving funds between portfolios.

## changelog

### data migration

- Updates the `NFTOwner` storage;
