### PR TITLE
Add comment on feature flag.

### DIFF
--- a/contracts/upgradeable-polymesh-ink/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ink",
  "parity-scale-codec",

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -28,6 +28,8 @@ features = ["as-library"]
 
 [features]
 default = ["std"]
+
+# Needs Polymesh >=6.2.0
 use_call_runtime_with_error = ["polymesh-api-ink/use_call_runtime_with_error"]
 
 # Compile as upgradable library.

--- a/contracts/upgradeable-polymesh-ink/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh-ink"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["PolymeshAssociation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.lock
@@ -2112,9 +2112,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polymesh-api"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0447542e190095b2950c3047483a4f676d07be3cce61e095a672ef2197cb28e"
+checksum = "fe458a4721937ff96c6e7765d18d21b71148c398656a17814dfbb72cb62bdb9d"
 dependencies = [
  "ink",
  "log",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-client"
-version = "3.2.5"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9724c8ccc50b2aeb885d9b6906b02bf0a6815cf2e80e6b95dcfd3c6714820f3"
+checksum = "eeac54b128958d9aac03d3f88f43be10ee396c746b7ee329e5794f990c1ff5c7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-codegen"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cb9faabe0fcc9b39b1e58f8de3b0771bb6240dc0ec9643d9b50c1880357eae"
+checksum = "420d0d8d2abb36e1581e373505933620af181c99e788833b4f7714ee2b05e1eb"
 dependencies = [
  "frame-metadata",
  "heck",
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-codegen-macro"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140562a50fce7873d1d1e43bccddf5d1930704352d2d2cafa01c6feaf96c799c"
+checksum = "e165461828beeb9832b9b7a33caa6ebad97a4a900c2f50149df084455170f53c"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-ink"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d34465f4790fc4836dcc35b0ccc033a9bf4cc93d56ad240f381203e46ae279"
+checksum = "37133ff748242241c6ebaaff618b9d7a4e8beb7689ce0c4c2d102c3110dfe9b4"
 dependencies = [
  "hex",
  "ink",
@@ -2211,12 +2211,13 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ink",
  "parity-scale-codec",
  "paste",
  "polymesh-api",
+ "polymesh-api-ink",
  "scale-info",
 ]
 

--- a/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/Cargo.toml
@@ -11,7 +11,7 @@ ink = { version = "4.3", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "3.0.0", path = "../../", default-features = false, features = ["as-library"] }
+polymesh-ink = { version = "3.1.0", path = "../../", default-features = false, features = ["as-library"] }
 
 [lib]
 path = "lib.rs"

--- a/contracts/upgradeable-polymesh-ink/examples/simple/lib.rs
+++ b/contracts/upgradeable-polymesh-ink/examples/simple/lib.rs
@@ -11,16 +11,9 @@ pub mod test_polymesh_ink {
     use crate::*;
     use alloc::vec::Vec;
 
-    /// A simple proxy contract.
+    /// A simple test contract.
     #[ink(storage)]
-    pub struct Proxy {
-        /// The `AccountId` of a privileged account that override the
-        /// code hash for `PolymeshInk`.
-        ///
-        /// This address is set to the account that instantiated this contract.
-        admin: AccountId,
-        /// Upgradable Polymesh Ink API.
-        api: PolymeshInk,
+    pub struct SimpleTest {
     }
 
     /// The contract error types.
@@ -40,58 +33,18 @@ pub mod test_polymesh_ink {
     /// The contract result type.
     pub type Result<T> = core::result::Result<T, Error>;
 
-    impl Proxy {
+    impl SimpleTest {
         /// Instantiate this contract with an address of the `logic` contract.
-        ///
-        /// Sets the privileged account to the caller. Only this account may
-        /// later changed the `forward_to` address.
         #[ink(constructor)]
         pub fn new() -> Result<Self> {
             Ok(Self {
-                admin: Self::env().caller(),
-                api: PolymeshInk::new()?,
             })
-        }
-
-        /// Instantiate this contract with an address of the `logic` contract.
-        ///
-        /// Sets the privileged account to the caller. Only this account may
-        /// later changed the `forward_to` address.
-        #[ink(constructor)]
-        pub fn new_with_hash(hash: Hash) -> Self {
-            Self {
-                admin: Self::env().caller(),
-                api: PolymeshInk::new_with_hash(hash),
-            }
-        }
-
-        /// Update the code hash of the polymesh runtime API.
-        ///
-        /// Only the `admin` is allowed to call this.
-        #[ink(message)]
-        pub fn update_code_hash(&mut self, hash: Hash) {
-            assert_eq!(
-                self.env().caller(),
-                self.admin,
-                "caller {:?} does not have sufficient permissions, only {:?} does",
-                self.env().caller(),
-                self.admin,
-            );
-            self.api.update_code_hash(hash);
-        }
-
-        /// Update the `polymesh-ink` API using the tracker.
-        ///
-        /// Anyone can pay the gas fees to do the update using the tracker.
-        #[ink(message)]
-        pub fn update_polymesh_ink(&mut self) -> Result<()> {
-            self.api.check_for_upgrade()?;
-            Ok(())
         }
 
         #[ink(message)]
         pub fn system_remark(&mut self, remark: Vec<u8>) -> Result<()> {
-            self.api.system_remark(remark)?;
+            let api = PolymeshInk::new()?;
+            api.system_remark(remark)?;
             Ok(())
         }
 
@@ -107,8 +60,8 @@ pub mod test_polymesh_ink {
 
         #[ink(message)]
         pub fn create_venue(&mut self, details: Vec<u8>) -> Result<VenueId> {
-            Ok(self
-                .api
+            let api = PolymeshInk::new()?;
+            Ok(api
                 .create_venue(VenueDetails(details), VenueType::Other)?)
         }
 
@@ -120,7 +73,8 @@ pub mod test_polymesh_ink {
             ticker: Ticker,
             amount: Balance,
         ) -> Result<()> {
-            self.api.asset_create_and_issue(
+            let api = PolymeshInk::new()?;
+            api.asset_create_and_issue(
                 AssetName(name),
                 ticker,
                 AssetType::EquityCommon,

--- a/contracts/upgradeable-polymesh-ink/rust-toolchain.toml
+++ b/contracts/upgradeable-polymesh-ink/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.70.0"
+targets = [ "wasm32-unknown-unknown" ]
+components = [ "rustfmt", "rust-std", "rust-src" ]
+profile = "minimal"

--- a/contracts/wrapped-polyx/Cargo.lock
+++ b/contracts/wrapped-polyx/Cargo.lock
@@ -2112,9 +2112,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polymesh-api"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0447542e190095b2950c3047483a4f676d07be3cce61e095a672ef2197cb28e"
+checksum = "fe458a4721937ff96c6e7765d18d21b71148c398656a17814dfbb72cb62bdb9d"
 dependencies = [
  "ink",
  "log",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-client"
-version = "3.2.5"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9724c8ccc50b2aeb885d9b6906b02bf0a6815cf2e80e6b95dcfd3c6714820f3"
+checksum = "eeac54b128958d9aac03d3f88f43be10ee396c746b7ee329e5794f990c1ff5c7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-codegen"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cb9faabe0fcc9b39b1e58f8de3b0771bb6240dc0ec9643d9b50c1880357eae"
+checksum = "420d0d8d2abb36e1581e373505933620af181c99e788833b4f7714ee2b05e1eb"
 dependencies = [
  "frame-metadata",
  "heck",
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-codegen-macro"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140562a50fce7873d1d1e43bccddf5d1930704352d2d2cafa01c6feaf96c799c"
+checksum = "e165461828beeb9832b9b7a33caa6ebad97a4a900c2f50149df084455170f53c"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "polymesh-api-ink"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d34465f4790fc4836dcc35b0ccc033a9bf4cc93d56ad240f381203e46ae279"
+checksum = "37133ff748242241c6ebaaff618b9d7a4e8beb7689ce0c4c2d102c3110dfe9b4"
 dependencies = [
  "hex",
  "ink",
@@ -2211,12 +2211,15 @@ dependencies = [
 
 [[package]]
 name = "polymesh-ink"
-version = "3.0.0"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdcb55151975f7cfb24299bd523cb44145cbfe7eb0107b7a6d7b6b20cc1d9f3"
 dependencies = [
  "ink",
  "parity-scale-codec",
  "paste",
  "polymesh-api",
+ "polymesh-api-ink",
  "scale-info",
 ]
 
@@ -4347,7 +4350,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wrapped-polyx"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ink",
  "parity-scale-codec",

--- a/contracts/wrapped-polyx/Cargo.toml
+++ b/contracts/wrapped-polyx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped-polyx"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["PolymeshAssociation"]
 edition = "2021"
 publish = false
@@ -11,7 +11,7 @@ ink = { version = "4.3", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-polymesh-ink = { version = "3.0.0", path = "../upgradeable-polymesh-ink/", default-features = false, features = ["as-library"] }
+polymesh-ink = { version = "3.1.0", default-features = false, features = ["as-library"] }
 
 [lib]
 path = "lib.rs"

--- a/contracts/wrapped-polyx/rust-toolchain.toml
+++ b/contracts/wrapped-polyx/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.70.0"
+targets = [ "wasm32-unknown-unknown" ]
+components = [ "rustfmt", "rust-std", "rust-src" ]
+profile = "minimal"


### PR DESCRIPTION
Just adds a comment on the feature flag about requiring Polymesh v6.2+.

Also bump the minor version since 3.0.0 was released on Staging/Testnet without support for CallRuntimeWithError