### PR TITLE
Mesh 2104/add mediator

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -653,4 +653,48 @@ benchmarks! {
         let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
         Module::<T>::pre_approve_ticker(alice.clone().origin().into(), ticker).unwrap();
     }: _(alice.origin, ticker)
+
+    add_mandatory_mediators {
+        let n in 1 .. T::MaxAssetMediators::get() as u32;
+
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
+        let mediators: BTreeSet<IdentityId> = (0..n).map(|i| IdentityId::from(i as u128)).collect();
+
+        Module::<T>::create_asset(
+            alice.clone().origin().into(),
+            ticker.as_ref().into(),
+            ticker,
+            false,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new(),
+            None,
+        ).unwrap();
+
+    }: _(alice.origin, ticker, mediators.try_into().unwrap())
+
+    remove_mediators {
+        let n in 1 .. T::MaxAssetMediators::get() as u32;
+
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
+        let mediators: BTreeSet<IdentityId> = (0..n).map(|i| IdentityId::from(i as u128)).collect();
+
+        Module::<T>::create_asset(
+            alice.clone().origin().into(),
+            ticker.as_ref().into(),
+            ticker,
+            false,
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new(),
+            None,
+        ).unwrap();
+
+        Module::<T>::add_mandatory_mediators(
+            alice.clone().origin().into(),
+            ticker,
+            mediators.clone().try_into().unwrap()
+        ).unwrap();
+    }: _(alice.origin, ticker, mediators.try_into().unwrap())
+
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -91,6 +91,7 @@ use core::result::Result as StdResult;
 use currency::*;
 use frame_support::dispatch::{DispatchError, DispatchResult, Weight};
 use frame_support::traits::{Get, PalletInfoAccess};
+use frame_support::BoundedBTreeSet;
 use frame_support::{decl_error, decl_module, decl_storage, ensure, fail};
 use frame_system::ensure_root;
 use scale_info::TypeInfo;
@@ -290,6 +291,10 @@ decl_storage! {
         /// All tickers that don't need an affirmation to be received by an identity.
         pub PreApprovedTicker get(fn pre_approved_tickers):
             double_map hasher(identity) IdentityId, hasher(blake2_128_concat) Ticker => bool;
+
+        /// The list of mandatory mediators for every ticker.
+        pub MandatoryMediators get(fn mandatory_mediators):
+            map hasher(blake2_128_concat) Ticker => BoundedBTreeSet<IdentityId, T::MaxAssetMediators>;
 
         /// Storage version.
         StorageVersion get(fn storage_version) build(|_| Version::new(3)): Version;
@@ -893,6 +898,42 @@ decl_module! {
         pub fn remove_ticker_pre_approval(origin, ticker: Ticker) -> DispatchResult {
             Self::base_remove_ticker_pre_approval(origin, ticker)
         }
+
+        /// Sets all identities in the `mediators` set as mandatory mediators for any instruction transfering `ticker`.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `ticker`: The [`Ticker`] of the asset that will require the mediators.
+        /// * `mediators`: A set of [`IdentityId`] of all the mandatory mediators for the given ticker.
+        ///
+        /// # Permissions
+        /// * Asset
+        #[weight = <T as Config>::WeightInfo::add_mandatory_mediators()]
+        pub fn add_mandatory_mediators(
+            origin,
+            ticker: Ticker,
+            mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>
+        ) -> DispatchResult {
+            Self::base_add_mandatory_mediators(origin, ticker, mediators)
+        }
+
+        /// Removes all identities in the `mediators` set from the mandatory mediators list for the given `ticker`.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `ticker`: The [`Ticker`] of the asset that will have mediators removed.
+        /// * `mediators`: A set of [`IdentityId`] of all the mediators that will be removed from the mandatory mediators list.
+        ///
+        /// # Permissions
+        /// * Asset
+        #[weight = <T as Config>::WeightInfo::remove_mediators()]
+        pub fn remove_mediators(
+            origin,
+            ticker: Ticker,
+            mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>
+        ) -> DispatchResult {
+            Self::base_remove_mediators(origin, ticker, mediators)
+        }
     }
 }
 
@@ -972,6 +1013,8 @@ decl_error! {
         AssetMetadataKeyBelongsToNFTCollection,
         /// Attempt to lock a metadata value that is empty.
         AssetMetadataValueIsEmpty,
+        /// Number of asset mediators would exceed the maximum allowed.
+        NumberOfAssetMediatorsExceeded,
     }
 }
 
