### PR TITLE
Fix set-controller and ref count update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
+ "hex-literal 0.3.4",
  "log",
  "pallet-balances 0.1.0",
  "pallet-base",

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4.8"
 serde = { version = "1.0.104", default-features = false }
 serde_derive = { version = "1.0.104", optional = true, default-features = false  }
 either = { version = "1.6.1", default-features = false }
+hex-literal = "0.3.0"
 
 # Cryptography
 schnorrkel = { version = "0.10.1", default-features = false, optional = true }

--- a/pallets/runtime/tests/src/lib.rs
+++ b/pallets/runtime/tests/src/lib.rs
@@ -36,6 +36,7 @@ mod settlement_pallet;
 mod settlement_test;
 mod signed_extra;
 mod staking;
+mod staking_extra_tests;
 mod sto_test;
 mod transaction_payment_test;
 mod transfer_compliance_test;

--- a/pallets/runtime/tests/src/staking_extra_tests.rs
+++ b/pallets/runtime/tests/src/staking_extra_tests.rs
@@ -1,0 +1,96 @@
+use frame_support::{assert_ok, StorageMap};
+use sp_keyring::AccountKeyring;
+
+use polymesh_primitives::{AuthorizationData, Permissions};
+
+use crate::ext_builder::ExtBuilder;
+use crate::storage::{add_secondary_key, TestStorage, User};
+
+type Origin = <TestStorage as frame_system::Config>::RuntimeOrigin;
+
+#[test]
+fn updating_controller() {
+    let charlie = vec![AccountKeyring::Charlie.to_account_id()];
+    ExtBuilder::default()
+        .cdd_providers(charlie)
+        .build()
+        .execute_with(|| {
+            let alice: User = User::new(AccountKeyring::Alice);
+            let eve: User = User::new_with(alice.did, AccountKeyring::Eve);
+
+            add_secondary_key(alice.did, eve.acc());
+
+            let auth_id = pallet_identity::Module::<TestStorage>::add_auth(
+                alice.did,
+                eve.signatory_acc(),
+                AuthorizationData::RotatePrimaryKeyToSecondary(Permissions::default()),
+                None,
+            )
+            .unwrap();
+
+            assert_ok!(
+                pallet_staking::Pallet::<TestStorage>::add_permissioned_validator(
+                    Origin::root(),
+                    alice.did,
+                    None
+                )
+            );
+
+            assert_ok!(pallet_staking::Pallet::<TestStorage>::bond(
+                alice.origin(),
+                sp_runtime::MultiAddress::Id(alice.acc()),
+                10_000_000,
+                pallet_staking::RewardDestination::Controller
+            ));
+
+            assert_ok!(
+                pallet_staking::Pallet::<TestStorage>::set_min_bond_threshold(
+                    Origin::root(),
+                    50_000
+                )
+            );
+
+            assert_ok!(pallet_staking::Pallet::<TestStorage>::validate(
+                Origin::signed(alice.acc()),
+                pallet_staking::ValidatorPrefs::default()
+            ));
+
+            assert_ok!(pallet_identity::Module::<TestStorage>::revoke_claim(
+                Origin::signed(AccountKeyring::Charlie.to_account_id()),
+                alice.did,
+                polymesh_primitives::Claim::CustomerDueDiligence(Default::default())
+            ));
+
+            assert_ok!(
+                pallet_staking::Pallet::<TestStorage>::remove_permissioned_validator(
+                    Origin::root(),
+                    alice.did,
+                )
+            );
+
+            assert_eq!(
+                pallet_identity::AccountKeyRefCount::<TestStorage>::get(alice.acc()),
+                1
+            );
+
+            assert_ok!(pallet_staking::Pallet::<TestStorage>::chill(alice.origin(),));
+
+            assert_eq!(
+                pallet_identity::AccountKeyRefCount::<TestStorage>::get(alice.acc()),
+                0
+            );
+
+            assert_ok!(
+                pallet_identity::Module::<TestStorage>::rotate_primary_key_to_secondary(
+                    eve.origin(),
+                    auth_id,
+                    None
+                )
+            );
+
+            assert_ok!(pallet_staking::Pallet::<TestStorage>::set_controller(
+                alice.origin(),
+                sp_runtime::MultiAddress::Id(eve.acc()),
+            ));
+        });
+}

--- a/pallets/staking/src/pallet/impls.rs
+++ b/pallets/staking/src/pallet/impls.rs
@@ -702,10 +702,10 @@ impl<T: Config> Pallet<T> {
                 if let Some(p) = pref {
                     if p.running_count > 0 {
                         p.running_count -= 1;
-                        <Identity<T>>::remove_account_key_ref_count(&stash);
                     }
                 }
             });
+            <Identity<T>>::remove_account_key_ref_count(&stash);
         }
     }
 

--- a/pallets/staking/src/pallet/mod.rs
+++ b/pallets/staking/src/pallet/mod.rs
@@ -1430,8 +1430,8 @@ pub mod pallet {
             }
 
             // Prevents stashes which are controllers of another ledger from calling the extrinsic
-            if let Some(bonded_ledger) = <Ledger<T>>::get(&stash) {
-                if bonded_ledger.stash != stash {
+            if old_controller != stash {
+                if <Ledger<T>>::contains_key(&stash) {
                     return Err(Error::<T>::BadState.into());
                 }
             }

--- a/pallets/staking/src/pallet/mod.rs
+++ b/pallets/staking/src/pallet/mod.rs
@@ -1428,9 +1428,12 @@ pub mod pallet {
             if <Ledger<T>>::contains_key(&controller) {
                 return Err(Error::<T>::AlreadyPaired.into());
             }
-            // Prevents stashes which are controllers from calling the extrinsic
-            if <Ledger<T>>::contains_key(&stash) {
-                return Err(Error::<T>::BadState.into());
+
+            // Prevents stashes which are controllers of another ledger from calling the extrinsic
+            if let Some(bonded_ledger) = <Ledger<T>>::get(&stash) {
+                if bonded_ledger.stash != stash {
+                    return Err(Error::<T>::BadState.into());
+                }
             }
 
             if controller != old_controller {


### PR DESCRIPTION
## changelog

### other

Allow updating the controller if the stash is the same as the controller; 
Update reference count even if the validator is not a permission-ed identity;

### data migration

Update reference count for three keys; 
