### PR TITLE
Improvements to the Asset Pallet

### DIFF
--- a/pallets/asset/src/error.rs
+++ b/pallets/asset/src/error.rs
@@ -83,6 +83,10 @@ decl_error! {
         /// Number of asset mediators would exceed the maximum allowed.
         NumberOfAssetMediatorsExceeded,
         /// Invalid ticker character - valid set: A`..`Z` `0`..`9` `_` `-` `.` `/`.
-        InvalidTickerCharacter
+        InvalidTickerCharacter,
+        /// Failed to transfer the asset - asset is frozen.
+        InvalidTransferFrozenAsset,
+        /// Failed to transfer an NFT - compliance failed.
+        InvalidTransferComplianceFailure
     }
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -950,7 +950,7 @@ impl<T: Config> Module<T> {
             divisible,
             asset_type,
             identifiers,
-            funding_round_name.clone(),
+            funding_round_name,
         )?;
 
         Ok(caller_data.primary_did)
@@ -1243,7 +1243,7 @@ impl<T: Config> Module<T> {
             divisible,
             asset_type,
             identifiers,
-            funding_round_name.clone(),
+            funding_round_name,
         )?;
 
         Ok(())

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -68,9 +68,6 @@
 //! - `extension_details` - It provides the list of Smart extension added for the given tokens.
 //! - `extensions` - It provides the list of Smart extension added for the given tokens and for the given type.
 //! - `frozen` - It tells whether the given ticker is frozen or not.
-//! - `is_ticker_available` - It checks whether the given ticker is available or not.
-//! - `is_ticker_registry_valid` - It checks whether the ticker is owned by a given IdentityId or not.
-//! - `is_ticker_available_or_registered_to` - It provides the status of a given ticker.
 //! - `total_supply` - It provides the total supply of a ticker.
 //! - `get_balance_at` - It provides the balance of a DID at a certain checkpoint.
 
@@ -84,24 +81,21 @@ pub mod checkpoint;
 mod error;
 mod types;
 
-use arrayvec::ArrayVec;
 use codec::{Decode, Encode};
 use core::mem;
-use core::result::Result as StdResult;
 use currency::*;
-use frame_support::dispatch::{DispatchError, DispatchResult, Weight};
-use frame_support::traits::{Get, PalletInfoAccess};
+use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::traits::Get;
 use frame_support::BoundedBTreeSet;
-use frame_support::{decl_module, decl_storage, ensure, fail};
+use frame_support::{decl_module, decl_storage, ensure};
 use frame_system::ensure_root;
 use sp_runtime::traits::Zero;
 use sp_std::collections::btree_set::BTreeSet;
-use sp_std::{convert::TryFrom, prelude::*};
+use sp_std::prelude::*;
 
 use pallet_base::{
     ensure_opt_string_limited, ensure_string_limited, try_next_pre, Error::CounterOverflow,
 };
-use pallet_identity::PermissionedCallOriginData;
 use polymesh_common_utilities::asset::AssetFnTrait;
 use polymesh_common_utilities::compliance_manager::ComplianceFnConfig;
 use polymesh_common_utilities::constants::*;
@@ -130,7 +124,6 @@ use polymesh_primitives::{
 pub use error::Error;
 pub use types::{
     AssetOwnershipRelation, SecurityToken, TickerRegistration, TickerRegistrationConfig,
-    TickerRegistrationStatus,
 };
 
 type Checkpoint<T> = checkpoint::Module<T>;
@@ -173,10 +166,10 @@ decl_storage! {
 
         /// The name of the current funding round.
         /// ticker -> funding round
-        FundingRound get(fn funding_round): map hasher(blake2_128_concat) Ticker => FundingRoundName;
+        pub FundingRound get(fn funding_round): map hasher(blake2_128_concat) Ticker => FundingRoundName;
         /// The total balances of tokens issued in all recorded funding rounds.
         /// (ticker, funding round) -> balance
-        IssuedInFundingRound get(fn issued_in_funding_round): map hasher(blake2_128_concat) (Ticker, FundingRoundName) => Balance;
+        pub IssuedInFundingRound get(fn issued_in_funding_round): map hasher(blake2_128_concat) (Ticker, FundingRoundName) => Balance;
         /// The set of frozen assets implemented as a membership map.
         /// ticker -> bool
         pub Frozen get(fn frozen): map hasher(blake2_128_concat) Ticker => bool;
@@ -252,7 +245,7 @@ decl_storage! {
             // Reserving country currency logic
             let fiat_tickers_reservation_did = polymesh_common_utilities::SystematicIssuers::FiatTickersReservation.as_id();
             for currency_ticker in &config.reserved_country_currency_codes {
-                <Module<T>>::unverified_register_ticker(&currency_ticker, fiat_tickers_reservation_did, None);
+                let _ = <Module<T>>::unverified_register_ticker(*currency_ticker, fiat_tickers_reservation_did, None);
             }
         });
     }