@@ -2508,6 +2551,44 @@ impl<T: Config> Module<T> {
         let caller_did = Identity::<T>::ensure_perms(origin)?;
         PreApprovedTicker::remove(&caller_did, &ticker);
         Self::deposit_event(RawEvent::RemovePreApprovedAsset(caller_did, ticker));
+        Ok(())
+    }
+
+    /// Sets all identities in the `mediators` set as mandatory mediators for any instruction transfering `ticker`.
+    fn base_add_mandatory_mediators(
+        origin: T::RuntimeOrigin,
+        ticker: Ticker,
+        new_mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>,
+    ) -> DispatchResult {
+        // Verifies if the caller has the correct permissions for this asset
+        <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        // Tries to add all new identities as mandatory mediators for the asset
+        MandatoryMediators::<T>::try_mutate(ticker, |mandatory_mediators| -> DispatchResult {
+            for new_mediator in new_mediators {
+                mandatory_mediators
+                    .try_insert(new_mediator)
+                    .map_err(|_| Error::<T>::NumberOfAssetMediatorsExceeded)?;
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    /// Removes all identities in the `mediators` set from the mandatory mediators list for the given `ticker`.
+    fn base_remove_mediators(
+        origin: T::RuntimeOrigin,
+        ticker: Ticker,
+        mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>,
+    ) -> DispatchResult {
+        // Verifies if the caller has the correct permissions for this asset
+        <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        // Removes the identities from the mandatory mediators list
+        MandatoryMediators::<T>::mutate(ticker, |mandatory_mediators| {
+            for mediator in mediators {
+                mandatory_mediators.remove(&mediator);
+            }
+        });
         Ok(())
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -84,6 +84,9 @@ pub mod checkpoint;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
 
+#[cfg(feature = "runtime-benchmarks")]
+use sp_std::collections::btree_set::BTreeSet;
+
 use arrayvec::ArrayVec;
 use codec::{Decode, Encode};
 use core::mem;
@@ -2658,5 +2661,14 @@ impl<T: Config> AssetFnTrait<T::AccountId, T::RuntimeOrigin> for Module<T> {
             Some(ticker) => Self::register_asset_metadata_local_type(origin, ticker, name, spec),
             None => Self::register_asset_metadata_global_type(origin, name, spec),
         }
+    }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    fn add_mandatory_mediators(
+        origin: T::RuntimeOrigin,
+        ticker: Ticker,
+        mediators: BTreeSet<IdentityId>,
+    ) -> DispatchResult {
+        Self::add_mandatory_mediators(origin, ticker, mediators.try_into().unwrap_or_default())
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2567,15 +2567,19 @@ impl<T: Config> Module<T> {
         let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         // Tries to add all new identities as mandatory mediators for the asset
         MandatoryMediators::<T>::try_mutate(ticker, |mandatory_mediators| -> DispatchResult {
-            for new_mediator in new_mediators {
+            for new_mediator in &new_mediators {
                 mandatory_mediators
-                    .try_insert(new_mediator)
+                    .try_insert(*new_mediator)
                     .map_err(|_| Error::<T>::NumberOfAssetMediatorsExceeded)?;
             }
             Ok(())
         })?;
 
-        Self::deposit_event(RawEvent::AssetMediatorsAdded(caller_did, ticker));
+        Self::deposit_event(RawEvent::AssetMediatorsAdded(
+            caller_did,
+            ticker,
+            new_mediators.into_inner(),
+        ));
         Ok(())
     }
 
@@ -2589,11 +2593,15 @@ impl<T: Config> Module<T> {
         let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         // Removes the identities from the mandatory mediators list
         MandatoryMediators::<T>::mutate(ticker, |mandatory_mediators| {
-            for mediator in mediators {
-                mandatory_mediators.remove(&mediator);
+            for mediator in &mediators {
+                mandatory_mediators.remove(mediator);
             }
         });
-        Self::deposit_event(RawEvent::AssetMediatorsRemoved(caller_did, ticker));
+        Self::deposit_event(RawEvent::AssetMediatorsRemoved(
+            caller_did,
+            ticker,
+            mediators.into_inner(),
+        ));
         Ok(())
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -913,8 +913,8 @@ decl_module! {
             origin,
             ticker: Ticker,
             mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>
-        ) -> DispatchResult {
-            Self::base_add_mandatory_mediators(origin, ticker, mediators)
+        ) {
+            Self::base_add_mandatory_mediators(origin, ticker, mediators)?;
         }
 
         /// Removes all identities in the `mediators` set from the mandatory mediators list for the given `ticker`.
@@ -931,8 +931,8 @@ decl_module! {
             origin,
             ticker: Ticker,
             mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>
-        ) -> DispatchResult {
-            Self::base_remove_mediators(origin, ticker, mediators)
+        ) {
+            Self::base_remove_mediators(origin, ticker, mediators)?;
         }
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -929,13 +929,13 @@ decl_module! {
         ///
         /// # Permissions
         /// * Asset
-        #[weight = <T as Config>::WeightInfo::remove_mediators(mediators.len() as u32)]
-        pub fn remove_mediators(
+        #[weight = <T as Config>::WeightInfo::remove_mandatory_mediators(mediators.len() as u32)]
+        pub fn remove_mandatory_mediators(
             origin,
             ticker: Ticker,
             mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>
         ) {
-            Self::base_remove_mediators(origin, ticker, mediators)?;
+            Self::base_remove_mandatory_mediators(origin, ticker, mediators)?;
         }
     }
 }
@@ -2575,12 +2575,12 @@ impl<T: Config> Module<T> {
             Ok(())
         })?;
 
-        Self::deposit_event(RawEvent::SetAssetMediators(caller_did, ticker));
+        Self::deposit_event(RawEvent::AssetMediatorsAdded(caller_did, ticker));
         Ok(())
     }
 
     /// Removes all identities in the `mediators` set from the mandatory mediators list for the given `ticker`.
-    fn base_remove_mediators(
+    fn base_remove_mandatory_mediators(
         origin: T::RuntimeOrigin,
         ticker: Ticker,
         mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>,

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -911,7 +911,7 @@ decl_module! {
         ///
         /// # Permissions
         /// * Asset
-        #[weight = <T as Config>::WeightInfo::add_mandatory_mediators()]
+        #[weight = <T as Config>::WeightInfo::add_mandatory_mediators(mediators.len() as u32)]
         pub fn add_mandatory_mediators(
             origin,
             ticker: Ticker,
@@ -929,7 +929,7 @@ decl_module! {
         ///
         /// # Permissions
         /// * Asset
-        #[weight = <T as Config>::WeightInfo::remove_mediators()]
+        #[weight = <T as Config>::WeightInfo::remove_mediators(mediators.len() as u32)]
         pub fn remove_mediators(
             origin,
             ticker: Ticker,

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2564,7 +2564,7 @@ impl<T: Config> Module<T> {
         new_mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>,
     ) -> DispatchResult {
         // Verifies if the caller has the correct permissions for this asset
-        <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         // Tries to add all new identities as mandatory mediators for the asset
         MandatoryMediators::<T>::try_mutate(ticker, |mandatory_mediators| -> DispatchResult {
             for new_mediator in new_mediators {
@@ -2575,6 +2575,7 @@ impl<T: Config> Module<T> {
             Ok(())
         })?;
 
+        Self::deposit_event(RawEvent::SetAssetMediators(caller_did, ticker));
         Ok(())
     }
 
@@ -2585,13 +2586,14 @@ impl<T: Config> Module<T> {
         mediators: BoundedBTreeSet<IdentityId, T::MaxAssetMediators>,
     ) -> DispatchResult {
         // Verifies if the caller has the correct permissions for this asset
-        <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         // Removes the identities from the mandatory mediators list
         MandatoryMediators::<T>::mutate(ticker, |mandatory_mediators| {
             for mediator in mediators {
                 mandatory_mediators.remove(&mediator);
             }
         });
+        Self::deposit_event(RawEvent::AssetMediatorsRemoved(caller_did, ticker));
         Ok(())
     }
 }

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #[cfg(feature = "runtime-benchmarks")]
 use sp_std::collections::btree_set::BTreeSet;
 

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -13,6 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+
+#[cfg(feature = "runtime-benchmarks")]
+use sp_std::collections::btree_set::BTreeSet;
+
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, Get, UnixTime};
@@ -257,5 +261,12 @@ pub trait AssetFnTrait<Account, Origin> {
         ticker: Option<Ticker>,
         name: AssetMetadataName,
         spec: AssetMetadataSpec,
+    ) -> DispatchResult;
+
+    #[cfg(feature = "runtime-benchmarks")]
+    fn add_mandatory_mediators(
+        origin: Origin,
+        ticker: Ticker,
+        mediators: BTreeSet<IdentityId>,
     ) -> DispatchResult;
 }

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -13,9 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(feature = "runtime-benchmarks")]
-use sp_std::collections::btree_set::BTreeSet;
-
 use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, Get, UnixTime};

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -224,8 +224,8 @@ pub trait WeightInfo {
     fn remove_ticker_affirmation_exemption() -> Weight;
     fn pre_approve_ticker() -> Weight;
     fn remove_ticker_pre_approval() -> Weight;
-    fn add_mandatory_mediators() -> Weight;
-    fn remove_mediators() -> Weight;
+    fn add_mandatory_mediators(n: u32) -> Weight;
+    fn remove_mediators(n: u32) -> Weight;
 }
 
 pub trait AssetFnTrait<Account, Origin> {

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -20,6 +20,7 @@ use frame_support::decl_event;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, Get, UnixTime};
 use frame_support::weights::Weight;
+use sp_std::collections::btree_set::BTreeSet;
 use sp_std::prelude::Vec;
 
 use polymesh_primitives::asset::{AssetName, AssetType, CustomAssetTypeId, FundingRoundName};
@@ -185,11 +186,11 @@ decl_event! {
         /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
         RemovePreApprovedAsset(IdentityId, Ticker),
         /// An identity has added mandatory mediators to an asset.
-        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
-        AssetMediatorsAdded(IdentityId, Ticker),
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset, the identity of all mediators added.
+        AssetMediatorsAdded(IdentityId, Ticker, BTreeSet<IdentityId>),
         /// An identity has removed mediators from an asset.
-        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
-        AssetMediatorsRemoved(IdentityId, Ticker)
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset, the identity of all mediators removed.
+        AssetMediatorsRemoved(IdentityId, Ticker, BTreeSet<IdentityId>)
     }
 }
 

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -186,7 +186,7 @@ decl_event! {
         RemovePreApprovedAsset(IdentityId, Ticker),
         /// An identity has added mandatory mediators to an asset.
         /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
-        SetAssetMediators(IdentityId, Ticker),
+        AssetMediatorsAdded(IdentityId, Ticker),
         /// An identity has removed mediators from an asset.
         /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
         AssetMediatorsRemoved(IdentityId, Ticker)
@@ -225,7 +225,7 @@ pub trait WeightInfo {
     fn pre_approve_ticker() -> Weight;
     fn remove_ticker_pre_approval() -> Weight;
     fn add_mandatory_mediators(n: u32) -> Weight;
-    fn remove_mediators(n: u32) -> Weight;
+    fn remove_mandatory_mediators(n: u32) -> Weight;
 }
 
 pub trait AssetFnTrait<Account, Origin> {

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -70,9 +70,13 @@ pub trait Config:
     type AssetFn: AssetFnTrait<Self::AccountId, Self::RuntimeOrigin>;
 
     type WeightInfo: WeightInfo;
+
     type CPWeightInfo: crate::traits::checkpoint::WeightInfo;
 
     type NFTFn: NFTTrait<Self::RuntimeOrigin>;
+
+    /// Maximum number of mediators for an asset.
+    type MaxAssetMediators: Get<u32>;
 }
 
 decl_event! {
@@ -211,6 +215,8 @@ pub trait WeightInfo {
     fn remove_ticker_affirmation_exemption() -> Weight;
     fn pre_approve_ticker() -> Weight;
     fn remove_ticker_pre_approval() -> Weight;
+    fn add_mandatory_mediators() -> Weight;
+    fn remove_mediators() -> Weight;
 }
 
 pub trait AssetFnTrait<Account, Origin> {

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -184,6 +184,12 @@ decl_event! {
         /// An identity has removed an asset to the list of pre aprroved receivement.
         /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
         RemovePreApprovedAsset(IdentityId, Ticker),
+        /// An identity has added mandatory mediators to an asset.
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
+        SetAssetMediators(IdentityId, Ticker),
+        /// An identity has removed mediators from an asset.
+        /// Parameters: [`IdentityId`] of caller, [`Ticker`] of the asset.
+        AssetMediatorsRemoved(IdentityId, Ticker)
     }
 }
 

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -101,6 +101,9 @@ pub trait WeightInfo {
     fn affirm_with_receipts_rcv(f: u32, n: u32, o: u32) -> Weight;
     fn affirm_instruction_rcv(f: u32, n: u32) -> Weight;
     fn withdraw_affirmation_rcv(f: u32, n: u32, o: u32) -> Weight;
+    fn add_instruction_with_mediators() -> Weight;
+    fn affirm_instruction_as_mediator() -> Weight;
+    fn remove_affirmation_as_mediator() -> Weight;
 
     fn add_instruction_legs(legs: &[Leg]) -> Weight {
         let (f, n, o) = Self::get_transfer_by_asset(legs);

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -107,10 +107,19 @@ pub trait WeightInfo {
     fn affirm_with_receipts_rcv(f: u32, n: u32, o: u32) -> Weight;
     fn affirm_instruction_rcv(f: u32, n: u32) -> Weight;
     fn withdraw_affirmation_rcv(f: u32, n: u32, o: u32) -> Weight;
-    fn add_instruction_with_mediators() -> Weight;
+    fn add_instruction_with_mediators(f: u32, n: u32, o: u32, m: u32) -> Weight;
+    fn add_and_affirm_with_mediators(f: u32, n: u32, o: u32, m: u32) -> Weight;
     fn affirm_instruction_as_mediator() -> Weight;
-    fn remove_affirmation_as_mediator() -> Weight;
+    fn withdraw_affirmation_as_mediator() -> Weight;
 
+    fn add_and_affirm_with_mediators_legs(legs: &[Leg], n_mediators: u32) -> Weight {
+        let (f, n, o) = Self::get_transfer_by_asset(legs);
+        Self::add_and_affirm_with_mediators(f, n, o, n_mediators)
+    }
+    fn add_instruction_with_mediators_legs(legs: &[Leg], n_mediators: u32) -> Weight {
+        let (f, n, o) = Self::get_transfer_by_asset(legs);
+        Self::add_instruction_with_mediators(f, n, o, n_mediators)
+    }
     fn add_instruction_legs(legs: &[Leg]) -> Weight {
         let (f, n, o) = Self::get_transfer_by_asset(legs);
         Self::add_instruction(f, n, o)

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -82,7 +82,7 @@ decl_event!(
         MediatorAffirmationReceived(IdentityId, InstructionId),
         /// An instruction affirmation has been withdrawn by a mediator.
         /// Parameters: [`IdentityId`] of the mediator and [`InstructionId`] of the instruction.
-        MediatorAffirmationWithdrawn(IdentityId, InstructionId)
+        MediatorAffirmationWithdrawn(IdentityId, InstructionId),
     }
 );
 

--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -77,6 +77,12 @@ decl_event!(
         /// An instruction has been automatically affirmed.
         /// Parameters: [`IdentityId`] of the caller, [`PortfolioId`] of the receiver, and [`InstructionId`] of the instruction.
         InstructionAutomaticallyAffirmed(IdentityId, PortfolioId, InstructionId),
+        /// An instruction has affirmed by a mediator.
+        /// Parameters: [`IdentityId`] of the mediator and [`InstructionId`] of the instruction.
+        MediatorAffirmationReceived(IdentityId, InstructionId),
+        /// An instruction affirmation has been withdrawn by a mediator.
+        /// Parameters: [`IdentityId`] of the mediator and [`InstructionId`] of the instruction.
+        MediatorAffirmationWithdrawn(IdentityId, InstructionId)
     }
 );
 

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -91,8 +91,8 @@ pub fn setup_nft_transfer<T>(
     sender_portfolio_name: Option<&str>,
     receiver_portolfio_name: Option<&str>,
     pause_compliance: bool,
-    mediators: u8,
-) -> (PortfolioId, PortfolioId)
+    n_mediators: u8,
+) -> (PortfolioId, PortfolioId, Vec<User<T>>)
 where
     T: Config + TestUtilsFn<AccountIdOf<T>>,
 {
@@ -111,17 +111,25 @@ where
     );
 
     // Sets mandatory mediators
-    if mediators > 0 {
-        let mediators: BTreeSet<IdentityId> = (0..mediators)
-            .map(|i| IdentityId::from((i + 200) as u128))
+    let mut asset_mediators = Vec::new();
+    if n_mediators > 0 {
+        let mediators_identity: BTreeSet<IdentityId> = (0..n_mediators)
+            .map(|i| {
+                let mediator = UserBuilder::<T>::default()
+                    .generate_did()
+                    .build(&format!("Mediator{:?}{}", ticker, i));
+                asset_mediators.push(mediator.clone());
+                mediator.did()
+            })
             .collect();
-        T::AssetFn::add_mandatory_mediators(sender.origin().into(), ticker, mediators).unwrap();
+        T::AssetFn::add_mandatory_mediators(sender.origin().into(), ticker, mediators_identity)
+            .unwrap();
     }
 
     // Adds the maximum number of compliance requirement
     T::Compliance::setup_ticker_compliance(sender.did(), ticker, 50, pause_compliance);
 
-    (sender_portfolio, receiver_portfolio)
+    (sender_portfolio, receiver_portfolio, asset_mediators)
 }
 
 benchmarks! {
@@ -209,7 +217,7 @@ benchmarks! {
         let nft_type: Option<NonFungibleType> = Some(NonFungibleType::Derivative);
         let mut weight_meter = WeightMeter::max_limit_no_minimum();
 
-        let (sender_portfolio, receiver_portfolio) =
+        let (sender_portfolio, receiver_portfolio, _) =
             setup_nft_transfer::<T>(&alice, &bob, ticker, n, None, None, true, 0);
         let nfts = NFTs::new_unverified(ticker, (0..n).map(|i| NFTId((i + 1) as u64)).collect());
     }: {
@@ -235,7 +243,7 @@ benchmarks! {
         let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER".as_ref());
         let mut weight_meter = WeightMeter::max_limit_no_minimum();
 
-        let (alice_user_portfolio, bob_user_portfolio) =
+        let (alice_user_portfolio, bob_user_portfolio, _) =
             setup_nft_transfer::<T>(&alice, &bob, ticker, n, None, None, true, 0);
         let nfts = NFTs::new_unverified(ticker, (0..n).map(|i| NFTId((i + 1) as u64)).collect());
         with_transaction(|| {

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -91,7 +91,7 @@ pub fn setup_nft_transfer<T>(
     sender_portfolio_name: Option<&str>,
     receiver_portolfio_name: Option<&str>,
     pause_compliance: bool,
-    mediators: u8
+    mediators: u8,
 ) -> (PortfolioId, PortfolioId)
 where
     T: Config + TestUtilsFn<AccountIdOf<T>>,
@@ -115,12 +115,7 @@ where
         let mediators: BTreeSet<IdentityId> = (0..mediators)
             .map(|i| IdentityId::from((i + 200) as u128))
             .collect();
-        T::AssetFn::add_mandatory_mediators(
-            sender.origin().into(),
-            ticker,
-            mediators,
-        )
-        .unwrap();
+        T::AssetFn::add_mandatory_mediators(sender.origin().into(), ticker, mediators).unwrap();
     }
 
     // Adds the maximum number of compliance requirement

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -322,6 +322,7 @@ macro_rules! misc_pallet_impls {
             type WeightInfo = polymesh_weights::pallet_asset::SubstrateWeight;
             type CPWeightInfo = polymesh_weights::pallet_checkpoint::SubstrateWeight;
             type NFTFn = pallet_nft::Module<Runtime>;
+            type MaxAssetMediators = MaxAssetMediators;
         }
 
         impl polymesh_contracts::Config for Runtime {
@@ -482,6 +483,7 @@ macro_rules! misc_pallet_impls {
             type MaxNumberOfNFTs = MaxNumberOfNFTs;
             type MaxNumberOfOffChainAssets = MaxNumberOfOffChainAssets;
             type MaxNumberOfVenueSigners = MaxNumberOfVenueSigners;
+            type MaxInstructionMediators = MaxInstructionMediators;
         }
 
         impl pallet_sto::Config for Runtime {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -90,6 +90,7 @@ parameter_types! {
     pub const MaxNumberOfNFTsPerLeg: u32 = 10;
     pub const MaxNumberOfNFTs: u32 = 100;
     pub const MaxNumberOfVenueSigners: u32 = 50;
+    pub const MaxInstructionMediators: u32 = 4;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -106,6 +107,7 @@ parameter_types! {
     pub const AssetMetadataNameMaxLength: u32 = 256;
     pub const AssetMetadataValueMaxLength: u32 = 8 * 1024;
     pub const AssetMetadataTypeDefMaxLength: u32 = 8 * 1024;
+    pub const MaxAssetMediators: u32 = 4;
 
     // Compliance manager:
     pub const MaxConditionComplexity: u32 = 50;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -88,6 +88,7 @@ parameter_types! {
     pub const MaxNumberOfNFTsPerLeg: u32 = 10;
     pub const MaxNumberOfNFTs: u32 = 100;
     pub const MaxNumberOfVenueSigners: u32 = 50;
+    pub const MaxInstructionMediators: u32 = 4;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -104,6 +105,7 @@ parameter_types! {
     pub const AssetMetadataNameMaxLength: u32 = 256;
     pub const AssetMetadataValueMaxLength: u32 = 8 * 1024;
     pub const AssetMetadataTypeDefMaxLength: u32 = 8 * 1024;
+    pub const MaxAssetMediators: u32 = 4;
 
     // Compliance manager:
     pub const MaxConditionComplexity: u32 = 50;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -94,6 +94,7 @@ parameter_types! {
     pub const MaxNumberOfNFTsPerLeg: u32 = 10;
     pub const MaxNumberOfNFTs: u32 = 100;
     pub const MaxNumberOfVenueSigners: u32 = 50;
+    pub const MaxInstructionMediators: u32 = 4;
 
     // I'm online:
     pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -110,6 +111,7 @@ parameter_types! {
     pub const AssetMetadataNameMaxLength: u32 = 256;
     pub const AssetMetadataValueMaxLength: u32 = 8 * 1024;
     pub const AssetMetadataTypeDefMaxLength: u32 = 8 * 1024;
+    pub const MaxAssetMediators: u32 = 4;
 
     // Compliance manager:
     pub const MaxConditionComplexity: u32 = 50;

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -2647,7 +2647,7 @@ fn unauthorized_remove_mediators() {
             None,
         ));
         assert_noop!(
-            Asset::remove_mediators(bob.origin(), ticker, mediators.try_into().unwrap()),
+            Asset::remove_mandatory_mediators(bob.origin(), ticker, mediators.try_into().unwrap()),
             EAError::UnauthorizedAgent
         );
     });
@@ -2679,7 +2679,7 @@ fn successfully_remove_mediators() {
         ));
 
         let remove_mediators = BTreeSet::from([IdentityId::from(0 as u128)]);
-        assert_ok!(Asset::remove_mediators(
+        assert_ok!(Asset::remove_mandatory_mediators(
             alice.origin(),
             ticker,
             remove_mediators.clone().try_into().unwrap()

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -8,6 +8,7 @@ use rand::Rng;
 use sp_consensus_babe::Slot;
 use sp_io::hashing::keccak_256;
 use sp_runtime::AnySignature;
+use sp_std::collections::btree_set::BTreeSet;
 use sp_std::convert::{From, TryFrom, TryInto};
 use sp_std::iter;
 
@@ -15,7 +16,8 @@ use pallet_asset::{
     AssetDocuments, AssetMetadataLocalKeyToName, AssetMetadataLocalNameToKey,
     AssetMetadataLocalSpecs, AssetMetadataValues, AssetOwnershipRelation, BalanceOf,
     Config as AssetConfig, CustomTypeIdSequence, CustomTypes, CustomTypesInverse,
-    PreApprovedTicker, SecurityToken, TickerRegistrationConfig, TickersExemptFromAffirmation,
+    MandatoryMediators, PreApprovedTicker, SecurityToken, TickerRegistrationConfig,
+    TickersExemptFromAffirmation,
 };
 use pallet_portfolio::{NextPortfolioNumber, PortfolioAssetBalances};
 use polymesh_common_utilities::asset::AssetFnTrait;
@@ -2522,5 +2524,172 @@ fn unauthorized_custodian_ticker_exemption() {
         assert!(!PreApprovedTicker::get(alice.did, ticker));
         assert!(!TickersExemptFromAffirmation::get(ticker));
         assert!(!Asset::skip_ticker_affirmation(&alice.did, &ticker));
+    });
+}
+
+#[test]
+fn unauthorized_add_mandatory_mediators() {
+    ExtBuilder::default().build().execute_with(|| {
+        let ticker: Ticker = ticker("TICKER");
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let max_mediators = <TestStorage as pallet_asset::Config>::MaxAssetMediators::get();
+        let mediators: BTreeSet<IdentityId> = (0..max_mediators)
+            .map(|i| IdentityId::from(i as u128))
+            .collect();
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            ticker.as_ref().into(),
+            ticker,
+            true,
+            AssetType::default(),
+            Vec::new(),
+            None,
+        ));
+        assert_noop!(
+            Asset::add_mandatory_mediators(bob.origin(), ticker, mediators.try_into().unwrap()),
+            EAError::UnauthorizedAgent
+        );
+    });
+}
+
+#[test]
+fn successfully_add_mandatory_mediators() {
+    ExtBuilder::default().build().execute_with(|| {
+        let ticker: Ticker = ticker("TICKER");
+        let alice = User::new(AccountKeyring::Alice);
+        let max_mediators = <TestStorage as pallet_asset::Config>::MaxAssetMediators::get();
+        let mediators: BTreeSet<IdentityId> = (0..max_mediators)
+            .map(|i| IdentityId::from(i as u128))
+            .collect();
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            ticker.as_ref().into(),
+            ticker,
+            true,
+            AssetType::default(),
+            Vec::new(),
+            None,
+        ));
+        assert_ok!(Asset::add_mandatory_mediators(
+            alice.origin(),
+            ticker,
+            mediators.clone().try_into().unwrap()
+        ));
+
+        assert_eq!(
+            MandatoryMediators::<TestStorage>::get(&ticker).len(),
+            mediators.len()
+        );
+        for mediator in mediators {
+            assert!(MandatoryMediators::<TestStorage>::get(&ticker).contains(&mediator));
+        }
+    });
+}
+
+#[test]
+fn add_mandatory_mediators_exceed_limit() {
+    ExtBuilder::default().build().execute_with(|| {
+        let ticker: Ticker = ticker("TICKER");
+        let alice = User::new(AccountKeyring::Alice);
+        let max_mediators = <TestStorage as pallet_asset::Config>::MaxAssetMediators::get();
+        let mediators: BTreeSet<IdentityId> = (0..max_mediators)
+            .map(|i| IdentityId::from(i as u128))
+            .collect();
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            ticker.as_ref().into(),
+            ticker,
+            true,
+            AssetType::default(),
+            Vec::new(),
+            None,
+        ));
+        assert_ok!(Asset::add_mandatory_mediators(
+            alice.origin(),
+            ticker,
+            mediators.clone().try_into().unwrap()
+        ));
+
+        let new_mediator = BTreeSet::from([IdentityId::from(max_mediators as u128)]);
+        assert_noop!(
+            Asset::add_mandatory_mediators(
+                alice.origin(),
+                ticker,
+                new_mediator.try_into().unwrap()
+            ),
+            AssetError::NumberOfAssetMediatorsExceeded
+        );
+    });
+}
+
+#[test]
+fn unauthorized_remove_mediators() {
+    ExtBuilder::default().build().execute_with(|| {
+        let ticker: Ticker = ticker("TICKER");
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let max_mediators = <TestStorage as pallet_asset::Config>::MaxAssetMediators::get();
+        let mediators: BTreeSet<IdentityId> = (0..max_mediators)
+            .map(|i| IdentityId::from(i as u128))
+            .collect();
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            ticker.as_ref().into(),
+            ticker,
+            true,
+            AssetType::default(),
+            Vec::new(),
+            None,
+        ));
+        assert_noop!(
+            Asset::remove_mediators(bob.origin(), ticker, mediators.try_into().unwrap()),
+            EAError::UnauthorizedAgent
+        );
+    });
+}
+
+#[test]
+fn successfully_remove_mediators() {
+    ExtBuilder::default().build().execute_with(|| {
+        let ticker: Ticker = ticker("TICKER");
+        let alice = User::new(AccountKeyring::Alice);
+        let max_mediators = <TestStorage as pallet_asset::Config>::MaxAssetMediators::get();
+        let mediators: BTreeSet<IdentityId> = (0..max_mediators)
+            .map(|i| IdentityId::from(i as u128))
+            .collect();
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            ticker.as_ref().into(),
+            ticker,
+            true,
+            AssetType::default(),
+            Vec::new(),
+            None,
+        ));
+        assert_ok!(Asset::add_mandatory_mediators(
+            alice.origin(),
+            ticker,
+            mediators.clone().try_into().unwrap()
+        ));
+
+        let remove_mediators = BTreeSet::from([IdentityId::from(0 as u128)]);
+        assert_ok!(Asset::remove_mediators(
+            alice.origin(),
+            ticker,
+            remove_mediators.clone().try_into().unwrap()
+        ),);
+        assert_eq!(
+            MandatoryMediators::<TestStorage>::get(&ticker).len(),
+            mediators.len() - remove_mediators.len()
+        );
+        for mediator in remove_mediators {
+            assert!(!MandatoryMediators::<TestStorage>::get(&ticker).contains(&mediator));
+        }
     });
 }

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -17,9 +17,9 @@ use pallet_nft::NumberOfNFTs;
 use pallet_portfolio::{PortfolioLockedNFT, PortfolioNFT};
 use pallet_scheduler as scheduler;
 use pallet_settlement::{
-    AffirmsReceived, InstructionAffirmsPending, InstructionLegs, InstructionMemos,
-    NumberOfVenueSigners, OffChainAffirmations, RawEvent, UserAffirmations, UserVenues,
-    VenueInstructions,
+    AffirmsReceived, InstructionAffirmsPending, InstructionLegs, InstructionMediatorsAffirmations,
+    InstructionMemos, NumberOfVenueSigners, OffChainAffirmations, RawEvent, UserAffirmations,
+    UserVenues, VenueInstructions,
 };
 use polymesh_common_utilities::constants::currency::ONE_UNIT;
 use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
@@ -30,8 +30,8 @@ use polymesh_primitives::asset_metadata::{
 use polymesh_primitives::checked_inc::CheckedInc;
 use polymesh_primitives::settlement::{
     AffirmationCount, AffirmationStatus, AssetCount, Instruction, InstructionId, InstructionStatus,
-    Leg, LegId, LegStatus, Receipt, ReceiptDetails, SettlementType, VenueDetails, VenueId,
-    VenueType,
+    Leg, LegId, LegStatus, MediatorAffirmationStatus, Receipt, ReceiptDetails, SettlementType,
+    VenueDetails, VenueId, VenueType,
 };
 use polymesh_primitives::{
     AccountId, AuthorizationData, Balance, Claim, Condition, ConditionType, Fund, FundDescription,
@@ -3074,6 +3074,8 @@ fn add_instruction_with_offchain_assets() {
             &offchain_legs,
             instruction_memo,
             &legs,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
         );
     });
 }
@@ -3130,6 +3132,8 @@ fn add_instruction_with_pre_affirmed_tickers() {
             &BTreeSet::new(),
             instruction_memo,
             &legs,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
         );
     });
 }
@@ -3198,6 +3202,8 @@ fn add_instruction_with_pre_affirmed_tickers_with_assigned_custodian() {
             &BTreeSet::new(),
             instruction_memo,
             &legs,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
         );
     });
 }
@@ -3260,6 +3266,8 @@ fn add_instruction_with_pre_affirmed_portfolio() {
             &BTreeSet::new(),
             instruction_memo,
             &legs,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
         );
     });
 }
@@ -3317,6 +3325,8 @@ fn add_instruction_with_single_pre_affirmed() {
             &BTreeSet::new(),
             instruction_memo,
             &legs,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
         );
     });
 }
