### PR TITLE
Update inflation

### DIFF
--- a/pallets/staking/src/inflation.rs
+++ b/pallets/staking/src/inflation.rs
@@ -44,18 +44,20 @@ where
     const MILLISECONDS_PER_YEAR: u64 = 1000 * 3600 * 24 * 36525 / 100;
 
     let portion = Perbill::from_rational(era_duration as u64, MILLISECONDS_PER_YEAR);
-    // Have fixed rewards kicked in?
-    if total_tokens >= max_inflated_issuance {
-        let payout = portion * non_inflated_yearly_reward;
-        // payout is always maximum.
-        return (payout.clone(), payout);
-    }
 
     let payout = portion * yearly_inflation.calculate_for_fraction_times_denominator(
         npos_token_staked,
         total_tokens.clone(),
     );
-    let maximum = portion * (yearly_inflation.maximum * total_tokens);
+    let maximum = portion * (yearly_inflation.maximum * total_tokens.clone());
+    // Have fixed rewards kicked in?
+    if total_tokens >= max_inflated_issuance {
+        let fixed_payout = portion * non_inflated_yearly_reward;
+        if fixed_payout <= payout {
+            // payout is always maximum.
+            return (fixed_payout.clone(), fixed_payout);
+        }
+    }
     (payout, maximum)
 }
 
@@ -143,6 +145,8 @@ mod test {
             57_038_500_000_000_000_000_000
         );
 
+        // Even though the total issuance is above `max_inflated_issuance` we still have
+        // inflation calculated via the curve as this is below the non_inflated_yearly_reward
         assert_eq!(
             super::compute_total_payout(
                 &I_NPOS,
@@ -152,7 +156,24 @@ mod test {
                 1_000_000_000_000_000u128,
                 Perbill::from_percent(5) * 1_000_000_000_000_000u128
             ),
-            (34223100000, 34223100000)
+            (18387768858, 73551075022)
         );
+
+        // Since the staking ratio is high enough, the curve calculated inflation is
+        // above the fixed `non_inflated_yearly_reward` hence we use the latter
+        // i.e. expected response is 5% of 1 billion rather than 10% of 1.5 billion.
+        assert_eq!(
+            super::compute_total_payout(
+                &I_NPOS,
+                750_000_000_000_000u128, //50% staking ratio
+                1_500_000_000_000_000u128,
+                YEAR,
+                1_000_000_000_000_000u128,
+                Perbill::from_percent(5) * 1_000_000_000_000_000u128
+            ),
+            (49_965_776_850_000, 49_965_776_850_000)
+        );
+
+
     }
 }

--- a/pallets/staking/src/inflation.rs
+++ b/pallets/staking/src/inflation.rs
@@ -49,7 +49,6 @@ where
         npos_token_staked,
         total_tokens.clone(),
     );
-    let maximum = portion * (yearly_inflation.maximum * total_tokens.clone());
     // Have fixed rewards kicked in?
     if total_tokens >= max_inflated_issuance {
         let fixed_payout = portion * non_inflated_yearly_reward;
@@ -58,6 +57,7 @@ where
             return (fixed_payout.clone(), fixed_payout);
         }
     }
+    let maximum = portion * (yearly_inflation.maximum * total_tokens);
     (payout, maximum)
 }
 


### PR DESCRIPTION
Updates token inflation behaviour when POLYX total supply is greater than 1 billion.

# Previous behaviour

When the total supply exceeds 1 billion, a fixed amount of 140 million POLYX will be minted annually for validators / nominators.

# New behaviour

When the total supply exceeds 1 billion, and the reward curve based annual inflation (calculated based on the reward curve, staking ratio and total supply) exceeds 140 million, a fixed inflation of 140 million will be used instead.

# Rationale for change

Without this change, as soon as the total supply exceeds 1 billion, there will be a jump in the inflation rate (and corresponding interest rate for nominators) due to moving to a fixed inflation amount of 140 million annually.

Instead of this behaviour we would rather see a smooth transition, continuing to use the reward curve based mechanism until that mechanism would result in inflation greater than 140 million annually, at which point we revert to the previous logic, capping the annual inflation at 140 million.

In other words, the 140 million annual inflation becomes a cap on annual inflation, rather than a fixed value, once the total supply reaches 1 billion POLYX.

## changelog

### new features

Update token inflation to ensure a smooth continuous change as the total supply crosses 1 billion. Annual inflation remains capped at 140 million after the total supply is greater than 1 billion, but can be lower if the staking ratio and curve details calculate a lower rate.