@@ -272,25 +265,6 @@ decl_module! {
         const AssetMetadataNameMaxLength: u32 = T::AssetMetadataNameMaxLength::get();
         const AssetMetadataValueMaxLength: u32 = T::AssetMetadataValueMaxLength::get();
         const AssetMetadataTypeDefMaxLength: u32 = T::AssetMetadataTypeDefMaxLength::get();
-
-        // Remove all storage related to classic tickers in this module
-        fn on_runtime_upgrade() -> Weight {
-            use polymesh_primitives::storage_migrate_on;
-            storage_migrate_on!(StorageVersion, 3, {
-                let prefixes = &[
-                    "BalanceOfAtScope",
-                    "AggregateBalance",
-                    "ScopeIdOf",
-                    "DisableInvestorUniqueness",
-                ];
-                for prefix in prefixes {
-                    let res = frame_support::storage::migration::clear_storage_prefix(<Pallet<T>>::name().as_bytes(), prefix.as_bytes(), b"", None, None);
-                    log::info!("Cleared storage prefix[{prefix}]: cursor={:?}, backend={}, unique={}, loops={}",
-                        res.maybe_cursor, res.backend, res.unique, res.loops);
-                }
-            });
-            Weight::zero()
-        }
 
         /// Registers a new ticker or extends validity of an existing ticker.
         /// NB: Ticker validity does not get carry forward when renewing ticker.
@@ -372,8 +346,8 @@ decl_module! {
             identifiers: Vec<AssetIdentifier>,
             funding_round: Option<FundingRoundName>,
         ) -> DispatchResult {
-            Self::base_create_asset(origin, name, ticker, divisible, asset_type, identifiers, funding_round)
-                .map(drop)
+            Self::base_create_asset(origin, name, ticker, divisible, asset_type, identifiers, funding_round)?;
+            Ok(())
         }
 
         /// Freezes transfers of a given token.
@@ -571,7 +545,8 @@ decl_module! {
         /// * `ty` contains the string representation of the asset type.
         #[weight = <T as Config>::WeightInfo::register_custom_asset_type(ty.len() as u32)]
         pub fn register_custom_asset_type(origin, ty: Vec<u8>) -> DispatchResult {
-            Self::base_register_custom_asset_type(origin, ty).map(drop)
+            Self::base_register_custom_asset_type(origin, ty)?;
+            Ok(())
         }
 
         /// Utility extrinsic to batch `create_asset` and `register_custom_asset_type`.
@@ -589,20 +564,14 @@ decl_module! {
             identifiers: Vec<AssetIdentifier>,
             funding_round: Option<FundingRoundName>,
         ) -> DispatchResult {
-            let origin_data = Identity::<T>::ensure_origin_call_permissions(origin)?;
-            let asset_type_id = Self::unsafe_register_custom_asset_type(
-                origin_data.primary_did,
-                custom_asset_type,
-            )?;
-            Self::unsafe_create_asset(
-                origin_data.primary_did,
-                origin_data.secondary_key,
-                name,
+            Self::base_create_asset_with_custom_type(
+                origin,
                 ticker,
+                name,
                 divisible,
-                AssetType::Custom(asset_type_id),
+                custom_asset_type,
                 identifiers,
-                funding_round,
+                funding_round
             )?;
             Ok(())
         }
@@ -886,14 +855,21 @@ decl_module! {
 //==========================================================================
 
 impl<T: Config> Module<T> {
+    /// Registers `ticker` to the caller.
     fn base_register_ticker(origin: T::RuntimeOrigin, ticker: Ticker) -> DispatchResult {
-        let to_did = Identity::<T>::ensure_perms(origin)?;
-        let expiry = Self::ticker_registration_checks(&ticker, to_did, false, || {
-            Self::ticker_registration_config()
-        })?;
+        let caller_did = Identity::<T>::ensure_perms(origin)?;
 
-        T::ProtocolFee::charge_fee(ProtocolOp::AssetRegisterTicker)?;
-        Self::unverified_register_ticker(&ticker, to_did, expiry);
+        let ticker_registration_config = Self::ticker_registration_config();
+        Self::validate_ticker_registration_rules(
+            &ticker,
+            &caller_did,
+            ticker_registration_config.max_ticker_length,
+        )?;
+
+        let expiry = ticker_registration_config
+            .registration_length
+            .map(|x| <pallet_timestamp::Pallet<T>>::get() + x);
+        Self::unverified_register_ticker(ticker, caller_did, expiry)?;
 
         Ok(())
     }
@@ -904,7 +880,7 @@ impl<T: Config> Module<T> {
         <Identity<T>>::accept_auth_with(&to.into(), auth_id, |data, auth_by| {
             let ticker = extract_auth!(data, TransferTicker(t));
 
-            Self::ensure_asset_fresh(&ticker)?;
+            Self::ensure_asset_doesnt_exist(&ticker)?;
 
             let reg =
                 Self::ticker_registration(&ticker).ok_or(Error::<T>::TickerRegistrationExpired)?;
@@ -943,30 +919,41 @@ impl<T: Config> Module<T> {
         })
     }
 
+    /// Creates a new asset.
     fn base_create_asset(
         origin: T::RuntimeOrigin,
-        name: AssetName,
+        asset_name: AssetName,
         ticker: Ticker,
         divisible: bool,
         asset_type: AssetType,
         identifiers: Vec<AssetIdentifier>,
-        funding_round: Option<FundingRoundName>,
+        funding_round_name: Option<FundingRoundName>,
     ) -> Result<IdentityId, DispatchError> {
-        let PermissionedCallOriginData {
-            primary_did,
-            secondary_key,
-            ..
-        } = Identity::<T>::ensure_origin_call_permissions(origin)?;
-        Self::unsafe_create_asset(
-            primary_did,
-            secondary_key,
-            name,
+        let caller_data = Identity::<T>::ensure_origin_call_permissions(origin)?;
+
+        let token_did = Identity::<T>::get_token_did(&ticker)?;
+        Self::validate_asset_creation_rules(
+            caller_data.primary_did,
+            caller_data.secondary_key,
+            token_did,
+            &ticker,
+            &asset_name,
+            &asset_type,
+            funding_round_name.clone(),
+        )?;
+
+        Self::unverified_create_asset(
+            caller_data.primary_did,
+            token_did,
             ticker,
             divisible,
+            asset_name,
             asset_type,
+            funding_round_name,
             identifiers,
-            funding_round,
-        )
+        )?;
+
+        Ok(caller_data.primary_did)
     }
 
     fn base_set_freeze(origin: T::RuntimeOrigin, ticker: Ticker, freeze: bool) -> DispatchResult {
@@ -991,14 +978,14 @@ impl<T: Config> Module<T> {
     fn base_rename_asset(
         origin: T::RuntimeOrigin,
         ticker: Ticker,
-        name: AssetName,
+        asset_name: AssetName,
     ) -> DispatchResult {
-        Self::ensure_asset_name_bounded(&name)?;
+        Self::ensure_valid_asset_name(&asset_name)?;
         Self::ensure_asset_exists(&ticker)?;
-        let did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
 
-        AssetNames::insert(&ticker, name.clone());
-        Self::deposit_event(RawEvent::AssetRenamed(did, ticker, name));
+        AssetNames::insert(&ticker, asset_name.clone());
+        Self::deposit_event(RawEvent::AssetRenamed(caller_did, ticker, asset_name));
         Ok(())
     }
 
@@ -1160,13 +1147,17 @@ impl<T: Config> Module<T> {
     fn base_set_funding_round(
         origin: T::RuntimeOrigin,
         ticker: Ticker,
-        name: FundingRoundName,
+        funding_round_name: FundingRoundName,
     ) -> DispatchResult {
-        Self::ensure_funding_round_name_bounded(&name)?;
-        let did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
+        Self::ensure_valid_funding_round_name(&funding_round_name)?;
+        let caller_did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
 
-        FundingRound::insert(ticker, name.clone());
-        Self::deposit_event(RawEvent::FundingRoundSet(did, ticker, name));
+        FundingRound::insert(ticker, funding_round_name.clone());
+        Self::deposit_event(RawEvent::FundingRoundSet(
+            caller_did,
+            ticker,
+            funding_round_name,
+        ));
         Ok(())
     }
 
@@ -1215,12 +1206,58 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
+    /// Registers a new custom asset type.
     fn base_register_custom_asset_type(
         origin: T::RuntimeOrigin,
-        ty: Vec<u8>,
-    ) -> Result<CustomAssetTypeId, DispatchError> {
-        let did = Identity::<T>::ensure_perms(origin)?;
-        Self::unsafe_register_custom_asset_type(did, ty)
+        asset_type_bytes: Vec<u8>,
+    ) -> DispatchResult {
+        let caller_did = Identity::<T>::ensure_perms(origin)?;
+        Self::validate_custom_asset_type_rules(&asset_type_bytes)?;
+
+        Self::unverified_register_custom_asset_type(caller_did, asset_type_bytes)?;
+        Ok(())
+    }
+
+    /// Creates an asset with [`AssetType::Custom`].
+    fn base_create_asset_with_custom_type(
+        origin: T::RuntimeOrigin,
+        ticker: Ticker,
+        asset_name: AssetName,
+        divisible: bool,
+        asset_type_bytes: Vec<u8>,
+        identifiers: Vec<AssetIdentifier>,
+        funding_round_name: Option<FundingRoundName>,
+    ) -> DispatchResult {
+        let caller_data = Identity::<T>::ensure_origin_call_permissions(origin)?;
+
+        Self::validate_custom_asset_type_rules(&asset_type_bytes)?;
+        let custom_asset_type_id =
+            Self::unverified_register_custom_asset_type(caller_data.primary_did, asset_type_bytes)?;
+        let asset_type = AssetType::Custom(custom_asset_type_id);
+
+        let token_did = Identity::<T>::get_token_did(&ticker)?;
+        Self::validate_asset_creation_rules(
+            caller_data.primary_did,
+            caller_data.secondary_key,
+            token_did,
+            &ticker,
+            &asset_name,
+            &asset_type,
+            funding_round_name.clone(),
+        )?;
+
+        Self::unverified_create_asset(
+            caller_data.primary_did,
+            token_did,
+            ticker,
+            divisible,
+            asset_name,
+            asset_type,
+            funding_round_name,
+            identifiers,
+        )?;
+
+        Ok(())
     }
 
     fn base_set_asset_metadata(
@@ -1336,7 +1373,7 @@ impl<T: Config> Module<T> {
         asset_type: AssetType,
     ) -> DispatchResult {
         Self::ensure_asset_exists(&ticker)?;
-        Self::ensure_asset_type_valid(asset_type)?;
+        Self::ensure_valid_asset_type(&asset_type)?;
         let did = <ExternalAgents<T>>::ensure_perms(origin, ticker)?;
         Tokens::try_mutate(&ticker, |token| -> DispatchResult {
             let token = token.as_mut().ok_or(Error::<T>::NoSuchAsset)?;
@@ -1524,14 +1561,13 @@ impl<T: Config> Module<T> {
         // The only place this function is used right now is the settlement engine and the settlement engine
         // checks custodial permissions when the instruction is authorized.
 
-        // Validate the transfer
-        let is_transfer_success =
-            Self::_is_valid_transfer(&ticker, from_portfolio, to_portfolio, value, weight_meter)?;
-
-        ensure!(
-            is_transfer_success == ERC1400_TRANSFER_SUCCESS,
-            Error::<T>::InvalidTransfer
-        );
+        Self::validate_asset_transfer(
+            &ticker,
+            &from_portfolio,
+            &to_portfolio,
+            value,
+            weight_meter,
+        )?;
 
         Self::unsafe_transfer(
             from_portfolio,
@@ -1553,33 +1589,22 @@ impl<T: Config> Module<T> {
 //==========================================================================
 
 impl<T: Config> Module<T> {
-    /// Before registering a ticker, do some checks, and return the expiry moment.
-    fn ticker_registration_checks(
+    /// Returns `Ok` if all registration rules are satisfied.
+    fn validate_ticker_registration_rules(
         ticker: &Ticker,
-        to_did: IdentityId,
-        no_re_register: bool,
-        config: impl FnOnce() -> TickerRegistrationConfig<T::Moment>,
-    ) -> Result<Option<T::Moment>, DispatchError> {
+        ticker_owner_did: &IdentityId,
+        max_ticker_length: u8,
+    ) -> DispatchResult {
         Self::verify_ticker_characters(&ticker)?;
-        Self::ensure_asset_fresh(&ticker)?;
+        Self::ensure_asset_doesnt_exist(&ticker)?;
 
-        let config = config();
+        Self::ensure_ticker_length(ticker, max_ticker_length)?;
 
-        // Ensure the ticker is not too long.
-        Self::ensure_ticker_length(&ticker, &config)?;
-
-        // Ensure that the ticker is not registered by someone else (or `to_did`, possibly).
-        if match Self::is_ticker_available_or_registered_to(&ticker, to_did) {
-            TickerRegistrationStatus::RegisteredByOther => true,
-            TickerRegistrationStatus::RegisteredByDid => no_re_register,
-            _ => false,
-        } {
-            fail!(Error::<T>::TickerAlreadyRegistered);
+        if !Self::can_reregister_ticker(ticker, ticker_owner_did) {
+            return Err(Error::<T>::TickerAlreadyRegistered.into());
         }
 
-        Ok(config
-            .registration_length
-            .map(|exp| <pallet_timestamp::Pallet<T>>::get() + exp))
+        Ok(())
     }
 
     /// Returns `Ok` if the ticker contains only the following characters: `A`..`Z` `0`..`9` `_` `-` `.` `/`.
@@ -1608,8 +1633,8 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    /// Ensure asset `ticker` doesn't exist yet.
-    fn ensure_asset_fresh(ticker: &Ticker) -> DispatchResult {
+    /// Returns `Ok` if `ticker` doensn't exist. Otherwise, returns [`Error::AssetAlreadyCreated`].
+    fn ensure_asset_doesnt_exist(ticker: &Ticker) -> DispatchResult {
         ensure!(
             !Tokens::contains_key(ticker),
             Error::<T>::AssetAlreadyCreated
@@ -1617,66 +1642,102 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    /// Ensure ticker length is within limit per `config`.
-    fn ensure_ticker_length<U>(
-        ticker: &Ticker,
-        config: &TickerRegistrationConfig<U>,
-    ) -> DispatchResult {
+    /// Returns `Ok` if `ticker` length is less or equal to `max_ticker_length`. Otherwise, returns [`Error::TickerTooLong`].
+    fn ensure_ticker_length(ticker: &Ticker, max_ticker_length: u8) -> DispatchResult {
         ensure!(
-            ticker.len() <= usize::try_from(config.max_ticker_length).unwrap_or_default(),
+            ticker.len() <= max_ticker_length as usize,
             Error::<T>::TickerTooLong
         );
         Ok(())
     }
 
-    /// Returns:
-    /// - `RegisteredByOther` if ticker is registered to someone else.
-    /// - `Available` if ticker is available for registry.
-    /// - `RegisteredByDid` if ticker is already registered to provided did.
-    fn is_ticker_available_or_registered_to(
-        ticker: &Ticker,
-        did: IdentityId,
-    ) -> TickerRegistrationStatus {
-        // Assumes uppercase ticker
-        match Self::maybe_ticker(ticker) {
-            Some(TickerRegistration { expiry, owner }) => match expiry {
-                // Ticker registered to someone but expired and can be registered again.
-                Some(expiry) if <pallet_timestamp::Pallet<T>>::get() > expiry => {
-                    TickerRegistrationStatus::Available
+    /// Returns `false`` if the ticker hasn't expired and was registered by a different caller. Otherwise, returns `true`.
+    fn can_reregister_ticker(ticker: &Ticker, caller_did: &IdentityId) -> bool {
+        match <Tickers<T>>::get(ticker) {
+            Some(ticker_registration) => {
+                if &ticker_registration.owner == caller_did {
+                    return true;
                 }
-                // Ticker is already registered to provided did (may or may not expire in future).
-                _ if owner == did => TickerRegistrationStatus::RegisteredByDid,
-                // Ticker registered to someone else and hasn't expired.
-                _ => TickerRegistrationStatus::RegisteredByOther,
-            },
-            // Ticker not registered yet.
-            None => TickerRegistrationStatus::Available,
+
+                match ticker_registration.expiry {
+                    Some(expiration_time) => {
+                        if <pallet_timestamp::Pallet<T>>::get() > expiration_time {
+                            return true;
+                        }
+                        false
+                    }
+                    None => return false,
+                }
+            }
+            None => true,
         }
     }
 
-    fn maybe_ticker(ticker: &Ticker) -> Option<TickerRegistration<T::Moment>> {
-        <Tickers<T>>::get(ticker)
+    /// Returns `Ok` if all rules for creating an asset are satisfied.
+    fn validate_asset_creation_rules(
+        caller_did: IdentityId,
+        secondary_key: Option<SecondaryKey<T::AccountId>>,
+        token_did: IdentityId,
+        ticker: &Ticker,
+        asset_name: &AssetName,
+        asset_type: &AssetType,
+        funding_round_name: Option<FundingRoundName>,
+    ) -> DispatchResult {
+        if let Some(funding_round_name) = funding_round_name {
+            Self::ensure_valid_funding_round_name(&funding_round_name)?;
+        }
+        Self::ensure_valid_asset_name(asset_name)?;
+        Self::ensure_valid_asset_type(asset_type)?;
+
+        let ticker_registration_config = Self::ticker_registration_config();
+        Self::validate_ticker_registration_rules(
+            ticker,
+            &caller_did,
+            ticker_registration_config.max_ticker_length,
+        )?;
+
+        // Ensure there's no pre-existing entry for the DID.
+        Identity::<T>::ensure_no_id_record(token_did)?;
+
+        // Ensure that the caller has relevant portfolio permissions
+        Portfolio::<T>::ensure_portfolio_custody_and_permission(
+            PortfolioId::default_portfolio(caller_did),
+            caller_did,
+            secondary_key.as_ref(),
+        )?;
+        Ok(())
     }
 
     pub fn token_details(ticker: &Ticker) -> Result<SecurityToken, DispatchError> {
         Ok(Tokens::try_get(ticker).or(Err(Error::<T>::NoSuchAsset))?)
     }
 
-    /// Ensure `name` is within the global limit for asset name lengths.
-    fn ensure_funding_round_name_bounded(name: &FundingRoundName) -> DispatchResult {
+    /// Returns `Ok` if `funding_round_name` is valid. Otherwise, returns [`Error::<T>::FundingRoundNameMaxLengthExceeded`].
+    fn ensure_valid_funding_round_name(funding_round_name: &FundingRoundName) -> DispatchResult {
         ensure!(
-            name.len() as u32 <= T::FundingRoundNameMaxLength::get(),
+            funding_round_name.len() <= T::FundingRoundNameMaxLength::get() as usize,
             Error::<T>::FundingRoundNameMaxLengthExceeded
         );
         Ok(())
     }
 
-    /// Ensure `name` is within the global limit for asset name lengths.
-    fn ensure_asset_name_bounded(name: &AssetName) -> DispatchResult {
+    /// Returns `Ok` if `asset_name` is valid. Otherwise, returns [`Error::<T>::MaxLengthOfAssetNameExceeded`].
+    fn ensure_valid_asset_name(asset_name: &AssetName) -> DispatchResult {
         ensure!(
-            name.len() as u32 <= T::AssetNameMaxLength::get(),
+            asset_name.len() <= T::AssetNameMaxLength::get() as usize,
             Error::<T>::MaxLengthOfAssetNameExceeded
         );
+        Ok(())
+    }
+
+    /// Returns `Ok` if `asset_type` is valid. Otherwise, returns [`Error::<T>::InvalidCustomAssetTypeId`].
+    fn ensure_valid_asset_type(asset_type: &AssetType) -> DispatchResult {
+        if let AssetType::Custom(custom_type_id) = asset_type {
+            ensure!(
+                CustomTypes::contains_key(custom_type_id),
+                Error::<T>::InvalidCustomAssetTypeId
+            );
+        }
         Ok(())
     }
 
@@ -1687,12 +1748,6 @@ impl<T: Config> Module<T> {
             Error::<T>::InvalidAssetIdentifier
         );
         Ok(())
-    }
-
-    /// Performs necessary checks on parameters of `create_asset`.
-    fn ensure_create_asset_parameters(ticker: &Ticker) -> DispatchResult {
-        Self::ensure_asset_fresh(&ticker)?;
-        Self::ensure_ticker_length(&ticker, &Self::ticker_registration_config())
     }
 
     /// Ensures that `origin` is a permissioned agent for `ticker`, that the portfolio is valid and that calller
@@ -1715,6 +1770,12 @@ impl<T: Config> Module<T> {
             portfolio_id,
         )?;
         Ok(portfolio_id)
+    }
+
+    /// Returns `Ok` if all rules for creating a custom type are satisfied.
+    fn validate_custom_asset_type_rules(asset_type_bytes: &[u8]) -> DispatchResult {
+        ensure_string_limited::<T>(asset_type_bytes)?;
+        Ok(())
     }
 
     fn ensure_granular(ticker: &Ticker, value: Balance) -> DispatchResult {
@@ -1756,18 +1817,6 @@ impl<T: Config> Module<T> {
     /// Ensure that `ticker` is a valid created asset.
     fn ensure_asset_exists(ticker: &Ticker) -> DispatchResult {
         ensure!(Tokens::contains_key(&ticker), Error::<T>::NoSuchAsset);
-        Ok(())
-    }
-
-    /// Ensure `AssetType` is valid.
-    /// This checks that the `AssetType::Custom(custom_type_id)` is valid.
-    fn ensure_asset_type_valid(asset_type: AssetType) -> DispatchResult {
-        if let AssetType::Custom(custom_type_id) = asset_type {
-            ensure!(
-                CustomTypes::contains_key(custom_type_id),
-                Error::<T>::InvalidCustomAssetTypeId
-            );
-        }
         Ok(())
     }
 
@@ -1829,77 +1878,47 @@ impl<T: Config> Module<T> {
             .unwrap_or_else(|| Self::balance_of(&ticker, &did))
     }
 
-    pub fn _is_valid_transfer(
+    pub fn validate_asset_transfer(
         ticker: &Ticker,
-        from_portfolio: PortfolioId,
-        to_portfolio: PortfolioId,
+        sender_portfolio: &PortfolioId,
+        receiver_portfolio: &PortfolioId,
         value: Balance,
         weight_meter: &mut WeightMeter,
-    ) -> StdResult<u8, DispatchError> {
-        if Self::frozen(ticker) {
-            return Ok(ERC1400_TRANSFERS_HALTED);
-        }
+    ) -> DispatchResult {
+        // Verifies that the asset is not frozen
+        ensure!(!Frozen::get(ticker), Error::<T>::InvalidTransferFrozenAsset);
 
-        if Self::portfolio_failure(&from_portfolio, &to_portfolio, ticker, value) {
-            return Ok(PORTFOLIO_FAILURE);
-        }
-
-        if Self::statistics_failures(
-            &from_portfolio.did,
-            &to_portfolio.did,
-            ticker,
-            value,
-            weight_meter,
-        ) {
-            return Ok(TRANSFER_MANAGER_FAILURE);
-        }
-
-        if !T::ComplianceManager::is_compliant(
-            ticker,
-            from_portfolio.did,
-            to_portfolio.did,
-            weight_meter,
-        )? {
-            return Ok(COMPLIANCE_MANAGER_FAILURE);
-        }
-
-        Ok(ERC1400_TRANSFER_SUCCESS)
-    }
-
-    fn portfolio_failure(
-        from_portfolio: &PortfolioId,
-        to_portfolio: &PortfolioId,
-        ticker: &Ticker,
-        value: Balance,
-    ) -> bool {
+        // Verifies that both portfolios exist an that the sender has sufficient balance
         Portfolio::<T>::ensure_portfolio_transfer_validity(
-            from_portfolio,
-            to_portfolio,
+            sender_portfolio,
+            receiver_portfolio,
             ticker,
             value,
-        )
-        .is_err()
-    }
+        )?;
 
-    fn statistics_failures(
-        from_did: &IdentityId,
-        to_did: &IdentityId,
-        ticker: &Ticker,
-        value: Balance,
-        weight_meter: &mut WeightMeter,
-    ) -> bool {
-        let total_supply = Self::total_supply(ticker);
+        // Verifies that the statistics restrictions are satisfied
         Statistics::<T>::verify_transfer_restrictions(
             ticker,
-            from_did,
-            to_did,
-            Self::balance_of(ticker, from_did),
-            Self::balance_of(ticker, to_did),
+            &sender_portfolio.did,
+            &receiver_portfolio.did,
+            Self::balance_of(ticker, sender_portfolio.did),
+            Self::balance_of(ticker, receiver_portfolio.did),
             value,
-            total_supply,
+            Self::total_supply(ticker),
             weight_meter,
-        )
-        .is_err()
+        )?;
+
+        // Verifies that all compliance rules are being respected
+        if !T::ComplianceManager::is_compliant(
+            ticker,
+            sender_portfolio.did,
+            receiver_portfolio.did,
+            weight_meter,
+        )? {
+            return Err(Error::<T>::InvalidTransferComplianceFailure.into());
+        }
+
+        Ok(())
     }
 
     // Get the total supply of an asset `id`.
@@ -1915,24 +1934,26 @@ impl<T: Config> Module<T> {
 //==========================================================================
 
 impl<T: Config> Module<T> {
-    /// Registers the given `ticker` to the `owner` identity with an optional expiry time.
-    ///
-    /// ## Expected constraints
-    /// - `owner` should be a valid IdentityId.
-    /// - `ticker` should be valid, please see `ticker_registration_checks`.
-    /// - `ticker` should be available or already registered by `owner`.
-    fn unverified_register_ticker(ticker: &Ticker, owner: IdentityId, expiry: Option<T::Moment>) {
-        if let Some(ticker_details) = Self::maybe_ticker(ticker) {
-            AssetOwnershipRelations::remove(ticker_details.owner, ticker);
+    /// All storage writes for registering `ticker` to `owner` with an optional `expiry`.
+    /// Note: One fee is charged ([`ProtocolOp::AssetRegisterTicker`]).
+    fn unverified_register_ticker(
+        ticker: Ticker,
+        owner: IdentityId,
+        expiry: Option<T::Moment>,
+    ) -> DispatchResult {
+        T::ProtocolFee::charge_fee(ProtocolOp::AssetRegisterTicker)?;
+
+        // If the ticker was already registered, removes the previous owner
+        if let Some(ticker_registration) = <Tickers<T>>::get(ticker) {
+            AssetOwnershipRelations::remove(&ticker_registration.owner, &ticker);
         }
 
-        let ticker_registration = TickerRegistration { owner, expiry };
-
-        // Store ticker registration details
-        <Tickers<T>>::insert(ticker, ticker_registration);
+        // Write the ticker registration data to the storage
+        <Tickers<T>>::insert(ticker, TickerRegistration { owner, expiry });
         AssetOwnershipRelations::insert(owner, ticker, AssetOwnershipRelation::TickerOwned);
 
-        Self::deposit_event(RawEvent::TickerRegistered(owner, *ticker, expiry));
+        Self::deposit_event(RawEvent::TickerRegistered(owner, ticker, expiry));
+        Ok(())
     }
 
     /// Transfer the given `ticker`'s registration from `req.owner` to `to`.
@@ -1945,116 +1966,45 @@ impl<T: Config> Module<T> {
         Self::deposit_event(RawEvent::TickerTransferred(to, ticker, from));
     }
 
-    fn unsafe_create_asset(
-        did: IdentityId,
-        secondary_key: Option<SecondaryKey<T::AccountId>>,
-        name: AssetName,
+    /// All storage writes for creating an asset.
+    /// Note: two fees are charged ([`ProtocolOp::AssetCreateAsset`] and [`ProtocolOp::AssetRegisterTicker`]).
+    fn unverified_create_asset(
+        caller_did: IdentityId,
+        token_did: IdentityId,
         ticker: Ticker,
         divisible: bool,
+        asset_name: AssetName,
         asset_type: AssetType,
+        funding_round_name: Option<FundingRoundName>,
         identifiers: Vec<AssetIdentifier>,
-        funding_round: Option<FundingRoundName>,
-    ) -> Result<IdentityId, DispatchError> {
-        Self::ensure_asset_name_bounded(&name)?;
-        if let Some(fr) = &funding_round {
-            Self::ensure_funding_round_name_bounded(fr)?;
-        }
-        Self::ensure_asset_idents_valid(&identifiers)?;
-        Self::ensure_asset_type_valid(asset_type)?;
-
-        Self::ensure_create_asset_parameters(&ticker)?;
-
-        // Ensure its registered by DID or at least expired, thus available.
-        let available = match Self::is_ticker_available_or_registered_to(&ticker, did) {
-            TickerRegistrationStatus::RegisteredByOther => {
-                fail!(Error::<T>::TickerAlreadyRegistered)
-            }
-            TickerRegistrationStatus::RegisteredByDid => false,
-            TickerRegistrationStatus::Available => true,
-        };
-
-        // If `ticker` isn't registered, it will be, so ensure it is fully ascii.
-        if available {
-            Self::verify_ticker_characters(&ticker)?;
-        }
-
-        let token_did = Identity::<T>::get_token_did(&ticker)?;
-        // Ensure there's no pre-existing entry for the DID.
-        // This should never happen, but let's be defensive here.
-        Identity::<T>::ensure_no_id_record(token_did)?;
-
-        // Ensure that the caller has relevant portfolio permissions
-        let user_default_portfolio = PortfolioId::default_portfolio(did);
-        Portfolio::<T>::ensure_portfolio_custody_and_permission(
-            user_default_portfolio,
-            did,
-            secondary_key.as_ref(),
-        )?;
-
-        // Charge protocol fees.
-        T::ProtocolFee::charge_fees(&{
-            let mut fees = ArrayVec::<_, 2>::new();
-            if available {
-                fees.push(ProtocolOp::AssetRegisterTicker);
-                fees.push(ProtocolOp::AssetCreateAsset);
-            }
-            fees
-        })?;
-
-        //==========================================================================
-        // At this point all checks have been made; **only** storage changes follow!
-        //==========================================================================
+    ) -> DispatchResult {
+        T::ProtocolFee::charge_fee(ProtocolOp::AssetCreateAsset)?;
+        Self::unverified_register_ticker(ticker, caller_did, None)?;
 
         Identity::<T>::commit_token_did(token_did, ticker);
+        let token = SecurityToken::new(Zero::zero(), caller_did, divisible, asset_type);
+        Tokens::insert(ticker, token);
 
-        // Register the ticker or finish its registration.
-        if available {
-            // Ticker not registered by anyone (or registry expired), so register.
-            Self::unverified_register_ticker(&ticker, did, None);
-        } else {
-            // Ticker already registered by the user.
-            <Tickers<T>>::mutate(&ticker, |tr| {
-                if let Some(tr) = tr {
-                    tr.expiry = None;
-                }
-            });
+        AssetNames::insert(ticker, asset_name.clone());
+        if let Some(ref funding_round_name) = funding_round_name {
+            FundingRound::insert(ticker, funding_round_name);
         }
+        Self::unverified_update_idents(caller_did, ticker, identifiers.clone());
+        // Grant owner full agent permissions.
+        <ExternalAgents<T>>::unchecked_add_agent(ticker, caller_did, AgentGroup::Full)?;
 
-        let token = SecurityToken {
-            total_supply: Zero::zero(),
-            owner_did: did,
-            divisible,
-            asset_type,
-        };
-        Tokens::insert(&ticker, token);
-        AssetNames::insert(&ticker, &name);
-        // NB - At the time of asset creation it is obvious that the asset issuer will not have an
-        // `InvestorUniqueness` claim. So we are skipping the scope claim based stats update as
-        // those data points will get added in to the system whenever the asset issuer
-        // has an InvestorUniqueness claim. This also applies when issuing assets.
-        AssetOwnershipRelations::insert(did, ticker, AssetOwnershipRelation::AssetOwned);
+        AssetOwnershipRelations::insert(caller_did, ticker, AssetOwnershipRelation::AssetOwned);
         Self::deposit_event(RawEvent::AssetCreated(
-            did,
+            caller_did,
             ticker,
             divisible,
             asset_type,
-            did,
-            name,
-            identifiers.clone(),
-            funding_round.clone(),
+            caller_did,
+            asset_name,
+            identifiers,
+            funding_round_name,
         ));
-
-        // Add funding round name.
-        if let Some(funding_round) = funding_round {
-            FundingRound::insert(ticker, funding_round);
-        }
-
-        Self::unverified_update_idents(did, ticker, identifiers);
-
-        // Grant owner full agent permissions.
-        <ExternalAgents<T>>::unchecked_add_agent(ticker, did, AgentGroup::Full).unwrap();
-
-        Ok(did)
+        Ok(())
     }
 
     /// Update identitifiers of `ticker` as `did`.
@@ -2227,25 +2177,32 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    fn unsafe_register_custom_asset_type(
-        did: IdentityId,
-        ty: Vec<u8>,
+    /// Emits an event in case `asset_type_bytes` already exits, otherwise creates a new custom type.
+    fn unverified_register_custom_asset_type(
+        caller_did: IdentityId,
+        asset_type_bytes: Vec<u8>,
     ) -> Result<CustomAssetTypeId, DispatchError> {
-        ensure_string_limited::<T>(&ty)?;
-
-        Ok(match CustomTypesInverse::try_get(&ty) {
-            Ok(id) => {
-                Self::deposit_event(Event::<T>::CustomAssetTypeExists(did, id, ty));
-                id
+        match CustomTypesInverse::try_get(&asset_type_bytes) {
+            Ok(type_id) => {
+                Self::deposit_event(Event::<T>::CustomAssetTypeExists(
+                    caller_did,
+                    type_id,
+                    asset_type_bytes,
+                ));
+                Ok(type_id)
             }
-            Err(()) => {
-                let id = CustomTypeIdSequence::try_mutate(try_next_pre::<T, _>)?;
-                CustomTypesInverse::insert(&ty, id);
-                CustomTypes::insert(id, ty.clone());
-                Self::deposit_event(Event::<T>::CustomAssetTypeRegistered(did, id, ty));
-                id
+            Err(_) => {
+                let type_id = CustomTypeIdSequence::try_mutate(try_next_pre::<T, _>)?;
+                CustomTypesInverse::insert(asset_type_bytes.clone(), type_id);
+                CustomTypes::insert(type_id, asset_type_bytes.clone());
+                Self::deposit_event(Event::<T>::CustomAssetTypeRegistered(
+                    caller_did,
+                    type_id,
+                    asset_type_bytes,
+                ));
+                Ok(type_id)
             }
-        })
+        }
     }
 
     fn unverified_set_asset_metadata(

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -16,13 +16,30 @@ pub enum AssetOwnershipRelation {
     AssetOwned,
 }
 
-/// struct to store the token details.
+/// Stores the details of a security token.
 #[derive(Clone, Debug, Decode, Default, Encode, TypeInfo, PartialEq, Eq)]
 pub struct SecurityToken {
     pub total_supply: Balance,
     pub owner_did: IdentityId,
     pub divisible: bool,
     pub asset_type: AssetType,
+}
+
+impl SecurityToken {
+    /// Creates a new [`SecurityToken`] instance.
+    pub fn new(
+        total_supply: Balance,
+        owner_did: IdentityId,
+        divisible: bool,
+        asset_type: AssetType,
+    ) -> Self {
+        Self {
+            total_supply,
+            owner_did,
+            divisible,
+            asset_type,
+        }
+    }
 }
 
 /// struct to store the ticker registration details.
@@ -38,12 +55,4 @@ pub struct TickerRegistration<T> {
 pub struct TickerRegistrationConfig<T> {
     pub max_ticker_length: u8,
     pub registration_length: Option<T>,
-}
-
-/// Enum that represents the current status of a ticker.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq)]
-pub enum TickerRegistrationStatus {
-    RegisteredByOther,
-    Available,
-    RegisteredByDid,
 }

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -56,3 +56,30 @@ pub struct TickerRegistrationConfig<T> {
     pub max_ticker_length: u8,
     pub registration_length: Option<T>,
 }
+
+/// Tracks information regarding ticker registration.
+#[derive(Clone, Debug)]
+pub struct TickerRegistrationStatus {
+    can_reregister: bool,
+    charge_fee: bool,
+}
+
+impl TickerRegistrationStatus {
+    /// Creates a new [`TickerRegistrationStatus`] instance.
+    pub fn new(can_reregister: bool, charge_fee: bool) -> Self {
+        TickerRegistrationStatus {
+            can_reregister,
+            charge_fee,
+        }
+    }
+
+    /// Returns `true` if the ticker can be reregistered.
+    pub fn can_reregister(&self) -> bool {
+        self.can_reregister
+    }
+
+    /// Returns `true` if the ticker registration fee must be charged.
+    pub fn charge_fee(&self) -> bool {
+        self.charge_fee
+    }
+}

--- a/pallets/common/src/constants.rs
+++ b/pallets/common/src/constants.rs
@@ -47,10 +47,8 @@ pub mod queue_priority {
 
 // ERC1400 transfer status codes
 pub const ERC1400_TRANSFER_FAILURE: u8 = 0x50;
-pub const ERC1400_TRANSFER_SUCCESS: u8 = 0x51;
 pub const ERC1400_INSUFFICIENT_BALANCE: u8 = 0x52;
 pub const ERC1400_INSUFFICIENT_ALLOWANCE: u8 = 0x53;
-pub const ERC1400_TRANSFERS_HALTED: u8 = 0x54;
 pub const ERC1400_FUNDS_LOCKED: u8 = 0x55;
 pub const ERC1400_INVALID_SENDER: u8 = 0x56;
 pub const ERC1400_INVALID_RECEIVER: u8 = 0x57;
@@ -59,15 +57,12 @@ pub const ERC1400_INVALID_OPERATOR: u8 = 0x58;
 // Application-specific status codes
 pub const INVALID_SENDER_DID: u8 = 0xa0;
 pub const INVALID_RECEIVER_DID: u8 = 0xa1;
-pub const COMPLIANCE_MANAGER_FAILURE: u8 = 0xa2;
 pub const INVALID_GRANULARITY: u8 = 0xa4;
 pub const APP_TX_VOLUME_LIMIT_REACHED: u8 = 0xa5;
 pub const APP_BLOCKED_TX: u8 = 0xa6;
 pub const APP_FUNDS_LOCKED: u8 = 0xa7;
 pub const APP_FUNDS_LIMIT_REACHED: u8 = 0xa8;
-pub const PORTFOLIO_FAILURE: u8 = 0xa9;
 pub const CUSTODIAN_ERROR: u8 = 0xaa;
-pub const TRANSFER_MANAGER_FAILURE: u8 = 0xac;
 
 // PIP pallet constants.
 pub const PIP_MAX_REPORTING_SIZE: usize = 1024;

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -353,7 +353,10 @@ fn valid_transfers_pass() {
 
             // Should fail as sender matches receiver.
             let transfer = |from, to| transfer(ticker, from, to, 500);
-            assert_noop!(transfer(owner, owner), AssetError::InvalidTransfer);
+            assert_noop!(
+                transfer(owner, owner),
+                PortfolioError::DestinationIsSamePortfolio
+            );
             assert_ok!(transfer(owner, alice));
 
             assert_eq!(Asset::balance_of(&ticker, owner.did), TOTAL_SUPPLY - 500);
@@ -486,7 +489,7 @@ fn controller_transfer() {
             // Should fail as sender matches receiver.
             assert_noop!(
                 transfer(ticker, owner, owner, 500),
-                AssetError::InvalidTransfer
+                PortfolioError::DestinationIsSamePortfolio
             );
 
             assert_ok!(transfer(ticker, owner, alice, 500));

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -5,7 +5,6 @@ use sp_std::prelude::*;
 
 use pallet_compliance_manager::Error as CMError;
 use polymesh_common_utilities::compliance_manager::ComplianceFnConfig;
-use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
 use polymesh_primitives::agent::AgentGroup;
 use polymesh_primitives::compliance_manager::{
     AssetComplianceResult, ComplianceRequirement, ComplianceRequirementResult,
@@ -35,32 +34,27 @@ type EAError = pallet_external_agents::Error<TestStorage>;
 macro_rules! assert_invalid_transfer {
     ($ticker:expr, $from:expr, $to:expr, $amount:expr) => {
         let mut weight_meter = WeightMeter::max_limit_no_minimum();
-        assert_ne!(
-            Asset::_is_valid_transfer(
-                &$ticker,
-                PortfolioId::default_portfolio($from),
-                PortfolioId::default_portfolio($to),
-                $amount,
-                &mut weight_meter
-            ),
-            Ok(ERC1400_TRANSFER_SUCCESS)
-        );
+        assert!(Asset::validate_asset_transfer(
+            &$ticker,
+            &PortfolioId::default_portfolio($from),
+            &PortfolioId::default_portfolio($to),
+            $amount,
+            &mut weight_meter
+        )
+        .is_err(),);
     };
 }
 
 macro_rules! assert_valid_transfer {
     ($ticker:expr, $from:expr, $to:expr, $amount:expr) => {
         let mut weight_meter = WeightMeter::max_limit_no_minimum();
-        assert_eq!(
-            Asset::_is_valid_transfer(
-                &$ticker,
-                PortfolioId::default_portfolio($from),
-                PortfolioId::default_portfolio($to),
-                $amount,
-                &mut weight_meter
-            ),
-            Ok(ERC1400_TRANSFER_SUCCESS)
-        );
+        assert_ok!(Asset::validate_asset_transfer(
+            &$ticker,
+            &PortfolioId::default_portfolio($from),
+            &PortfolioId::default_portfolio($to),
+            $amount,
+            &mut weight_meter
+        ),);
     };
 }
 

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -2024,7 +2024,7 @@ fn dist_claim_misc_bad() {
 
         // Travel back in time. Now dist is active, but compliance rules not met, so transfer fails.
         set_timestamp(5);
-        noop(AssetError::InvalidTransfer.into());
+        noop(AssetError::InvalidTransferComplianceFailure.into());
     });
 }
 

--- a/pallets/runtime/tests/src/settlement_test.rs
+++ b/pallets/runtime/tests/src/settlement_test.rs
@@ -22,7 +22,6 @@ use pallet_settlement::{
     UserVenues, VenueInstructions,
 };
 use polymesh_common_utilities::constants::currency::ONE_UNIT;
-use polymesh_common_utilities::constants::ERC1400_TRANSFER_SUCCESS;
 use polymesh_primitives::asset::{AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataValue,
@@ -1430,16 +1429,13 @@ fn test_weights_for_settlement_transaction() {
             assert_affirm_instruction!(bob_signed.clone(), instruction_id, bob_did);
 
             let mut weight_meter = WeightMeter::max_limit_no_minimum();
-            assert_ok!(
-                Asset::_is_valid_transfer(
-                    &TICKER,
-                    PortfolioId::default_portfolio(alice_did),
-                    PortfolioId::default_portfolio(bob_did),
-                    100,
-                    &mut weight_meter
-                ),
-                ERC1400_TRANSFER_SUCCESS
-            );
+            assert_ok!(Asset::validate_asset_transfer(
+                &TICKER,
+                &PortfolioId::default_portfolio(alice_did),
+                &PortfolioId::default_portfolio(bob_did),
+                100,
+                &mut weight_meter
+            ),);
         });
 }
 

--- a/pallets/runtime/tests/src/transfer_compliance_test.rs
+++ b/pallets/runtime/tests/src/transfer_compliance_test.rs
@@ -463,10 +463,7 @@ impl AssetTracker {
 
     #[track_caller]
     pub fn ensure_invalid_transfer(&mut self, from: u64, to: u64, amount: u128) {
-        assert_noop!(
-            self.do_transfer(from, to, amount),
-            AssetError::InvalidTransfer
-        );
+        assert_noop!(self.do_transfer(from, to, amount), Error::InvalidTransfer);
     }
 
     pub fn fetch_stats_key2(&self, stat_type: &StatType) -> Vec<Stat2ndKey> {


### PR DESCRIPTION
- Adds private function: `base_create_asset_with_custom_type`;
- Splits all validation logic and storage write for registering ticker and creating an asset (`validate_ticker_registration_rules`, `validate_asset_creation_rules`, `unverified_register_ticker`, `unverified_create_asset`);
- Removes useless type: `TickerRegistrationStatus`;
- Remove useless error constants (`ERC1400_TRANSFERS_HALTED`, `PORTFOLIO_FAILURE`, `TRANSFER_MANAGER_FAILURE`, `COMPLIANCE_MANAGER_FAILURE`, `ERC1400_TRANSFER_SUCCESS`);

## changelog

### new external API
- Adds the following error variants to the `asset_pallet`: `InvalidTransferFrozenAsset`, `InvalidTransferComplianceFailure`;