@@ -3614,6 +3624,271 @@ fn reject_instruction_cost() {
     });
 }
 
+#[test]
+fn add_instruction_with_mediators() {
+    ExtBuilder::default().build().execute_with(|| {
+        let bob = User::new(AccountKeyring::Bob);
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
+        let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+        let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+
+        let venue_counter = create_token_and_venue(TICKER, alice);
+
+        let asset_mediator = BTreeSet::from([dave.did]);
+        Asset::add_mandatory_mediators(alice.origin(), TICKER, asset_mediator.try_into().unwrap())
+            .unwrap();
+
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        let instruction_mediators = BTreeSet::from([charlie.did]);
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            instruction_mediators.try_into().unwrap()
+        ));
+
+        let portfolios_pending_approval =
+            BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
+        let mediators_pending_approval = BTreeSet::from([dave.did, charlie.did]);
+        assert_add_instruction_storage(
+            &InstructionId(0),
+            &portfolios_pending_approval,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            None,
+            &legs,
+            &mediators_pending_approval,
+            &BTreeSet::new(),
+        );
+    });
+}
+
+#[test]
+fn affirm_as_mediator_invalid_mediator() {
+    ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder::default().build().execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let dave = User::new(AccountKeyring::Dave);
+            let alice = User::new(AccountKeyring::Alice);
+            let charlie = User::new(AccountKeyring::Charlie);
+
+            let venue_counter = create_token_and_venue(TICKER, alice);
+
+            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+            let legs: Vec<Leg> = vec![Leg::NonFungible {
+                sender: PortfolioId::default_portfolio(alice.did),
+                receiver: PortfolioId::default_portfolio(bob.did),
+                nfts,
+            }];
+            assert_ok!(Settlement::add_instruction_with_mediators(
+                alice.origin(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                legs.clone(),
+                None,
+                BTreeSet::from([charlie.did]).try_into().unwrap()
+            ));
+
+            assert_noop!(
+                Settlement::affirm_instruction_as_mediator(dave.origin(), InstructionId(0), None),
+                Error::CallerIsNotAMediator
+            );
+        });
+    });
+}
+
+#[test]
+fn affirm_as_mediator() {
+    ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder::default().build().execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let alice = User::new(AccountKeyring::Alice);
+            let charlie = User::new(AccountKeyring::Charlie);
+            let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+            let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+
+            let venue_counter = create_token_and_venue(TICKER, alice);
+
+            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+            let legs: Vec<Leg> = vec![Leg::NonFungible {
+                sender: PortfolioId::default_portfolio(alice.did),
+                receiver: PortfolioId::default_portfolio(bob.did),
+                nfts,
+            }];
+            assert_ok!(Settlement::add_instruction_with_mediators(
+                alice.origin(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                legs.clone(),
+                None,
+                BTreeSet::from([charlie.did]).try_into().unwrap()
+            ));
+
+            assert_ok!(Settlement::affirm_instruction_as_mediator(
+                charlie.origin(),
+                InstructionId(0),
+                None
+            ),);
+
+            let portfolios_pending_approval =
+                BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
+            let mediators_affirmed = BTreeSet::from([charlie.did]);
+            assert_add_instruction_storage(
+                &InstructionId(0),
+                &portfolios_pending_approval,
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+                None,
+                &legs,
+                &BTreeSet::new(),
+                &mediators_affirmed,
+            );
+        });
+    });
+}
+
+#[test]
+fn withdraw_as_mediator_invalid_mediator() {
+    ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder::default().build().execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let dave = User::new(AccountKeyring::Dave);
+            let alice = User::new(AccountKeyring::Alice);
+            let charlie = User::new(AccountKeyring::Charlie);
+
+            let venue_counter = create_token_and_venue(TICKER, alice);
+
+            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+            let legs: Vec<Leg> = vec![Leg::NonFungible {
+                sender: PortfolioId::default_portfolio(alice.did),
+                receiver: PortfolioId::default_portfolio(bob.did),
+                nfts,
+            }];
+            assert_ok!(Settlement::add_instruction_with_mediators(
+                alice.origin(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                legs.clone(),
+                None,
+                BTreeSet::from([charlie.did]).try_into().unwrap()
+            ));
+
+            assert_noop!(
+                Settlement::withdraw_affirmation_as_mediator(dave.origin(), InstructionId(0)),
+                Error::CallerIsNotAMediator
+            );
+        });
+    });
+}
+
+#[test]
+fn withdraw_as_mediator_invalid_status() {
+    ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder::default().build().execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let alice = User::new(AccountKeyring::Alice);
+            let charlie = User::new(AccountKeyring::Charlie);
+
+            let venue_counter = create_token_and_venue(TICKER, alice);
+
+            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+            let legs: Vec<Leg> = vec![Leg::NonFungible {
+                sender: PortfolioId::default_portfolio(alice.did),
+                receiver: PortfolioId::default_portfolio(bob.did),
+                nfts,
+            }];
+            assert_ok!(Settlement::add_instruction_with_mediators(
+                alice.origin(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                legs.clone(),
+                None,
+                BTreeSet::from([charlie.did]).try_into().unwrap()
+            ));
+
+            assert_noop!(
+                Settlement::withdraw_affirmation_as_mediator(charlie.origin(), InstructionId(0)),
+                Error::UnexpectedAffirmationStatus
+            );
+        });
+    });
+}
+
+#[test]
+fn withdraw_affirmation_as_mediator() {
+    ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder::default().build().execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let alice = User::new(AccountKeyring::Alice);
+            let charlie = User::new(AccountKeyring::Charlie);
+            let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+            let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+
+            let venue_counter = create_token_and_venue(TICKER, alice);
+
+            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+            let legs: Vec<Leg> = vec![Leg::NonFungible {
+                sender: PortfolioId::default_portfolio(alice.did),
+                receiver: PortfolioId::default_portfolio(bob.did),
+                nfts,
+            }];
+            assert_ok!(Settlement::add_instruction_with_mediators(
+                alice.origin(),
+                venue_counter,
+                SettlementType::SettleOnAffirmation,
+                None,
+                None,
+                legs.clone(),
+                None,
+                BTreeSet::from([charlie.did]).try_into().unwrap()
+            ));
+
+            assert_ok!(Settlement::affirm_instruction_as_mediator(
+                charlie.origin(),
+                InstructionId(0),
+                None
+            ),);
+            assert_ok!(Settlement::withdraw_affirmation_as_mediator(
+                charlie.origin(),
+                InstructionId(0),
+            ),);
+
+            let portfolios_pending_approval =
+                BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
+            let mediators_pending_approval = BTreeSet::from([charlie.did]);
+            assert_add_instruction_storage(
+                &InstructionId(0),
+                &portfolios_pending_approval,
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+                None,
+                &legs,
+                &mediators_pending_approval,
+                &BTreeSet::new(),
+            );
+        });
+    });
+}
+
 /// Asserts the storage has been updated after adding an instruction.
 /// While each portfolio in `portfolios_pending_approval` must have a pending `AffirmationStatus`, each portfolio in `portfolios_pre_approved`
 /// must have an affirmed status. The number of pending affirmations must be equal to the number of portfolios in `portfolios_pending_approval` + the number of offchain legs,
