### PR TITLE
Add Identity pallet to Subsidised whitelist

### DIFF
--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -457,7 +457,7 @@ impl<T: Config> Module<T> {
             // These pallets are subsidised by the paying key.
             b"Asset" | b"ComplianceManager" | b"CorporateAction" | b"ExternalAgents"
             | b"Permissions" | b"Portfolio" | b"Settlement" | b"Statistics" | b"Sto"
-            | b"Balances" => Ok(Some(())),
+            | b"Balances" | b"Identity" => Ok(Some(())),
             // The user key needs to pay for `remove_paying_key` call.
             b"Relayer" => Ok(None),
             // Reject all other pallets.


### PR DESCRIPTION
## changelog

### new features

- Allow `Identity` pallet extrinsics to be subsidised