### PR TITLE
Add staging network

### DIFF
--- a/primitives/src/multisig.rs
+++ b/primitives/src/multisig.rs
@@ -1,5 +1,5 @@
 // This file is part of the Polymesh distribution (https://github.com/PolymeshAssociation/Polymesh).
-// Copyright (c) 2020 Polymath
+// Copyright (c) 2024 Polymesh Association
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/command.rs
+++ b/src/command.rs
@@ -78,6 +78,10 @@ impl SubstrateCli for Cli {
             "TESTNET" | "testnet" => Box::new(chain_spec::mainnet::ChainSpec::from_json_bytes(
                 &include_bytes!("./chain_specs/testnet_raw.json")[..],
             )?),
+            // STAGING network should be considered unstable and may be replaced at any time.
+            "STAGING" | "staging" => Box::new(chain_spec::mainnet::ChainSpec::from_json_bytes(
+                &include_bytes!("./chain_specs/staging_raw.json")[..],
+            )?),
             path => Box::new(chain_spec::mainnet::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
             )?),

--- a/src/command.rs
+++ b/src/command.rs
@@ -75,11 +75,11 @@ impl SubstrateCli for Cli {
             "MAINNET" | "mainnet" => Box::new(chain_spec::mainnet::ChainSpec::from_json_bytes(
                 &include_bytes!("./chain_specs/mainnet_raw.json")[..],
             )?),
-            "TESTNET" | "testnet" => Box::new(chain_spec::mainnet::ChainSpec::from_json_bytes(
+            "TESTNET" | "testnet" => Box::new(chain_spec::testnet::ChainSpec::from_json_bytes(
                 &include_bytes!("./chain_specs/testnet_raw.json")[..],
             )?),
             // STAGING network should be considered unstable and may be replaced at any time.
-            "STAGING" | "staging" => Box::new(chain_spec::mainnet::ChainSpec::from_json_bytes(
+            "STAGING" | "staging" => Box::new(chain_spec::testnet::ChainSpec::from_json_bytes(
                 &include_bytes!("./chain_specs/staging_raw.json")[..],
             )?),
             path => Box::new(chain_spec::mainnet::ChainSpec::from_json_file(


### PR DESCRIPTION
## changelog

This adds a staging chainspec json file and allows `--chain staging` to be used.