@@ -3625,6 +3900,8 @@ fn assert_add_instruction_storage(
     offchain_legs: &BTreeSet<LegId>,
     instruction_memo: Option<Memo>,
     legs: &[Leg],
+    mediators_pending_approval: &BTreeSet<IdentityId>,
+    mediators_affirmed: &BTreeSet<IdentityId>,
 ) {
     portfolios_pending_approval.iter().for_each(|portfolio_id| {
         assert_eq!(
@@ -3650,7 +3927,9 @@ fn assert_add_instruction_storage(
     });
     assert_eq!(
         InstructionAffirmsPending::get(instruction_id),
-        portfolios_pending_approval.len() as u64 + offchain_legs.len() as u64
+        portfolios_pending_approval.len() as u64
+            + offchain_legs.len() as u64
+            + mediators_pending_approval.len() as u64
     );
 
     assert_eq!(InstructionMemos::get(instruction_id), instruction_memo);
@@ -3660,6 +3939,21 @@ fn assert_add_instruction_storage(
             InstructionLegs::get(instruction_id, LegId(i as u64)),
             Some(legs[i].clone())
         )
+    });
+
+    mediators_pending_approval.iter().for_each(|identity_id| {
+        assert_eq!(
+            InstructionMediatorsAffirmations::<TestStorage>::get(instruction_id, identity_id),
+            MediatorAffirmationStatus::Pending
+        )
+    });
+    mediators_affirmed.iter().for_each(|identity_id| {
+        match InstructionMediatorsAffirmations::<TestStorage>::get(instruction_id, identity_id) {
+            MediatorAffirmationStatus::Pending | MediatorAffirmationStatus::Unknown => {
+                panic!("unexpected mediator affirmation status")
+            }
+            MediatorAffirmationStatus::Affirmed { .. } => {}
+        }
     });
 }
 

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -3677,329 +3677,315 @@ fn add_instruction_with_mediators() {
 #[test]
 fn affirm_as_mediator_invalid_mediator() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let dave = User::new(AccountKeyring::Dave);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
+        let bob = User::new(AccountKeyring::Bob);
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_noop!(
-                Settlement::affirm_instruction_as_mediator(dave.origin(), InstructionId(0), None),
-                Error::CallerIsNotAMediator
-            );
-        });
+        assert_noop!(
+            Settlement::affirm_instruction_as_mediator(dave.origin(), InstructionId(0), None),
+            Error::CallerIsNotAMediator
+        );
     });
 }
 
 #[test]
 fn affirm_as_mediator() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
-            let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
-            let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
+        let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+        let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_ok!(Settlement::affirm_instruction_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-                None
-            ),);
+        assert_ok!(Settlement::affirm_instruction_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+            None
+        ),);
 
-            let portfolios_pending_approval =
-                BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
-            let mediators_affirmed = BTreeSet::from([charlie.did]);
-            assert_add_instruction_storage(
-                &InstructionId(0),
-                &portfolios_pending_approval,
-                &BTreeSet::new(),
-                &BTreeSet::new(),
-                None,
-                &legs,
-                &BTreeSet::new(),
-                &mediators_affirmed,
-            );
-        });
+        let portfolios_pending_approval =
+            BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
+        let mediators_affirmed = BTreeSet::from([charlie.did]);
+        assert_add_instruction_storage(
+            &InstructionId(0),
+            &portfolios_pending_approval,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            None,
+            &legs,
+            &BTreeSet::new(),
+            &mediators_affirmed,
+        );
     });
 }
 
 #[test]
 fn withdraw_as_mediator_invalid_mediator() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let dave = User::new(AccountKeyring::Dave);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
+        let bob = User::new(AccountKeyring::Bob);
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_noop!(
-                Settlement::withdraw_affirmation_as_mediator(dave.origin(), InstructionId(0)),
-                Error::CallerIsNotAMediator
-            );
-        });
+        assert_noop!(
+            Settlement::withdraw_affirmation_as_mediator(dave.origin(), InstructionId(0)),
+            Error::CallerIsNotAMediator
+        );
     });
 }
 
 #[test]
 fn withdraw_as_mediator_invalid_status() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_noop!(
-                Settlement::withdraw_affirmation_as_mediator(charlie.origin(), InstructionId(0)),
-                Error::UnexpectedAffirmationStatus
-            );
-        });
+        assert_noop!(
+            Settlement::withdraw_affirmation_as_mediator(charlie.origin(), InstructionId(0)),
+            Error::UnexpectedAffirmationStatus
+        );
     });
 }
 
 #[test]
 fn withdraw_affirmation_as_mediator() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
-            let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
-            let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
+        let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+        let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_ok!(Settlement::affirm_instruction_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-                None
-            ),);
-            assert_ok!(Settlement::withdraw_affirmation_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-            ),);
+        assert_ok!(Settlement::affirm_instruction_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+            None
+        ),);
+        assert_ok!(Settlement::withdraw_affirmation_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+        ),);
 
-            let portfolios_pending_approval =
-                BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
-            let mediators_pending_approval = BTreeSet::from([charlie.did]);
-            assert_add_instruction_storage(
-                &InstructionId(0),
-                &portfolios_pending_approval,
-                &BTreeSet::new(),
-                &BTreeSet::new(),
-                None,
-                &legs,
-                &mediators_pending_approval,
-                &BTreeSet::new(),
-            );
-        });
+        let portfolios_pending_approval =
+            BTreeSet::from([alice_default_portfolio, bob_default_portfolio]);
+        let mediators_pending_approval = BTreeSet::from([charlie.did]);
+        assert_add_instruction_storage(
+            &InstructionId(0),
+            &portfolios_pending_approval,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            None,
+            &legs,
+            &mediators_pending_approval,
+            &BTreeSet::new(),
+        );
     });
 }
 
 #[test]
 fn expired_affirmation_execution() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
-            let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
-            let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
+        let bob_default_portfolio = PortfolioId::default_portfolio(bob.did);
+        let alice_default_portfolio = PortfolioId::default_portfolio(alice.did);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let legs: Vec<Leg> = vec![Leg::Fungible {
-                sender: alice_default_portfolio,
-                receiver: bob_default_portfolio,
-                ticker: TICKER,
-                amount: 1,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
-            assert_ok!(Settlement::affirm_instruction(
-                alice.origin(),
-                InstructionId(0),
-                vec![alice_default_portfolio]
-            ),);
-            assert_ok!(Settlement::affirm_instruction(
-                bob.origin(),
-                InstructionId(0),
-                vec![bob_default_portfolio]
-            ),);
-            assert_ok!(Settlement::affirm_instruction_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-                Some(Timestamp::get().saturating_add(3))
-            ),);
+        let legs: Vec<Leg> = vec![Leg::Fungible {
+            sender: alice_default_portfolio,
+            receiver: bob_default_portfolio,
+            ticker: TICKER,
+            amount: 1,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
+        assert_ok!(Settlement::affirm_instruction(
+            alice.origin(),
+            InstructionId(0),
+            vec![alice_default_portfolio]
+        ),);
+        assert_ok!(Settlement::affirm_instruction(
+            bob.origin(),
+            InstructionId(0),
+            vec![bob_default_portfolio]
+        ),);
+        assert_ok!(Settlement::affirm_instruction_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+            Some(Timestamp::get().saturating_add(3))
+        ),);
 
-            next_block();
-            assert_instruction_status(InstructionId(0), InstructionStatus::Failed);
+        next_block();
+        assert_instruction_status(InstructionId(0), InstructionStatus::Failed);
 
-            assert_ok!(Settlement::affirm_instruction_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-                None
-            ),);
-            assert_ok!(Settlement::execute_manual_instruction(
-                alice.origin(),
-                InstructionId(0),
-                None,
-                1,
-                0,
-                0,
-                None
-            ));
-            assert_instruction_status(
-                InstructionId(0),
-                InstructionStatus::Success(System::block_number()),
-            );
-        });
+        assert_ok!(Settlement::affirm_instruction_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+            None
+        ),);
+        assert_ok!(Settlement::execute_manual_instruction(
+            alice.origin(),
+            InstructionId(0),
+            None,
+            1,
+            0,
+            0,
+            None
+        ));
+        assert_instruction_status(
+            InstructionId(0),
+            InstructionStatus::Success(System::block_number()),
+        );
     });
 }
 
 #[test]
 fn reject_instruction_as_mediator() {
     ExtBuilder::default().build().execute_with(|| {
-        ExtBuilder::default().build().execute_with(|| {
-            let bob = User::new(AccountKeyring::Bob);
-            let dave = User::new(AccountKeyring::Dave);
-            let alice = User::new(AccountKeyring::Alice);
-            let charlie = User::new(AccountKeyring::Charlie);
+        let bob = User::new(AccountKeyring::Bob);
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let charlie = User::new(AccountKeyring::Charlie);
 
-            let venue_counter = create_token_and_venue(TICKER, alice);
+        let venue_counter = create_token_and_venue(TICKER, alice);
 
-            let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
-            let legs: Vec<Leg> = vec![Leg::NonFungible {
-                sender: PortfolioId::default_portfolio(alice.did),
-                receiver: PortfolioId::default_portfolio(bob.did),
-                nfts,
-            }];
-            assert_ok!(Settlement::add_instruction_with_mediators(
-                alice.origin(),
-                venue_counter,
-                SettlementType::SettleOnAffirmation,
-                None,
-                None,
-                legs.clone(),
-                None,
-                BTreeSet::from([charlie.did]).try_into().unwrap()
-            ));
+        let nfts = NFTs::new_unverified(TICKER, vec![NFTId(1)]);
+        let legs: Vec<Leg> = vec![Leg::NonFungible {
+            sender: PortfolioId::default_portfolio(alice.did),
+            receiver: PortfolioId::default_portfolio(bob.did),
+            nfts,
+        }];
+        assert_ok!(Settlement::add_instruction_with_mediators(
+            alice.origin(),
+            venue_counter,
+            SettlementType::SettleOnAffirmation,
+            None,
+            None,
+            legs.clone(),
+            None,
+            BTreeSet::from([charlie.did]).try_into().unwrap()
+        ));
 
-            assert_noop!(
-                Settlement::reject_instruction_as_mediator(dave.origin(), InstructionId(0), None),
-                Error::CallerIsNotAMediator
-            );
-            assert_ok!(Settlement::reject_instruction_as_mediator(
-                charlie.origin(),
-                InstructionId(0),
-                None
-            ),);
-            assert_instruction_status(
-                InstructionId(0),
-                InstructionStatus::Rejected(System::block_number()),
-            );
-        });
+        assert_noop!(
+            Settlement::reject_instruction_as_mediator(dave.origin(), InstructionId(0), None),
+            Error::CallerIsNotAMediator
+        );
+        assert_ok!(Settlement::reject_instruction_as_mediator(
+            charlie.origin(),
+            InstructionId(0),
+            None
+        ),);
+        assert_instruction_status(
+            InstructionId(0),
+            InstructionStatus::Rejected(System::block_number()),
+        );
     });
 }
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -240,6 +240,8 @@ parameter_types! {
     pub const MaxNumberOfNFTsMoves: u32 = 100;
     pub const MaxNumberOfOffChainAssets: u32 = 10;
     pub const MaxNumberOfVenueSigners: u32 = 50;
+    pub const MaxInstructionMediators: u32 = 4;
+    pub const MaxAssetMediators: u32 = 4;
 }
 
 frame_support::construct_runtime!(

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -468,7 +468,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get();
         let n in 0..T::MaxNumberOfNFTs::get();
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -535,7 +536,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get();
         let n in 0..T::MaxNumberOfNFTs::get();
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -552,7 +554,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get();
         let n in 0..T::MaxNumberOfNFTs::get();
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -569,7 +572,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get() as u32;
         let n in 0..T::MaxNumberOfNFTs::get() as u32;
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -583,7 +587,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get() as u32;
         let n in 0..T::MaxNumberOfNFTs::get() as u32;
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -662,7 +667,8 @@ benchmarks! {
         let f in 1..T::MaxNumberOfFungibleAssets::get();
         let n in 0..T::MaxNumberOfNFTs::get();
         let o in 0..T::MaxNumberOfOffChainAssets::get();
-        let m in 0..T::MaxInstructionMediators::get();
+
+        let m = T::MaxInstructionMediators::get();
 
         let alice = UserBuilder::<T>::default().generate_did().build("Alice");
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
@@ -771,4 +777,20 @@ benchmarks! {
             None
         ).unwrap();
     }: _(david.origin, InstructionId(1))
+
+    reject_instruction_as_mediator {
+        // Number of fungible, non-fungible and offchain LEGS in the instruction
+        let f in 1..T::MaxNumberOfFungibleAssets::get();
+        let n in 0..T::MaxNumberOfNFTs::get();
+        let o in 0..T::MaxNumberOfOffChainAssets::get();
+
+        let m = T::MaxInstructionMediators::get();
+
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let settlement_type = SettlementType::SettleOnBlock(100u32.into());
+        let venue_id = create_venue_::<T>(alice.did(), vec![alice.account(), bob.account()]);
+
+        let parameters = setup_execute_instruction::<T>(&alice, &bob, settlement_type, venue_id, f, n, o, m, false, false);
+    }: _(parameters.asset_mediators[0].origin.clone(), InstructionId(1), None)
 }

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -653,6 +653,23 @@ benchmarks! {
         let parameters = setup_legs::<T>(&alice, &bob, f, n, o, false, false, 2);
     }: _(alice.origin, venue_id, settlement_type, None, None, parameters.legs, memo, mediators.try_into().unwrap())
 
+    add_and_affirm_with_mediators {
+        // Number of fungible, non-fungible, offchain legs and mediators
+        let f in 1..T::MaxNumberOfFungibleAssets::get();
+        let n in 0..T::MaxNumberOfNFTs::get();
+        let o in 0..T::MaxNumberOfOffChainAssets::get();
+        let m in 0..T::MaxInstructionMediators::get();
+
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let memo = Some(Memo::default());
+        let settlement_type = SettlementType::SettleOnBlock(100u32.into());
+        let venue_id = create_venue_::<T>(alice.did(), vec![alice.account()]);
+        let mediators: BTreeSet<IdentityId> = (0..m).map(|i| IdentityId::from(i as u128)).collect();
+
+        let parameters = setup_legs::<T>(&alice, &bob, f, n, o, false, false, 2);
+    }: _(alice.origin, venue_id, settlement_type, None, None, parameters.legs, parameters.portfolios.sdr_portfolios, memo, mediators.try_into().unwrap())
+
     affirm_instruction_as_mediator {
         let bob = UserBuilder::<T>::default().generate_did().build("Bob");
         let david = UserBuilder::<T>::default().generate_did().build("David");

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -97,7 +97,7 @@ fn setup_legs<T>(
     o: u32,
     pause_compliance: bool,
     pause_restrictions: bool,
-    asset_mediators: u8
+    asset_mediators: u8,
 ) -> Parameters
 where
     T: Config + TestUtilsFn<AccountIdOf<T>>,
@@ -158,7 +158,7 @@ where
                 Some(&sdr_portfolio_name),
                 Some(&rcv_portfolio_name),
                 pause_compliance,
-                asset_mediators
+                asset_mediators,
             );
             portfolios.sdr_portfolios.push(sdr_portfolio.clone());
             portfolios.rcv_portfolios.push(rcv_portfolio.clone());
@@ -189,7 +189,7 @@ fn setup_execute_instruction<T>(
     o: u32,
     pause_compliance: bool,
     pause_restrictions: bool,
-    n_mediators: u8
+    n_mediators: u8,
 ) -> Parameters
 where
     T: Config + TestUtilsFn<AccountIdOf<T>>,
@@ -203,7 +203,7 @@ where
         o,
         pause_compliance,
         pause_restrictions,
-        n_mediators
+        n_mediators,
     );
     Module::<T>::add_instruction(
         sender.origin.clone().into(),
@@ -662,13 +662,13 @@ benchmarks! {
         let mediators = BTreeSet::from([david.did()]);
 
         let parameters = setup_legs::<T>(
-            &alice, 
-            &bob, 
-            T::MaxNumberOfFungibleAssets::get(), 
-            T::MaxNumberOfNFTs::get(), 
-            T::MaxNumberOfOffChainAssets::get(), 
-            false, 
-            false, 
+            &alice,
+            &bob,
+            T::MaxNumberOfFungibleAssets::get(),
+            T::MaxNumberOfNFTs::get(),
+            T::MaxNumberOfOffChainAssets::get(),
+            false,
+            false,
             2
         );
         Module::<T>::add_instruction_with_mediators(
@@ -693,13 +693,13 @@ benchmarks! {
         let mediators = BTreeSet::from([david.did()]);
 
         let parameters = setup_legs::<T>(
-            &alice, 
-            &bob, 
-            T::MaxNumberOfFungibleAssets::get(), 
-            T::MaxNumberOfNFTs::get(), 
-            T::MaxNumberOfOffChainAssets::get(), 
-            false, 
-            false, 
+            &alice,
+            &bob,
+            T::MaxNumberOfFungibleAssets::get(),
+            T::MaxNumberOfNFTs::get(),
+            T::MaxNumberOfOffChainAssets::get(),
+            false,
+            false,
             2
         );
         Module::<T>::add_instruction_with_mediators(
@@ -713,8 +713,8 @@ benchmarks! {
             mediators.try_into().unwrap()
         ).unwrap();
         Module::<T>::affirm_instruction_as_mediator(
-            david.origin.clone().into(), 
-            InstructionId(1), 
+            david.origin.clone().into(),
+            InstructionId(1),
             None
         ).unwrap();
     }: _(david.origin, InstructionId(1))

--- a/pallets/settlement/src/benchmarking.rs
+++ b/pallets/settlement/src/benchmarking.rs
@@ -630,4 +630,14 @@ benchmarks! {
         let portfolios =
             [parameters.portfolios.rcv_portfolios, parameters.portfolios.rcv_receipt_portfolios].concat();
     }: withdraw_affirmation(bob.origin, InstructionId(1),  portfolios)
+
+//    add_instruction_with_mediators {
+//          let n in 0..T::MaxInstructionMediators::get();
+//    }
+//    affirm_instruction_as_mediator {
+//        let n in 0..T::MaxInstructionMediators::get();
+//    }
+//    remove_affirmation_as_mediator {
+//          let n in 0..T::MaxInstructionMediators::get();
+//    }
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -744,31 +744,6 @@ decl_module! {
                 .map_err(|e| e.error)?;
         }
 
-        /// Affirms the instruction as a mediator - should only be called by mediators, otherwise it will fail.
-        ///
-        /// # Arguments
-        /// * `origin`: The secondary key of the sender.
-        /// * `instruction_id`: The [`InstructionId`] that will be affirmed by the mediator.
-        /// * `expiry`: An Optional value for defining when the affirmation will expire (None means it will always be valid).
-        #[weight = <T as Config>::WeightInfo::affirm_instruction_as_mediator()]
-        pub fn affirm_instruction_as_mediator(
-            origin,
-            instruction_id: InstructionId,
-            expiry: Option<T::Moment>
-        ) {
-            Self::base_affirm_instruction_as_mediator(origin, instruction_id, expiry)?;
-        }
-
-        /// Removes the mediator's affirmation for the instruction - should only be called by mediators, otherwise it will fail.
-        ///
-        /// # Arguments
-        /// * `origin`: The secondary key of the sender.
-        /// * `instruction_id`: The [`InstructionId`] that will have the affirmation removed.
-        #[weight = <T as Config>::WeightInfo::remove_affirmation_as_mediator()]
-        pub fn withdraw_affirmation_as_mediator(origin, instruction_id: InstructionId) {
-            Self::base_withdraw_affirmation_as_mediator(origin, instruction_id)?;
-        }
-
         /// Adds a new instruction with mediators.
         ///
         /// # Arguments
@@ -801,6 +776,31 @@ decl_module! {
                 instruction_memo,
                 Some(mediators)
             )?;
+        }
+
+        /// Affirms the instruction as a mediator - should only be called by mediators, otherwise it will fail.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `instruction_id`: The [`InstructionId`] that will be affirmed by the mediator.
+        /// * `expiry`: An Optional value for defining when the affirmation will expire (None means it will always be valid).
+        #[weight = <T as Config>::WeightInfo::affirm_instruction_as_mediator()]
+        pub fn affirm_instruction_as_mediator(
+            origin,
+            instruction_id: InstructionId,
+            expiry: Option<T::Moment>
+        ) {
+            Self::base_affirm_instruction_as_mediator(origin, instruction_id, expiry)?;
+        }
+
+        /// Removes the mediator's affirmation for the instruction - should only be called by mediators, otherwise it will fail.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `instruction_id`: The [`InstructionId`] that will have the affirmation removed.
+        #[weight = <T as Config>::WeightInfo::remove_affirmation_as_mediator()]
+        pub fn withdraw_affirmation_as_mediator(origin, instruction_id: InstructionId) {
+            Self::base_withdraw_affirmation_as_mediator(origin, instruction_id)?;
         }
     }
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -2199,6 +2199,8 @@ impl<T: Config> Module<T> {
             );
             Self::maybe_schedule_instruction(n_pending_affirmations, instruction_id, weight_limit);
         }
+
+        Self::deposit_event(RawEvent::MediatorAffirmationReceived(caller_did, instruction_id));
         Ok(())
     }
 
@@ -2237,6 +2239,7 @@ impl<T: Config> Module<T> {
             // Cancel the scheduled task
             let _ = T::Scheduler::cancel_named(instruction_id.execution_name());
         }
+        Self::deposit_event(RawEvent::MediatorAffirmationWithdrawn(caller_did, instruction_id));
         Ok(())
     }
 

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -60,7 +60,9 @@ use frame_support::storage::{
 use frame_support::traits::schedule::{DispatchTime, Named};
 use frame_support::traits::Get;
 use frame_support::weights::Weight;
-use frame_support::{decl_error, decl_module, decl_storage, ensure, IterableStorageDoubleMap};
+use frame_support::{
+    decl_error, decl_module, decl_storage, ensure, BoundedBTreeSet, IterableStorageDoubleMap,
+};
 use frame_system::{ensure_root, RawOrigin};
 use sp_runtime::traits::{One, Verify};
 use sp_std::collections::btree_set::BTreeSet;
@@ -84,8 +86,8 @@ use polymesh_primitives::settlement::{
     VenueId, VenueType,
 };
 use polymesh_primitives::{
-    storage_migrate_on, storage_migration_ver, Balance, IdentityId, Memo, NFTs, PortfolioId,
-    SecondaryKey, Ticker, WeightMeter,
+    storage_migration_ver, Balance, IdentityId, Memo, NFTs, PortfolioId, SecondaryKey, Ticker,
+    WeightMeter,
 };
 
 type Identity<T> = pallet_identity::Module<T>;
@@ -225,6 +227,12 @@ decl_error! {
         UnexpectedLegStatus,
         /// The maximum number of venue signers was exceeded.
         NumberOfVenueSignersExceeded,
+        /// The caller is not a mediator in the instruction.
+        CallerIsNotAMediator,
+        /// The mediator's expiry date must be in the future.
+        InvalidExpiryDate,
+        /// The expiry date for the mediator's affirmation has passed.
+        MediatorAffirmationExpired
     }
 }
 
@@ -299,7 +307,7 @@ decl_storage! {
         pub NumberOfVenueSigners get(fn number_of_venue_signers): map hasher(twox_64_concat) VenueId => u32;
         /// The status for the mediators affirmation.
         pub InstructionMediatorsAffirmations get(fn venue_mediators_affirmations):
-            double_map hasher(twox_64_concat) InstructionId, hasher(identity) IdentityId => MediatorAffirmationStatus;
+            double_map hasher(twox_64_concat) InstructionId, hasher(identity) IdentityId => MediatorAffirmationStatus<T::Moment>;
     }
 }
 
@@ -308,16 +316,6 @@ decl_module! {
         type Error = Error<T>;
 
         fn deposit_event() = default;
-
-        fn on_runtime_upgrade() -> Weight {
-            storage_migrate_on!(StorageVersion, 1, {
-                migration::migrate_to_v1::<T>();
-            });
-            storage_migrate_on!(StorageVersion, 2, {
-                migration::migrate_to_v2::<T>();
-            });
-            Weight::zero()
-        }
 
         /// Registers a new venue.
         ///
@@ -729,6 +727,55 @@ decl_module! {
             Self::base_withdraw_affirmation(origin, id, portfolios, number_of_assets)
                 .map_err(|e| e.error)?;
         }
+
+        /// Affirms the instruction as a mediator - should only be called by mediators, otherwise it will fail.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `instruction_id`: The [`InstructionId`] that will be affirmed by the mediator.
+        /// * `expiry`: An Optional value for defining when the affirmation will expire (None means it will always be valid).
+        #[weight = <T as Config>::WeightInfo::affirm_instruction_as_mediator()]
+        pub fn affirm_instruction_as_mediator(
+            origin,
+            instruction_id: InstructionId,
+            expiry: Option<T::Moment>
+        ) {
+            Self::base_affirm_instruction_as_mediator(origin, instruction_id, expiry)?;
+        }
+
+        /// Removes the mediator's affirmation for the instruction - should only be called by mediators, otherwise it will fail.
+        ///
+        /// # Arguments
+        /// * `origin`: The secondary key of the sender.
+        /// * `instruction_id`: The [`InstructionId`] that will have the affirmation removed.
+        #[weight = <T as Config>::WeightInfo::remove_affirmation_as_mediator()]
+        pub fn remove_affirmation_as_mediator(origin, instruction_id: InstructionId) {
+            Self::base_remove_affirmation_as_mediator(origin, instruction_id)?;
+        }
+
+        /// Adds a new instruction.
+        ///
+        /// # Arguments
+        /// * `venue_id`: The [`VenueId`] of the venue this instruction belongs to.
+        /// * `settlement_type`: The [`SettlementType`] specifying when the instruction should be settled.
+        /// * `trade_date`: Optional date from which people can interact with this instruction.
+        /// * `value_date`: Optional date after which the instruction should be settled (not enforced).
+        /// * `legs`: A vector of all [`Leg`] included in this instruction.
+        /// * `memo`: An optional [`Memo`] field for this instruction.
+        /// * `mediators`: A set of [`IdentityId`] of all the mandatory mediators for the instruction.
+        #[weight = <T as Config>::WeightInfo::add_instruction_with_mediators()]
+        pub fn add_instruction_with_mediators(
+            _origin,
+            _venue_id: VenueId,
+            _settlement_type: SettlementType<T::BlockNumber>,
+            _trade_date: Option<T::Moment>,
+            _value_date: Option<T::Moment>,
+            _legs: Vec<Leg>,
+            _instruction_memo: Option<Memo>,
+            _mediators: BoundedBTreeSet<IdentityId, T::MaxInstructionMediators>,
+        ) {
+            unimplemented!()
+        }
     }
 }
 
@@ -841,7 +888,7 @@ impl<T: Config> Module<T> {
             ));
         }
         for mediator_id in instruction_info.mediators() {
-            InstructionMediatorsAffirmations::insert(
+            InstructionMediatorsAffirmations::<T>::insert(
                 instruction_id,
                 mediator_id,
                 MediatorAffirmationStatus::Pending,
@@ -1125,11 +1172,16 @@ impl<T: Config> Module<T> {
     /// Returns `Ok` if all mediator's affirmation are still valid. Otherwise, returns an error.
     fn ensure_non_expired_affirmations(instruction_id: &InstructionId) -> DispatchResult {
         for mediator_affirmation in
-            InstructionMediatorsAffirmations::iter_prefix_values(instruction_id)
+            InstructionMediatorsAffirmations::<T>::iter_prefix_values(instruction_id)
         {
             match mediator_affirmation {
-                MediatorAffirmationStatus::Affirmed { expiry, timestamp } => {
-                    unimplemented!()
+                MediatorAffirmationStatus::Affirmed { expiry, .. } => {
+                    if let Some(expiry) = expiry {
+                        ensure!(
+                            expiry < <pallet_timestamp::Pallet<T>>::get(),
+                            Error::<T>::MediatorAffirmationExpired
+                        );
+                    }
                 }
                 MediatorAffirmationStatus::Unknown | MediatorAffirmationStatus::Pending => {
                     return Err(Error::<T>::NotAllAffirmationsHaveBeenReceived.into())
@@ -1453,7 +1505,7 @@ impl<T: Config> Module<T> {
             instruction_asset_count.non_fungible(),
             instruction_asset_count.off_chain(),
         );
-        // Schedule instruction to be execute in the next block (expected) if conditions are met.
+        // Schedule instruction to be executed in the next block (expected) if conditions are met.
         Self::maybe_schedule_instruction(Self::instruction_affirms_pending(id), id, weight_limit);
         Ok(PostDispatchInfo::from(Some(
             Self::affirm_with_receipts_actual_weight(
@@ -2067,6 +2119,93 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
+    /// Affirms the instruction as a mediator.
+    fn base_affirm_instruction_as_mediator(
+        origin: T::RuntimeOrigin,
+        instruction_id: InstructionId,
+        expiry: Option<T::Moment>,
+    ) -> DispatchResult {
+        let (caller_did, _, instruction) =
+            Self::ensure_origin_perm_and_instruction_validity(origin, instruction_id, false)?;
+
+        // Verifies if the caller is a mediator
+        let mediator_affirmation_status =
+            InstructionMediatorsAffirmations::<T>::get(instruction_id, caller_did);
+        ensure!(
+            mediator_affirmation_status != MediatorAffirmationStatus::Unknown,
+            Error::<T>::CallerIsNotAMediator
+        );
+
+        // Verifies if the expiry date is in the future
+        let timestamp = <pallet_timestamp::Pallet<T>>::get();
+        if let Some(expiry) = expiry {
+            ensure!(expiry > timestamp, Error::<T>::InvalidExpiryDate);
+        }
+
+        // Updates the mediator's affirmation status to affirmed
+        InstructionMediatorsAffirmations::<T>::insert(
+            instruction_id,
+            caller_did,
+            MediatorAffirmationStatus::Affirmed { expiry, timestamp },
+        );
+        // If the mediator is not reaffirming the instruction, the number of pending affirmation must be updated
+        if MediatorAffirmationStatus::Pending == mediator_affirmation_status {
+            InstructionAffirmsPending::mutate(instruction_id, |n| *n = n.saturating_sub(1));
+        }
+        // If all affirmations have been received, the instruction will be scheduled for the next block
+        let n_pending_affirmations = InstructionAffirmsPending::get(instruction_id);
+        if n_pending_affirmations == 0
+            && instruction.settlement_type == SettlementType::SettleOnAffirmation
+        {
+            let instruction_asset_count = Self::get_instruction_asset_count(&instruction_id);
+            let weight_limit = Self::execute_scheduled_instruction_weight_limit(
+                instruction_asset_count.fungible(),
+                instruction_asset_count.non_fungible(),
+                instruction_asset_count.off_chain(),
+            );
+            Self::maybe_schedule_instruction(n_pending_affirmations, instruction_id, weight_limit);
+        }
+        Ok(())
+    }
+
+    /// Removes the mediator's affirmation for the instruction
+    fn base_remove_affirmation_as_mediator(
+        origin: T::RuntimeOrigin,
+        instruction_id: InstructionId,
+    ) -> DispatchResult {
+        let (caller_did, _, instruction) =
+            Self::ensure_origin_perm_and_instruction_validity(origin, instruction_id, false)?;
+
+        // Verifies if the caller is a mediator and has already affirmed the instruction
+        let mediator_affirmation_status =
+            InstructionMediatorsAffirmations::<T>::get(instruction_id, caller_did);
+        match mediator_affirmation_status {
+            MediatorAffirmationStatus::Unknown => {
+                return Err(Error::<T>::CallerIsNotAMediator.into())
+            }
+            MediatorAffirmationStatus::Pending => {
+                return Err(Error::<T>::UnexpectedAffirmationStatus.into())
+            }
+            MediatorAffirmationStatus::Affirmed { .. } => {}
+        }
+
+        // Updates the mediator's affirmation status to pending and add one to the number of pending affirmations
+        let n_pending_before_withdrawal = InstructionAffirmsPending::get(instruction_id);
+        InstructionMediatorsAffirmations::<T>::insert(
+            instruction_id,
+            caller_did,
+            MediatorAffirmationStatus::Pending,
+        );
+        InstructionAffirmsPending::mutate(instruction_id, |n| *n = n.saturating_add(1));
+        if n_pending_before_withdrawal == 0
+            && instruction.settlement_type == SettlementType::SettleOnAffirmation
+        {
+            // Cancel the scheduled task for the execution of a given instruction.
+            let _ = T::Scheduler::cancel_named(instruction_id.execution_name());
+        }
+        Ok(())
+    }
+
     /// Returns the worst case weight for an instruction with `f` fungible legs, `n` nfts being transferred and `o` offchain assets.
     fn execute_scheduled_instruction_weight_limit(f: u32, n: u32, o: u32) -> Weight {
         <T as Config>::WeightInfo::execute_scheduled_instruction(f, n, o)
@@ -2201,242 +2340,6 @@ impl<T: Config> Module<T> {
             filtered_legs.sender_asset_count().clone(),
             filtered_legs.receiver_asset_count().clone(),
             filtered_legs.unfiltered_asset_count().off_chain(),
-        )
-    }
-}
-
-pub mod migration {
-    use super::*;
-    use sp_runtime::runtime_logger::RuntimeLogger;
-    use sp_std::collections::btree_map::BTreeMap;
-
-    mod v1 {
-        use super::*;
-        use scale_info::TypeInfo;
-
-        #[derive(Encode, Decode, TypeInfo)]
-        #[derive(Default, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
-        pub struct Instruction<Moment, BlockNumber> {
-            pub instruction_id: InstructionId,
-            pub venue_id: VenueId,
-            pub status: InstructionStatus<BlockNumber>,
-            pub settlement_type: SettlementType<BlockNumber>,
-            pub created_at: Option<Moment>,
-            pub trade_date: Option<Moment>,
-            pub value_date: Option<Moment>,
-        }
-
-        #[derive(Encode, Decode, TypeInfo)]
-        #[derive(Default, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
-        pub struct Leg {
-            pub from: PortfolioId,
-            pub to: PortfolioId,
-            pub asset: Ticker,
-            pub amount: Balance,
-        }
-
-        #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
-        pub enum LegAsset {
-            Fungible { ticker: Ticker, amount: Balance },
-            NonFungible(NFTs),
-        }
-
-        impl Default for LegAsset {
-            fn default() -> Self {
-                LegAsset::Fungible {
-                    ticker: Ticker::default(),
-                    amount: Balance::default(),
-                }
-            }
-        }
-
-        #[derive(Encode, Decode, TypeInfo)]
-        #[derive(Clone, Debug, Default, Eq, PartialEq)]
-        pub struct LegV2 {
-            pub from: PortfolioId,
-            pub to: PortfolioId,
-            pub asset: LegAsset,
-        }
-
-        decl_storage! {
-            trait Store for Module<T: Config> as Settlement {
-                pub UserVenues get(fn user_venues): map hasher(twox_64_concat) IdentityId => Vec<VenueId>;
-                pub InstructionDetails get(fn instruction_details):
-                    map hasher(twox_64_concat) InstructionId => Instruction<T::Moment, T::BlockNumber>;
-                pub InstructionLegs get(fn instruction_legs):
-                    double_map hasher(twox_64_concat) InstructionId, hasher(twox_64_concat) LegId => Leg;
-                pub InstructionLegsV2 get(fn instruction_legsv2):
-                    double_map hasher(twox_64_concat) InstructionId, hasher(twox_64_concat) LegId => LegV2;
-            }
-        }
-
-        decl_module! {
-            pub struct Module<T: Config> for enum Call where origin: T::RuntimeOrigin { }
-        }
-    }
-
-    pub fn migrate_to_v1<T: Config>() {
-        RuntimeLogger::init();
-        log::info!(" >>> Updating Settlement storage. Migrating Legs and Instructions.");
-        migrate_user_venues::<T>();
-        migrate_legs::<T>();
-        migrate_status::<T>();
-        log::info!(" >>> All user_venues, legs and Instructions have been migrated.");
-    }
-
-    pub fn migrate_to_v2<T: Config>() {
-        RuntimeLogger::init();
-        log::info!(" >>> Rescheduling instructions");
-        reschedule_instructions::<T>();
-        log::info!(" >>> All instructions have been rescheduled");
-    }
-
-    fn migrate_user_venues<T: Config>() {
-        // Need to fully drain the old storage.
-        let user_venues = v1::UserVenues::drain().collect::<Vec<(IdentityId, Vec<VenueId>)>>();
-        let mut count = 0;
-        // Convert to new double map.
-        for (did, venues) in user_venues {
-            count += venues.len();
-            for venue_id in venues {
-                UserVenues::insert(did, venue_id, ());
-            }
-        }
-        log::info!(" >>> {count} UserVenues have been migrated.");
-    }
-
-    fn migrate_legs<T: Config>() {
-        // Migrate all itens from InstructionLegs
-        v1::InstructionLegs::drain().for_each(|(id, leg_id, old_leg)| {
-            let new_leg = {
-                if !pallet_asset::Tokens::contains_key(old_leg.asset) {
-                    Leg::OffChain {
-                        sender_identity: old_leg.from.did,
-                        receiver_identity: old_leg.to.did,
-                        ticker: old_leg.asset,
-                        amount: old_leg.amount,
-                    }
-                } else {
-                    Leg::Fungible {
-                        sender: old_leg.from,
-                        receiver: old_leg.to,
-                        ticker: old_leg.asset,
-                        amount: old_leg.amount,
-                    }
-                }
-            };
-            InstructionLegs::insert(&id, leg_id, new_leg);
-        });
-        // Migrate all itens from InstructionLegsV2
-        v1::InstructionLegsV2::drain().for_each(|(id, leg_id, leg_v2)| {
-            let new_leg = {
-                match leg_v2.asset {
-                    v1::LegAsset::Fungible { ticker, amount } => {
-                        if !pallet_asset::Tokens::contains_key(ticker) {
-                            Leg::OffChain {
-                                sender_identity: leg_v2.from.did,
-                                receiver_identity: leg_v2.to.did,
-                                ticker,
-                                amount,
-                            }
-                        } else {
-                            Leg::Fungible {
-                                sender: leg_v2.from,
-                                receiver: leg_v2.to,
-                                ticker,
-                                amount,
-                            }
-                        }
-                    }
-                    v1::LegAsset::NonFungible(nfts) => Leg::NonFungible {
-                        sender: leg_v2.from,
-                        receiver: leg_v2.to,
-                        nfts,
-                    },
-                }
-            };
-            InstructionLegs::insert(&id, leg_id, new_leg);
-        });
-    }
-
-    fn reschedule_instructions<T: Config>() {
-        let max_tasks_per_block = 50;
-        let mut n_scheduled_tasks: BTreeMap<T::BlockNumber, u32> = BTreeMap::new();
-        let mut next_available_block = System::<T>::block_number() + One::one();
-
-        for (instruction_id, instruction_details) in InstructionDetails::<T>::iter() {
-            let block = {
-                match instruction_details.settlement_type {
-                    SettlementType::SettleOnBlock(block) => {
-                        if block >= System::<T>::block_number() {
-                            n_scheduled_tasks
-                                .entry(block)
-                                .and_modify(|count| *count += 1)
-                                .or_insert(1);
-                            Some(block)
-                        } else {
-                            None
-                        }
-                    }
-                    SettlementType::SettleOnAffirmation => {
-                        if InstructionStatuses::<T>::get(instruction_id)
-                            == InstructionStatus::Pending
-                            && Module::<T>::instruction_affirms_pending(instruction_id) == 0
-                        {
-                            while n_scheduled_tasks.get(&next_available_block)
-                                >= Some(&max_tasks_per_block)
-                            {
-                                next_available_block += 1u32.into();
-                            }
-                            n_scheduled_tasks
-                                .entry(next_available_block)
-                                .and_modify(|count| *count += 1)
-                                .or_insert(1);
-                            Some(next_available_block)
-                        } else {
-                            None
-                        }
-                    }
-                    SettlementType::SettleManual(_) => None,
-                }
-            };
-
-            if let Some(block_number) = block {
-                // Attempts to cancel the old scheduled task.
-                if let Ok(_) = T::Scheduler::cancel_named(instruction_id.execution_name()) {
-                    // Get the weight limit for the instruction
-                    let instruction_asset_count =
-                        Module::<T>::get_instruction_asset_count(&instruction_id);
-                    let weight_limit = Module::<T>::execute_scheduled_instruction_weight_limit(
-                        instruction_asset_count.fungible(),
-                        instruction_asset_count.non_fungible(),
-                        instruction_asset_count.off_chain(),
-                    );
-                    // If the old taks was cancelled, create new scheduled task
-                    Module::<T>::schedule_instruction(instruction_id, block_number, weight_limit);
-                }
-            }
-        }
-    }
-
-    fn migrate_status<T: Config>() -> usize {
-        v1::InstructionDetails::<T>::drain().fold(
-            0,
-            |n_instructions, (instruction_id, instruction_details)| {
-                InstructionStatuses::<T>::insert(instruction_id, instruction_details.status);
-                InstructionDetails::<T>::insert(
-                    instruction_id,
-                    Instruction {
-                        instruction_id,
-                        venue_id: instruction_details.venue_id,
-                        settlement_type: instruction_details.settlement_type,
-                        created_at: instruction_details.created_at,
-                        trade_date: instruction_details.trade_date,
-                        value_date: instruction_details.value_date,
-                    },
-                );
-                n_instructions + 1
-            },
         )
     }
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -2200,7 +2200,10 @@ impl<T: Config> Module<T> {
             Self::maybe_schedule_instruction(n_pending_affirmations, instruction_id, weight_limit);
         }
 
-        Self::deposit_event(RawEvent::MediatorAffirmationReceived(caller_did, instruction_id));
+        Self::deposit_event(RawEvent::MediatorAffirmationReceived(
+            caller_did,
+            instruction_id,
+        ));
         Ok(())
     }
 
@@ -2239,7 +2242,10 @@ impl<T: Config> Module<T> {
             // Cancel the scheduled task
             let _ = T::Scheduler::cancel_named(instruction_id.execution_name());
         }
-        Self::deposit_event(RawEvent::MediatorAffirmationWithdrawn(caller_did, instruction_id));
+        Self::deposit_event(RawEvent::MediatorAffirmationWithdrawn(
+            caller_did,
+            instruction_id,
+        ));
         Ok(())
     }
 

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -135,6 +135,9 @@ pub trait Config:
 
     /// Maximum number of venue signers.
     type MaxNumberOfVenueSigners: Get<u32>;
+
+    /// Maximum number mediators in the instruction level (this does not include asset mediators).
+    type MaxInstructionMediators: Get<u32>;
 }
 
 decl_error! {
@@ -511,9 +514,6 @@ decl_module! {
         /// * `value_date` - Optional date after which the instruction should be settled (not enforced)
         /// * `legs` - Legs included in this instruction.
         /// * `memo` - Memo field for this instruction.
-        ///
-        /// # Weight
-        /// `950_000_000 + 1_000_000 * legs.len()`
         #[weight = <T as Config>::WeightInfo::add_instruction_legs(legs)]
         pub fn add_instruction(
             origin,

--- a/pallets/sto/src/benchmarking.rs
+++ b/pallets/sto/src/benchmarking.rs
@@ -44,6 +44,7 @@ where
         Some(&format!("RcvPortfolio{:?}", offering_ticker)),
         false,
         false,
+        0,
     );
     let (investor_raising_portfolio, fundraiser_raising_portfolio) = setup_asset_transfer(
         investor,
@@ -53,6 +54,7 @@ where
         Some(&format!("RcvPortfolio{:?}", raise_ticker)),
         false,
         false,
+        0,
     );
 
     let trusted_user = UserBuilder::<T>::default()

--- a/pallets/sto/src/benchmarking.rs
+++ b/pallets/sto/src/benchmarking.rs
@@ -36,7 +36,7 @@ fn create_assets_and_compliance<T>(
 where
     T: Config + TestUtilsFn<AccountIdOf<T>>,
 {
-    let (fundraiser_offering_portfolio, investor_offering_portfolio) = setup_asset_transfer(
+    let (fundraiser_offering_portfolio, investor_offering_portfolio, _) = setup_asset_transfer(
         fundraiser,
         investor,
         offering_ticker,
@@ -46,7 +46,7 @@ where
         false,
         0,
     );
-    let (investor_raising_portfolio, fundraiser_raising_portfolio) = setup_asset_transfer(
+    let (investor_raising_portfolio, fundraiser_raising_portfolio, _) = setup_asset_transfer(
         investor,
         fundraiser,
         raise_ticker,

--- a/pallets/sto/src/lib.rs
+++ b/pallets/sto/src/lib.rs
@@ -477,6 +477,7 @@ decl_module! {
                     None,
                     legs,
                     None,
+                    None
                 )?;
 
                 let portfolios = [fundraiser.offering_portfolio, fundraiser.raising_portfolio].iter().copied().collect::<BTreeSet<_>>();

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -695,10 +695,51 @@ impl pallet_asset::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(1))
             .saturating_add(DbWeight::get().writes(1))
     }
-    fn add_mandatory_mediators() -> Weight {
-        unimplemented!()
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: ExternalAgents GroupOfAgent (r:1 w:0)
+    /// Proof Skipped: ExternalAgents GroupOfAgent (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Permissions CurrentPalletName (r:1 w:0)
+    /// Proof Skipped: Permissions CurrentPalletName (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Permissions CurrentDispatchableName (r:1 w:0)
+    /// Proof Skipped: Permissions CurrentDispatchableName (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Asset MandatoryMediators (r:1 w:1)
+    /// Proof Skipped: Asset MandatoryMediators (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `n` is `[1, 4]`.
+    fn add_mandatory_mediators(n: u32) -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `1129`
+        //  Estimated: `19010`
+        // Minimum execution time: 46_407 nanoseconds.
+        Weight::from_ref_time(49_009_947)
+            .saturating_add(Weight::from_proof_size(19010))
+            // Standard Error: 118_620
+            .saturating_add(Weight::from_ref_time(281_996).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(5))
+            .saturating_add(DbWeight::get().writes(1))
     }
-    fn remove_mediators() -> Weight {
-        unimplemented!()
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: ExternalAgents GroupOfAgent (r:1 w:0)
+    /// Proof Skipped: ExternalAgents GroupOfAgent (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Permissions CurrentPalletName (r:1 w:0)
+    /// Proof Skipped: Permissions CurrentPalletName (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Permissions CurrentDispatchableName (r:1 w:0)
+    /// Proof Skipped: Permissions CurrentDispatchableName (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Asset MandatoryMediators (r:1 w:1)
+    /// Proof Skipped: Asset MandatoryMediators (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `n` is `[1, 4]`.
+    fn remove_mediators(n: u32) -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `1180 + n * (32 ±0)`
+        //  Estimated: `19270 + n * (160 ±0)`
+        // Minimum execution time: 48_597 nanoseconds.
+        Weight::from_ref_time(50_264_278)
+            .saturating_add(Weight::from_proof_size(19270))
+            // Standard Error: 57_762
+            .saturating_add(Weight::from_ref_time(46_485).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(5))
+            .saturating_add(DbWeight::get().writes(1))
+            .saturating_add(Weight::from_proof_size(160).saturating_mul(n.into()))
     }
 }

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -695,4 +695,10 @@ impl pallet_asset::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(1))
             .saturating_add(DbWeight::get().writes(1))
     }
+    fn add_mandatory_mediators() -> Weight {
+        unimplemented!()
+    }
+    fn remove_mediators() -> Weight {
+        unimplemented!()
+    }
 }

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -729,7 +729,7 @@ impl pallet_asset::WeightInfo for SubstrateWeight {
     /// Storage: Asset MandatoryMediators (r:1 w:1)
     /// Proof Skipped: Asset MandatoryMediators (max_values: None, max_size: None, mode: Measured)
     /// The range of component `n` is `[1, 4]`.
-    fn remove_mediators(n: u32) -> Weight {
+    fn remove_mandatory_mediators(n: u32) -> Weight {
         // Proof Size summary in bytes:
         //  Measured:  `1180 + n * (32 ±0)`
         //  Estimated: `19270 + n * (160 ±0)`

--- a/pallets/weights/src/pallet_settlement.rs
+++ b/pallets/weights/src/pallet_settlement.rs
@@ -852,4 +852,13 @@ impl pallet_settlement::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(f.into())))
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(n.into())))
     }
+    fn add_instruction_with_mediators() -> Weight {
+        unimplemented!()
+    }
+    fn affirm_instruction_as_mediator() -> Weight {
+        unimplemented!()
+    }
+    fn remove_affirmation_as_mediator() -> Weight {
+        unimplemented!()
+    }
 }

--- a/pallets/weights/src/pallet_settlement.rs
+++ b/pallets/weights/src/pallet_settlement.rs
@@ -1053,4 +1053,62 @@ impl pallet_settlement::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(5))
             .saturating_add(DbWeight::get().writes(2))
     }
+    /// Storage: Settlement InstructionStatuses (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionStatuses (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionLegs (r:121 w:120)
+    /// Proof Skipped: Settlement InstructionLegs (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMediatorsAffirmations (r:444 w:444)
+    /// Proof Skipped: Settlement InstructionMediatorsAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionLegStatus (r:120 w:120)
+    /// Proof Skipped: Settlement InstructionLegStatus (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioLockedNFT (r:100 w:100)
+    /// Proof Skipped: Portfolio PortfolioLockedNFT (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioLockedAssets (r:10 w:10)
+    /// Proof Skipped: Portfolio PortfolioLockedAssets (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Scheduler Lookup (r:1 w:1)
+    /// Proof: Scheduler Lookup (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+    /// Storage: Scheduler Agenda (r:1 w:1)
+    /// Proof: Scheduler Agenda (max_values: None, max_size: Some(10463), added: 12938, mode: MaxEncodedLen)
+    /// Storage: Settlement InstructionDetails (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionDetails (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement OffChainAffirmations (r:10 w:10)
+    /// Proof Skipped: Settlement OffChainAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement AffirmsReceived (r:220 w:220)
+    /// Proof Skipped: Settlement AffirmsReceived (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement UserAffirmations (r:0 w:220)
+    /// Proof Skipped: Settlement UserAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionAffirmsPending (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionAffirmsPending (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueInstructions (r:0 w:1)
+    /// Proof Skipped: Settlement VenueInstructions (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `f` is `[1, 10]`.
+    /// The range of component `n` is `[0, 100]`.
+    /// The range of component `o` is `[0, 10]`.
+    fn reject_instruction_as_mediator(f: u32, n: u32, o: u32) -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `2482 + f * (528 ±0) + n * (515 ±0) + o * (202 ±0)`
+        //  Estimated: `78604 + f * (29191 ±0) + n * (28970 ±0) + o * (10141 ±0)`
+        // Minimum execution time: 644_972 nanoseconds.
+        Weight::from_ref_time(100_281_583)
+            .saturating_add(Weight::from_proof_size(78604))
+            // Standard Error: 1_357_413
+            .saturating_add(Weight::from_ref_time(27_925_665).saturating_mul(f.into()))
+            // Standard Error: 125_564
+            .saturating_add(Weight::from_ref_time(42_734_438).saturating_mul(n.into()))
+            // Standard Error: 1_229_606
+            .saturating_add(Weight::from_ref_time(13_236_731).saturating_mul(o.into()))
+            .saturating_add(DbWeight::get().reads(10))
+            .saturating_add(DbWeight::get().reads((9_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().reads((9_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().reads((3_u64).saturating_mul(o.into())))
+            .saturating_add(DbWeight::get().writes(10))
+            .saturating_add(DbWeight::get().writes((11_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().writes((11_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(o.into())))
+            .saturating_add(Weight::from_proof_size(29191).saturating_mul(f.into()))
+            .saturating_add(Weight::from_proof_size(28970).saturating_mul(n.into()))
+            .saturating_add(Weight::from_proof_size(10141).saturating_mul(o.into()))
+    }
 }

--- a/pallets/weights/src/pallet_settlement.rs
+++ b/pallets/weights/src/pallet_settlement.rs
@@ -852,13 +852,205 @@ impl pallet_settlement::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(f.into())))
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(n.into())))
     }
-    fn add_instruction_with_mediators() -> Weight {
-        unimplemented!()
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueInfo (r:1 w:0)
+    /// Proof Skipped: Settlement VenueInfo (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset Tokens (r:110 w:0)
+    /// Proof Skipped: Asset Tokens (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueFiltering (r:110 w:0)
+    /// Proof Skipped: Settlement VenueFiltering (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioCustodian (r:110 w:0)
+    /// Proof Skipped: Portfolio PortfolioCustodian (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset TickersExemptFromAffirmation (r:110 w:0)
+    /// Proof Skipped: Asset TickersExemptFromAffirmation (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset PreApprovedTicker (r:110 w:0)
+    /// Proof Skipped: Asset PreApprovedTicker (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PreApprovedPortfolios (r:110 w:0)
+    /// Proof Skipped: Portfolio PreApprovedPortfolios (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset MandatoryMediators (r:110 w:0)
+    /// Proof Skipped: Asset MandatoryMediators (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionCounter (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionCounter (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Timestamp Now (r:1 w:0)
+    /// Proof: Timestamp Now (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+    /// Storage: Scheduler Lookup (r:1 w:1)
+    /// Proof: Scheduler Lookup (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+    /// Storage: Scheduler Agenda (r:1 w:1)
+    /// Proof: Scheduler Agenda (max_values: None, max_size: Some(10463), added: 12938, mode: MaxEncodedLen)
+    /// Storage: Settlement InstructionLegs (r:0 w:120)
+    /// Proof Skipped: Settlement InstructionLegs (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement UserAffirmations (r:0 w:220)
+    /// Proof Skipped: Settlement UserAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement OffChainAffirmations (r:0 w:10)
+    /// Proof Skipped: Settlement OffChainAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionAffirmsPending (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionAffirmsPending (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMemos (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionMemos (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionStatuses (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionStatuses (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionDetails (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionDetails (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueInstructions (r:0 w:1)
+    /// Proof Skipped: Settlement VenueInstructions (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMediatorsAffirmations (r:0 w:8)
+    /// Proof Skipped: Settlement InstructionMediatorsAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `f` is `[1, 10]`.
+    /// The range of component `n` is `[0, 100]`.
+    /// The range of component `o` is `[0, 10]`.
+    /// The range of component `m` is `[0, 4]`.
+    fn add_instruction_with_mediators(f: u32, n: u32, o: u32, m: u32) -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `2102 + f * (162 ±0) + n * (165 ±0)`
+        //  Estimated: `71991 + f * (20441 ±0) + n * (20479 ±0) + o * (38 ±0) + m * (76 ±0)`
+        // Minimum execution time: 443_758 nanoseconds.
+        Weight::from_ref_time(85_910_485)
+            .saturating_add(Weight::from_proof_size(71991))
+            // Standard Error: 412_254
+            .saturating_add(Weight::from_ref_time(31_478_244).saturating_mul(f.into()))
+            // Standard Error: 38_042
+            .saturating_add(Weight::from_ref_time(28_916_450).saturating_mul(n.into()))
+            // Standard Error: 373_560
+            .saturating_add(Weight::from_ref_time(4_490_553).saturating_mul(o.into()))
+            .saturating_add(DbWeight::get().reads(6))
+            .saturating_add(DbWeight::get().reads((7_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().reads((7_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes(12))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(o.into())))
+            .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(m.into())))
+            .saturating_add(Weight::from_proof_size(20441).saturating_mul(f.into()))
+            .saturating_add(Weight::from_proof_size(20479).saturating_mul(n.into()))
+            .saturating_add(Weight::from_proof_size(38).saturating_mul(o.into()))
+            .saturating_add(Weight::from_proof_size(76).saturating_mul(m.into()))
     }
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueInfo (r:1 w:0)
+    /// Proof Skipped: Settlement VenueInfo (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset Tokens (r:110 w:0)
+    /// Proof Skipped: Asset Tokens (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueFiltering (r:110 w:0)
+    /// Proof Skipped: Settlement VenueFiltering (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioCustodian (r:220 w:0)
+    /// Proof Skipped: Portfolio PortfolioCustodian (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset TickersExemptFromAffirmation (r:110 w:0)
+    /// Proof Skipped: Asset TickersExemptFromAffirmation (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset PreApprovedTicker (r:110 w:0)
+    /// Proof Skipped: Asset PreApprovedTicker (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PreApprovedPortfolios (r:110 w:0)
+    /// Proof Skipped: Portfolio PreApprovedPortfolios (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Asset MandatoryMediators (r:110 w:0)
+    /// Proof Skipped: Asset MandatoryMediators (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionCounter (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionCounter (max_values: Some(1), max_size: None, mode: Measured)
+    /// Storage: Timestamp Now (r:1 w:0)
+    /// Proof: Timestamp Now (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+    /// Storage: Scheduler Lookup (r:1 w:1)
+    /// Proof: Scheduler Lookup (max_values: None, max_size: Some(48), added: 2523, mode: MaxEncodedLen)
+    /// Storage: Scheduler Agenda (r:1 w:1)
+    /// Proof: Scheduler Agenda (max_values: None, max_size: Some(10463), added: 12938, mode: MaxEncodedLen)
+    /// Storage: Settlement InstructionLegs (r:121 w:120)
+    /// Proof Skipped: Settlement InstructionLegs (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioNFT (r:100 w:0)
+    /// Proof Skipped: Portfolio PortfolioNFT (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioLockedNFT (r:100 w:100)
+    /// Proof Skipped: Portfolio PortfolioLockedNFT (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioAssetBalances (r:10 w:0)
+    /// Proof Skipped: Portfolio PortfolioAssetBalances (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Portfolio PortfolioLockedAssets (r:10 w:10)
+    /// Proof Skipped: Portfolio PortfolioLockedAssets (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement UserAffirmations (r:0 w:220)
+    /// Proof Skipped: Settlement UserAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement OffChainAffirmations (r:0 w:10)
+    /// Proof Skipped: Settlement OffChainAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionAffirmsPending (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionAffirmsPending (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMemos (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionMemos (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionStatuses (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionStatuses (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionDetails (r:0 w:1)
+    /// Proof Skipped: Settlement InstructionDetails (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement VenueInstructions (r:0 w:1)
+    /// Proof Skipped: Settlement VenueInstructions (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMediatorsAffirmations (r:0 w:8)
+    /// Proof Skipped: Settlement InstructionMediatorsAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement AffirmsReceived (r:0 w:110)
+    /// Proof Skipped: Settlement AffirmsReceived (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionLegStatus (r:0 w:110)
+    /// Proof Skipped: Settlement InstructionLegStatus (max_values: None, max_size: None, mode: Measured)
+    /// The range of component `f` is `[1, 10]`.
+    /// The range of component `n` is `[0, 100]`.
+    /// The range of component `o` is `[0, 10]`.
+    /// The range of component `m` is `[0, 4]`.
+    fn add_and_affirm_with_mediators(f: u32, n: u32, o: u32, m: u32) -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `2166 + f * (281 ±0) + n * (257 ±0)`
+        //  Estimated: `92707 + f * (34300 ±0) + n * (33698 ±0) + o * (2525 ±0) + m * (125 ±0)`
+        // Minimum execution time: 924_080 nanoseconds.
+        Weight::from_ref_time(937_878_000)
+            .saturating_add(Weight::from_proof_size(92707))
+            // Standard Error: 1_294_869
+            .saturating_add(Weight::from_ref_time(71_730_347).saturating_mul(f.into()))
+            // Standard Error: 122_233
+            .saturating_add(Weight::from_ref_time(64_851_571).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(7))
+            .saturating_add(DbWeight::get().reads((11_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().reads((11_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(o.into())))
+            .saturating_add(DbWeight::get().writes(12))
+            .saturating_add(DbWeight::get().writes((6_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().writes((6_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(o.into())))
+            .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(m.into())))
+            .saturating_add(Weight::from_proof_size(34300).saturating_mul(f.into()))
+            .saturating_add(Weight::from_proof_size(33698).saturating_mul(n.into()))
+            .saturating_add(Weight::from_proof_size(2525).saturating_mul(o.into()))
+            .saturating_add(Weight::from_proof_size(125).saturating_mul(m.into()))
+    }
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionDetails (r:1 w:0)
+    /// Proof Skipped: Settlement InstructionDetails (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionStatuses (r:1 w:0)
+    /// Proof Skipped: Settlement InstructionStatuses (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMediatorsAffirmations (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionMediatorsAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Timestamp Now (r:1 w:0)
+    /// Proof: Timestamp Now (max_values: Some(1), max_size: Some(8), added: 503, mode: MaxEncodedLen)
+    /// Storage: Settlement InstructionAffirmsPending (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionAffirmsPending (max_values: None, max_size: None, mode: Measured)
     fn affirm_instruction_as_mediator() -> Weight {
-        unimplemented!()
+        // Proof Size summary in bytes:
+        //  Measured:  `1336`
+        //  Estimated: `25498`
+        // Minimum execution time: 82_213 nanoseconds.
+        Weight::from_ref_time(90_077_000)
+            .saturating_add(Weight::from_proof_size(25498))
+            .saturating_add(DbWeight::get().reads(6))
+            .saturating_add(DbWeight::get().writes(2))
     }
-    fn remove_affirmation_as_mediator() -> Weight {
-        unimplemented!()
+    /// Storage: Identity KeyRecords (r:1 w:0)
+    /// Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionDetails (r:1 w:0)
+    /// Proof Skipped: Settlement InstructionDetails (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionStatuses (r:1 w:0)
+    /// Proof Skipped: Settlement InstructionStatuses (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionMediatorsAffirmations (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionMediatorsAffirmations (max_values: None, max_size: None, mode: Measured)
+    /// Storage: Settlement InstructionAffirmsPending (r:1 w:1)
+    /// Proof Skipped: Settlement InstructionAffirmsPending (max_values: None, max_size: None, mode: Measured)
+    fn withdraw_affirmation_as_mediator() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `1236`
+        //  Estimated: `23505`
+        // Minimum execution time: 74_897 nanoseconds.
+        Weight::from_ref_time(76_604_000)
+            .saturating_add(Weight::from_proof_size(23505))
+            .saturating_add(DbWeight::get().reads(5))
+            .saturating_add(DbWeight::get().writes(2))
     }
 }

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -520,6 +520,11 @@ impl InstructionInfo {
     pub fn off_chain(&self) -> u32 {
         self.instruction_asset_count.off_chain()
     }
+
+    /// Extends the mediator's set with the contents of `new_mediators`.
+    pub fn extend_mediators(&mut self, new_mediators: BTreeSet<IdentityId>) {
+        self.mediators.extend(new_mediators.iter());
+    }
 }
 
 /// Holds the [`SenderSideInfo`] and the [`AssetCount`] both for the receiver and unfiltered set.

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -43,9 +43,12 @@ impl_checked_inc!(VenueId);
 pub struct VenueDetails(Vec<u8>);
 
 /// Status of an instruction
-#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone, Debug, Decode, Default, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo
+)]
 pub enum InstructionStatus<BlockNumber> {
     /// Invalid instruction or details pruned
+    #[default]
     Unknown,
     /// Instruction is pending execution
     Pending,
@@ -57,17 +60,13 @@ pub enum InstructionStatus<BlockNumber> {
     Rejected(BlockNumber),
 }
 
-impl<BlockNumber> Default for InstructionStatus<BlockNumber> {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
-
 /// Type of the venue. Used for offchain filtering.
-#[derive(Encode, Decode, TypeInfo)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Copy, Clone, Debug, Decode, Default, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo
+)]
 pub enum VenueType {
     /// Default type - used for mixed and unknown types
+    #[default]
     Other,
     /// Represents a primary distribution
     Distribution,
@@ -77,16 +76,13 @@ pub enum VenueType {
     Exchange,
 }
 
-impl Default for VenueType {
-    fn default() -> Self {
-        Self::Other
-    }
-}
-
 /// Status of a leg
-#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Copy, Clone, Debug, Decode, Default, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo
+)]
 pub enum LegStatus<AccountId> {
     /// It is waiting for affirmation
+    #[default]
     PendingTokenLock,
     /// It is waiting execution (tokens currently locked)
     ExecutionPending,
@@ -94,16 +90,13 @@ pub enum LegStatus<AccountId> {
     ExecutionToBeSkipped(AccountId, u64),
 }
 
-impl<AccountId> Default for LegStatus<AccountId> {
-    fn default() -> Self {
-        Self::PendingTokenLock
-    }
-}
-
 /// Status of an affirmation
-#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone, Debug, Decode, Default, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo
+)]
 pub enum AffirmationStatus {
     /// Invalid affirmation
+    #[default]
     Unknown,
     /// Pending user's consent
     Pending,
@@ -111,28 +104,18 @@ pub enum AffirmationStatus {
     Affirmed,
 }
 
-impl Default for AffirmationStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
-
 /// Type of settlement
-#[derive(Encode, Decode, TypeInfo)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Copy, Clone, Debug, Decode, Default, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo
+)]
 pub enum SettlementType<BlockNumber> {
     /// Instruction should be settled in the next block as soon as all affirmations are received.
+    #[default]
     SettleOnAffirmation,
     /// Instruction should be settled on a particular block.
     SettleOnBlock(BlockNumber),
     /// Instruction must be settled manually on or after BlockNumber.
     SettleManual(BlockNumber),
-}
-
-impl<BlockNumber> Default for SettlementType<BlockNumber> {
-    fn default() -> Self {
-        Self::SettleOnAffirmation
-    }
 }
 
 /// A per-Instruction leg ID.
@@ -469,8 +452,8 @@ impl AssetCount {
     }
 }
 
-/// Stores [`AssetCount`] for the instruction, all portfolio that have pre-affirmed the transfer
-/// and all portfolios that still have to approve the transfer.
+/// Stores the [`AssetCount`] for the instruction, all portfolio that have pre-affirmed the transfer
+/// all portfolios that still have to approve the transfer, and the identity of all mediators.
 pub struct InstructionInfo {
     /// The number of fungible, non fungible and off-chain transfers in the instruction.
     instruction_asset_count: AssetCount,
@@ -478,6 +461,8 @@ pub struct InstructionInfo {
     portfolios_pending_approval: BTreeSet<PortfolioId>,
     /// All portfolios that have pre-approved the transfer of a ticker.
     portfolios_pre_approved: BTreeSet<PortfolioId>,
+    /// All mediators that need to affirm the instruction.
+    mediators: BTreeSet<IdentityId>,
 }
 
 impl InstructionInfo {
@@ -486,11 +471,13 @@ impl InstructionInfo {
         instruction_asset_count: AssetCount,
         portfolios_pending_approval: BTreeSet<PortfolioId>,
         portfolios_pre_approved: BTreeSet<PortfolioId>,
+        mediators: BTreeSet<IdentityId>,
     ) -> Self {
         Self {
             instruction_asset_count,
             portfolios_pending_approval,
             portfolios_pre_approved,
+            mediators,
         }
     }
 
@@ -506,11 +493,17 @@ impl InstructionInfo {
             .collect()
     }
 
+    /// Returns a [`BTreeSet<&IdentityId>`] of all mediators that have to affirm the instruction.
+    pub fn mediators(&self) -> &BTreeSet<IdentityId> {
+        &self.mediators
+    }
+
     /// Returns the number of pending affirmations for the instruction.
-    /// The value must be equal to all unique portfolio that have not pre-approved the transfer + the number of offchain legs.
+    /// The value must be equal to all unique portfolio that have not pre-approved the transfer + the number of offchain legs + the number of mediators.
     pub fn number_of_pending_affirmations(&self) -> u64 {
         self.portfolios_pending_approval.len() as u64
             + self.instruction_asset_count.off_chain() as u64
+            + self.mediators.len() as u64
     }
 
     /// Returns the number of fungible transfers.
@@ -700,4 +693,21 @@ impl ExecuteInstructionInfo {
             error: error.map(|e| e.to_string()),
         }
     }
+}
+
+/// The status of the mediator's affirmation.
+#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq, TypeInfo)]
+pub enum MediatorAffirmationStatus {
+    /// Invalid affirmation status
+    #[default]
+    Unknown,
+    /// The mediator hasn't affirmed the instruction.
+    Pending,
+    /// The mediator has already affirmed the instruction.
+    Affirmed {
+        /// Sets an expiration date for the affirmation.
+        expiry: Option<u64>,
+        /// Registers the time the instruction was affirmed.
+        timestamp: u64,
+    },
 }

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -697,7 +697,7 @@ impl ExecuteInstructionInfo {
 
 /// The status of the mediator's affirmation.
 #[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq, TypeInfo)]
-pub enum MediatorAffirmationStatus {
+pub enum MediatorAffirmationStatus<T> {
     /// Invalid affirmation status
     #[default]
     Unknown,
@@ -706,8 +706,8 @@ pub enum MediatorAffirmationStatus {
     /// The mediator has already affirmed the instruction.
     Affirmed {
         /// Sets an expiration date for the affirmation.
-        expiry: Option<u64>,
+        expiry: Option<T>,
         /// Registers the time the instruction was affirmed.
-        timestamp: u64,
+        timestamp: T,
     },
 }

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -712,7 +712,5 @@ pub enum MediatorAffirmationStatus<T> {
     Affirmed {
         /// Sets an expiration date for the affirmation.
         expiry: Option<T>,
-        /// Registers the time the instruction was affirmed.
-        timestamp: T,
     },
 }


### PR DESCRIPTION
## changelog

### new features
 - Allows instructions and assets to have mediators;
### new external API
- Adds the following storage to the asset pallet: `MandatoryMediators`;
- Adds the following error to the asset pallet: `NumberOfAssetMediatorsExceeded`;
- Adds the following extrinsics to the asset pallet: `add_mandatory_mediators `, `remove_mandatory_mediators`;
- Adds the following storage to the settlement pallet: `InstructionMediatorsAffirmations`;
- Adds the following error to the settlement pallet: `CallerIsNotAMediator`, `InvalidExpiryDate`, `MediatorAffirmationExpired`;
 - Adds the following extrinsics to the settlement pallet: `add_instruction_with_mediators`, `affirm_instruction_as_mediator`, `withdraw_affirmation_as_mediator`, `add_and_affirm_with_mediators`, `reject_instruction_as_mediator`;

### new events
- Adds the following events to the asset pallet: `SetAssetMediators`, `AssetMediatorsRemoved`;
- Adds the following events to the settlement pallet: `MediatorAffirmationReceived`, `MediatorAffirmationWithdrawn`;
