### PR TITLE
Remove use of Context::current_identity

### DIFF
--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -183,7 +183,7 @@ use polymesh_common_utilities::{
         identity::IdentityFnTrait,
         NegativeImbalance, PositiveImbalance,
     },
-    Context, SystematicIssuers, GC_DID,
+    SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::traits::BlockRewardsReserveCurrency;
 use polymesh_primitives::{Balance, Memo};
@@ -348,8 +348,7 @@ decl_module! {
         ) {
             ensure_root(origin)?;
             let who = T::Lookup::lookup(who)?;
-            let caller_id = Context::current_identity_or::<T::IdentityFn>(&who)
-                .unwrap_or(GC_DID);
+            let caller_id = GC_DID;
 
             let (free, reserved) = Self::mutate_account(&who, |account| {
                 if new_free > account.free {
@@ -397,8 +396,7 @@ decl_module! {
         #[weight = <T as Config>::WeightInfo::burn_account_balance()]
         pub fn burn_account_balance(origin, amount: Balance) -> DispatchResult {
             let who = ensure_signed(origin)?;
-            CallPermissions::<T>::ensure_call_permissions(&who)?;
-            let caller_id = Context::current_identity_or::<T::IdentityFn>(&who)?;
+            let caller_id = CallPermissions::<T>::ensure_call_permissions(&who)?.primary_did;
             // Withdraw the account balance and burn the resulting imbalance by dropping it.
             let _ = <Self as Currency<T::AccountId>>::withdraw(
                 &who,

--- a/pallets/committee/src/benchmarking.rs
+++ b/pallets/committee/src/benchmarking.rs
@@ -64,7 +64,6 @@ where
     for i in 0..(PROPOSALS_MAX - 1) {
         let index = Module::<T, I>::proposal_count();
         let proposal = make_proposal::<T, I>(i).0;
-        identity::CurrentDid::put(users[0].did());
         Module::<T, I>::vote_or_propose(users[0].origin.clone().into(), true, Box::new(proposal))
             .unwrap();
         if users.len() > 1 {
@@ -74,7 +73,6 @@ where
             for (j, user) in users.iter().skip(1).take(i as usize).enumerate() {
                 // Vote for the proposal if it's not finalised.
                 if Module::<T, I>::voting(&hash).is_some() {
-                    identity::CurrentDid::put(user.did());
                     Module::<T, I>::vote(user.origin.clone().into(), hash, index, j % 2 != 0)
                         .unwrap();
                 }
@@ -180,7 +178,6 @@ benchmarks_instance! {
         let members = make_members_and_proposals::<T, I>().unwrap();
         let last_proposal_num = ProposalCount::<I>::get();
         let (proposal, hash) = make_proposal::<T, I>(PROPOSALS_MAX);
-        identity::CurrentDid::put(members[0].did());
     }: vote_or_propose(members[0].origin.clone(), true, Box::new(proposal.clone()))
     verify {
         // The proposal was stored.
@@ -193,7 +190,6 @@ benchmarks_instance! {
         let (proposal, hash) = make_proposal::<T, I>(0);
         let proposals = Proposals::<T, I>::get();
         assert!(proposals.contains(&hash), "cannot find the first proposal");
-        identity::CurrentDid::put(members[1].did());
         let member1 = members[1].origin.clone();
         let boxed_proposal = Box::new(proposal.clone());
     }: vote_or_propose(member1, true, boxed_proposal)
@@ -217,8 +213,6 @@ benchmarks_instance! {
         assert!(Proposals::<T, I>::get().contains(&hash), "vote_aye target proposal not found");
         let member = &members[PROPOSAL_ALMOST_APPROVED as usize + 1];
         let origin = member.origin.clone();
-        let did = member.did();
-        identity::CurrentDid::put(did);
     }: vote(origin, hash, PROPOSAL_ALMOST_APPROVED, true)
     verify {
         assert!(!Proposals::<T, I>::get().contains(&hash), "vote_aye target proposal not executed");
@@ -231,7 +225,6 @@ benchmarks_instance! {
         let member = &members[1];
         let origin = member.origin.clone();
         let did = member.did();
-        identity::CurrentDid::put(did);
     }: vote(origin, hash, first_proposal_num, false)
     verify {
         vote_verify::<T, I>(&did, hash, first_proposal_num, false).unwrap();

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -468,6 +468,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
             return;
         }
 
+        // TODO: Either remove or use a fixed DID?
         let did = Context::current_identity::<Identity<T>>().unwrap_or_default();
         Self::finalize_proposal(approved, seats, ayes, nays, proposal, did);
         let event = RawEvent::FinalVotes(did, voting.index, proposal, voting.ayes, voting.nays);
@@ -656,6 +657,7 @@ impl<T: Config<I>, I: Instance> ChangeMembers<IdentityId> for Module<T, I> {
         if let Some(curr_rc) = Self::release_coordinator() {
             if outgoing.contains(&curr_rc) {
                 <ReleaseCoordinator<I>>::kill();
+                // TODO: Either remove or use a fixed DID?
                 Self::deposit_event(RawEvent::ReleaseCoordinatorUpdated(
                     Context::current_identity::<Identity<T>>().unwrap_or_default(),
                     None,

--- a/pallets/committee/src/lib.rs
+++ b/pallets/committee/src/lib.rs
@@ -75,7 +75,7 @@ use polymesh_common_utilities::{
     governance_group::GovernanceGroupTrait,
     group::{GroupTrait, InactiveMember, MemberCount},
     identity::Config as IdentityConfig,
-    Context, MaybeBlock, SystematicIssuers, GC_DID,
+    MaybeBlock, SystematicIssuers, GC_DID,
 };
 use polymesh_primitives::{storage_migration_ver, IdentityId};
 use scale_info::TypeInfo;
@@ -196,21 +196,21 @@ decl_event!(
         VoteRetracted(IdentityId, ProposalIndex, Hash, bool),
         /// Final votes on a motion (given hash)
         /// caller DID, ProposalIndex, Proposal hash, yes voters, no voter
-        FinalVotes(IdentityId, ProposalIndex, Hash, Vec<IdentityId>, Vec<IdentityId>),
+        FinalVotes(Option<IdentityId>, ProposalIndex, Hash, Vec<IdentityId>, Vec<IdentityId>),
         /// A motion was approved by the required threshold with the following
         /// tally (yes votes, no votes and total seats given respectively as `MemberCount`).
         /// Parameters: caller DID, proposal hash, yay vote count, nay vote count, total seats.
-        Approved(IdentityId, Hash, MemberCount, MemberCount, MemberCount),
+        Approved(Option<IdentityId>, Hash, MemberCount, MemberCount, MemberCount),
         /// A motion was rejected by the required threshold with the following
         /// tally (yes votes, no votes and total seats given respectively as `MemberCount`).
         /// Parameters: caller DID, proposal hash, yay vote count, nay vote count, total seats.
-        Rejected(IdentityId, Hash, MemberCount, MemberCount, MemberCount),
+        Rejected(Option<IdentityId>, Hash, MemberCount, MemberCount, MemberCount),
         /// A motion was executed; `DispatchResult` is `Ok(())` if returned without error.
         /// Parameters: caller DID, proposal hash, result of proposal dispatch.
-        Executed(IdentityId, Hash, DispatchResult),
+        Executed(Option<IdentityId>, Hash, DispatchResult),
         /// Release coordinator has been updated.
-        /// Parameters: caller DID, DID of the release coordinator.
-        ReleaseCoordinatorUpdated(IdentityId, Option<IdentityId>),
+        /// Parameters: DID of the release coordinator.
+        ReleaseCoordinatorUpdated(Option<IdentityId>),
         /// Proposal expiry time has been updated.
         /// Parameters: caller DID, new expiry time (if any).
         ExpiresAfterUpdated(IdentityId, MaybeBlock<BlockNumber>),
@@ -288,7 +288,7 @@ decl_module! {
             T::CommitteeOrigin::ensure_origin(origin)?;
             Self::ensure_did_is_member(&id)?;
             <ReleaseCoordinator<I>>::put(id);
-            Self::deposit_event(RawEvent::ReleaseCoordinatorUpdated(GC_DID, Some(id)));
+            Self::deposit_event(RawEvent::ReleaseCoordinatorUpdated(Some(id)));
         }
 
         /// Changes the time after which a proposal expires.
@@ -382,7 +382,7 @@ decl_module! {
             ));
 
             // 5. Check whether majority has been reached and if so, execute proposal.
-            Self::execute_if_passed(proposal);
+            Self::execute_if_passed(Some(did), proposal);
         }
     }
 }
@@ -449,7 +449,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
     }
 
     /// Accepts or rejects the proposal if its threshold is satisfied.
-    fn execute_if_passed(proposal: T::Hash) {
+    fn execute_if_passed(did: Option<IdentityId>, proposal: T::Hash) {
         let voting = match Self::voting(&proposal) {
             // Make sure we don't have an expired proposal at this point.
             Some(v) if Self::ensure_not_expired(&proposal, v.expiry).is_ok() => v,
@@ -468,8 +468,6 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
             return;
         }
 
-        // TODO: Either remove or use a fixed DID?
-        let did = Context::current_identity::<Identity<T>>().unwrap_or_default();
         Self::finalize_proposal(approved, seats, ayes, nays, proposal, did);
         let event = RawEvent::FinalVotes(did, voting.index, proposal, voting.ayes, voting.nays);
         Self::deposit_event(event);
@@ -497,7 +495,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
         yes_votes: MemberCount,
         no_votes: MemberCount,
         proposal: T::Hash,
-        current_did: IdentityId,
+        current_did: Option<IdentityId>,
     ) {
         let event = if approved {
             RawEvent::Approved
@@ -542,7 +540,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
         }
     }
 
-    fn execute(did: IdentityId, proposal: <T as Config<I>>::Proposal, hash: T::Hash) {
+    fn execute(did: Option<IdentityId>, proposal: <T as Config<I>>::Proposal, hash: T::Hash) {
         let origin = RawOrigin::Endorsed(PhantomData).into();
         let res = proposal.dispatch(origin).map_err(|e| e.error).map(drop);
         Self::deposit_event(RawEvent::Executed(did, hash, res));
@@ -574,7 +572,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 
         // 3. Execute if committee is single member, and otherwise record the vote.
         if Self::seats() < 2 {
-            Self::execute(did, proposal, proposal_hash);
+            Self::execute(Some(did), proposal, proposal_hash);
         } else {
             let index = <ProposalCount<I>>::mutate(|i| mem::replace(i, *i + 1));
             <Proposals<T, I>>::append(proposal_hash);
@@ -651,17 +649,13 @@ impl<T: Config<I>, I: Instance> ChangeMembers<IdentityId> for Module<T, I> {
                     .iter()
                     .any(|id| Self::remove_vote_from(*id, *proposal))
             })
-            .for_each(Self::execute_if_passed);
+            .for_each(|proposal| Self::execute_if_passed(None, proposal));
 
         // Double check if any `outgoing` is the Release coordinator.
         if let Some(curr_rc) = Self::release_coordinator() {
             if outgoing.contains(&curr_rc) {
                 <ReleaseCoordinator<I>>::kill();
-                // TODO: Either remove or use a fixed DID?
-                Self::deposit_event(RawEvent::ReleaseCoordinatorUpdated(
-                    Context::current_identity::<Identity<T>>().unwrap_or_default(),
-                    None,
-                ));
+                Self::deposit_event(RawEvent::ReleaseCoordinatorUpdated(None));
             }
         }
 

--- a/pallets/common/src/constants.rs
+++ b/pallets/common/src/constants.rs
@@ -33,6 +33,10 @@ pub mod did {
     pub const CLASSIC_MIGRATION_DID: &[u8; 32] = b"system:polymath_classic_mig\0\0\0\0\0";
     /// Fiat Currency Reservation DID
     pub const FIAT_TICKERS_RESERVATION_DID: &[u8; 32] = b"system:fiat_tickers_reservation\0";
+    /// Technical Committee DID.
+    pub const TECHNICAL_COMMITTEE_DID: &[u8; 32] = b"system:technical_committee\0\0\0\0\0\0";
+    /// Upgrade Committee DID.
+    pub const UPGRADE_COMMITTEE_DID: &[u8; 32] = b"system:upgrade_committee\0\0\0\0\0\0\0\0";
 }
 
 /// Priorities for the task that get scheduled.

--- a/pallets/common/src/context.rs
+++ b/pallets/common/src/context.rs
@@ -1,35 +1,15 @@
 use crate::traits::identity::IdentityFnTrait;
-use polymesh_primitives::IdentityId;
-use sp_runtime::DispatchError;
 use sp_std::marker::PhantomData;
 
 /// Helper class to access to some context information.
 /// Currently it allows to access to
-///     - `current_identity` throught an `IdentityFnTrait`, because it is stored using extrinsics.
-///     .
+///     - `current_payer throught an `IdentityFnTrait`, because it is stored using extrinsics.
 #[derive(Default)]
 pub struct Context<AccountId> {
     _marker: PhantomData<AccountId>,
 }
 
 impl<AccountId> Context<AccountId> {
-    #[inline]
-    #[cfg(not(feature = "default_identity"))]
-    pub fn current_identity<I: IdentityFnTrait<AccountId>>() -> Option<IdentityId> {
-        I::current_identity()
-    }
-
-    #[inline]
-    #[cfg(feature = "default_identity")]
-    pub fn current_identity<I: IdentityFnTrait<AccountId>>() -> Option<IdentityId> {
-        I::current_identity().or_else(|| Some(IdentityId::default()))
-    }
-
-    #[inline]
-    pub fn set_current_identity<I: IdentityFnTrait<AccountId>>(id: Option<IdentityId>) {
-        I::set_current_identity(id)
-    }
-
     #[inline]
     pub fn current_payer<I: IdentityFnTrait<AccountId>>() -> Option<AccountId> {
         I::current_payer()
@@ -39,32 +19,6 @@ impl<AccountId> Context<AccountId> {
     pub fn set_current_payer<I: IdentityFnTrait<AccountId>>(payer: Option<AccountId>) {
         I::set_current_payer(payer)
     }
-
-    /// It gets the current identity and if it is none, it will use the identity from `key`.
-    /// This function is a helper tool for testing where SignedExtension is not used and
-    /// `current_identity` is always none.
-    #[cfg(not(feature = "default_identity"))]
-    pub fn current_identity_or<I: IdentityFnTrait<AccountId>>(
-        key: &AccountId,
-    ) -> Result<IdentityId, DispatchError> {
-        Self::current_identity::<I>()
-            .or_else(|| I::get_identity(key))
-            .ok_or_else(|| {
-                DispatchError::Other(
-                    "Current identity is none and key is not linked to any identity",
-                )
-            })
-    }
-
-    #[cfg(feature = "default_identity")]
-    pub fn current_identity_or<I: IdentityFnTrait<AccountId>>(
-        key: &AccountId,
-    ) -> Result<IdentityId, DispatchError> {
-        I::current_identity()
-            .or_else(|| I::get_identity(key))
-            .or_else(|| Some(IdentityId::default()))
-            .ok_or_else(|| DispatchError::Other("Unreachable code"))
-    }
 }
 
 #[cfg(test)]
@@ -72,13 +26,8 @@ mod test {
     use super::*;
     use polymesh_primitives::{AccountId, IdentityId};
 
-    use lazy_static::lazy_static;
     use sp_keyring::AccountKeyring;
     use std::{collections::BTreeMap, convert::From, sync::RwLock, thread};
-
-    lazy_static! {
-        pub static ref CURR_IDENTITY: RwLock<Option<IdentityId>> = RwLock::new(None);
-    }
 
     struct IdentityTest {}
 
@@ -99,16 +48,6 @@ mod test {
             }
         }
 
-        fn current_identity() -> Option<IdentityId> {
-            let r = CURR_IDENTITY.read().unwrap();
-            r.clone()
-        }
-
-        fn set_current_identity(id: Option<IdentityId>) {
-            let mut w = CURR_IDENTITY.write().unwrap();
-            *w = id;
-        }
-
         fn current_payer() -> Option<AccountId> {
             None
         }
@@ -118,56 +57,5 @@ mod test {
         fn has_valid_cdd(_target_did: IdentityId) -> bool {
             true
         }
-    }
-
-    #[test]
-    fn context_functions() -> Result<(), &'static str> {
-        assert_eq!(Context::current_identity::<IdentityTest>(), None);
-        Context::set_current_identity::<IdentityTest>(Some(IdentityId::from(42)));
-
-        let _ = thread::spawn(|| {
-            let id = Context::current_identity::<IdentityTest>();
-            assert_eq!(id, Some(IdentityId::from(42u128)));
-            Context::set_current_identity::<IdentityTest>(None);
-        })
-        .join()
-        .map_err(|_| "Poison error")?;
-
-        assert_eq!(Context::current_identity::<IdentityTest>(), None);
-
-        let _ = thread::spawn(|| {
-            let id = Context::current_identity::<IdentityTest>();
-            assert_eq!(id, None);
-            Context::set_current_identity::<IdentityTest>(Some(IdentityId::from(15)));
-        })
-        .join()
-        .map_err(|_| "Poison error")?;
-
-        assert_eq!(
-            Context::current_identity::<IdentityTest>(),
-            Some(IdentityId::from(15))
-        );
-
-        // Check "or" option.
-        let alice = AccountId::from(AccountKeyring::Alice.public().0);
-        assert_eq!(
-            Context::current_identity_or::<IdentityTest>(&alice),
-            Ok(IdentityId::from(15))
-        );
-        Context::set_current_identity::<IdentityTest>(None);
-        assert_eq!(
-            Context::current_identity_or::<IdentityTest>(&alice),
-            Ok(IdentityId::from(1))
-        );
-
-        let eve = AccountId::from(AccountKeyring::Eve.public().0);
-        assert_eq!(
-            Context::current_identity_or::<IdentityTest>(&eve),
-            Err(DispatchError::Other(
-                "Current identity is none and key is not linked to any identity"
-            ))
-        );
-
-        Ok(())
     }
 }

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -140,6 +140,8 @@ impl SystematicIssuers {
 }
 
 pub const GC_DID: IdentityId = SystematicIssuers::Committee.as_id();
+pub const TECHNICAL_DID: IdentityId = IdentityId(*constants::did::TECHNICAL_COMMITTEE_DID);
+pub const UPGRADE_DID: IdentityId = IdentityId(*constants::did::UPGRADE_COMMITTEE_DID);
 
 /// Execute the supplied function in a new storage transaction,
 /// committing on `Ok(_)` and rolling back on `Err(_)`, returning the result.

--- a/pallets/common/src/traits/identity.rs
+++ b/pallets/common/src/traits/identity.rs
@@ -341,8 +341,6 @@ decl_event!(
 
 pub trait IdentityFnTrait<AccountId> {
     fn get_identity(key: &AccountId) -> Option<IdentityId>;
-    fn current_identity() -> Option<IdentityId>;
-    fn set_current_identity(id: Option<IdentityId>);
     fn current_payer() -> Option<AccountId>;
     fn set_current_payer(payer: Option<AccountId>);
 

--- a/pallets/common/src/traits/transaction_payment.rs
+++ b/pallets/common/src/traits/transaction_payment.rs
@@ -1,5 +1,3 @@
-use polymesh_primitives::IdentityId;
-
 use frame_support::dispatch::DispatchInfo;
 use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 
@@ -12,7 +10,6 @@ pub trait CddAndFeeDetails<AccountId, Call> {
     fn clear_context();
     fn set_payer_context(payer: Option<AccountId>);
     fn get_payer_from_context() -> Option<AccountId>;
-    fn set_current_identity(did: &IdentityId);
 }
 
 // Polymesh note: This was specifically added for Polymesh

--- a/pallets/group/src/benchmarking.rs
+++ b/pallets/group/src/benchmarking.rs
@@ -2,7 +2,7 @@ use crate::*;
 use polymesh_common_utilities::{
     benchs::{AccountIdOf, User, UserBuilder},
     group::{Config, GroupTrait},
-    Context, TestUtilsFn,
+    TestUtilsFn,
 };
 
 use frame_benchmarking::benchmarks_instance;
@@ -79,8 +79,6 @@ benchmarks_instance! {
             Module::<T,I>::disable_member(RawOrigin::Root.into(), *did, None, None)
                 .expect("Member cannot be disabled");
         });
-        Context::set_current_identity::<T::IdentityFn>(Some(new_member));
-
     }: _(RawOrigin::Root, new_member)
     verify {
         assert_eq!( Module::<T,I>::get_members().contains(&new_member), false);

--- a/pallets/group/src/lib.rs
+++ b/pallets/group/src/lib.rs
@@ -220,7 +220,7 @@ decl_module! {
                 &[remove],
                 &members[..],
             );
-            let current_did = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
+            let current_did = GC_DID;
             Self::deposit_event(RawEvent::MembersSwapped(current_did, remove, add));
         }
 
@@ -242,7 +242,7 @@ decl_module! {
                 T::MembershipChanged::set_members_sorted(&new_members[..], m);
                 *m = new_members;
             });
-            let current_did = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
+            let current_did = GC_DID;
             Self::deposit_event(RawEvent::MembersReset(current_did, members));
         }
 
@@ -291,8 +291,6 @@ decl_error! {
         NoSuchMember,
         /// Last member of the committee can not quit.
         LastMemberCannotQuit,
-        /// Missing current DID
-        MissingCurrentIdentity,
         /// The limit for the number of concurrent active members for this group has been exceeded.
         ActiveMembersLimitExceeded,
         /// Active member limit was greater than maximum committee members limit.
@@ -340,8 +338,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
         members.swap_remove(position);
 
         <InactiveMembers<T, I>>::put(&members);
-        let current_did = Context::current_identity::<Identity<T>>()
-            .ok_or_else(|| Error::<T, I>::MissingCurrentIdentity)?;
+        let current_did = GC_DID;
         Self::deposit_event(RawEvent::MemberRemoved(current_did, who));
         Ok(())
     }
@@ -361,7 +358,7 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
         <ActiveMembers<I>>::put(&members);
 
         T::MembershipChanged::change_members_sorted(&[], &[who], &members[..]);
-        let current_did = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
+        let current_did = GC_DID;
         Self::deposit_event(RawEvent::MemberRemoved(current_did, who));
         Ok(())
     }
@@ -400,7 +397,7 @@ impl<T: Config<I>, I: Instance> GroupTrait<T::Moment> for Module<T, I> {
         at: Option<T::Moment>,
     ) -> DispatchResult {
         Self::base_remove_active_member(who)?;
-        let current_did = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
+        let current_did = GC_DID;
 
         let deactivated_at = at.unwrap_or_else(<pallet_timestamp::Pallet<T>>::get);
         let inactive_member = InactiveMember {
@@ -446,7 +443,7 @@ impl<T: Config<I>, I: Instance> GroupTrait<T::Moment> for Module<T, I> {
         <ActiveMembers<I>>::put(&members);
 
         T::MembershipChanged::change_members_sorted(&[who], &[], &members[..]);
-        let current_did = Context::current_identity::<Identity<T>>().unwrap_or(GC_DID);
+        let current_did = GC_DID;
         Self::deposit_event(RawEvent::MemberAdded(current_did, who));
         Ok(())
     }

--- a/pallets/identity/src/auth.rs
+++ b/pallets/identity/src/auth.rs
@@ -20,7 +20,6 @@ use crate::{
 use frame_support::dispatch::DispatchResult;
 use frame_support::{ensure, StorageDoubleMap, StorageMap, StorageValue};
 use frame_system::ensure_signed;
-use polymesh_common_utilities::Context;
 use polymesh_primitives::{
     Authorization, AuthorizationData, AuthorizationError, IdentityId, Signatory,
 };
@@ -102,7 +101,8 @@ impl<T: Config> Module<T> {
             // If the sender is linked to an identity, ensure that it has relevant permissions
             pallet_permissions::Module::<T>::ensure_call_permissions(&sender)?.primary_did
         } else {
-            Context::current_identity_or::<Self>(&sender)?
+            // TODO: This should work for unlinked keys?
+            Self::get_identity(&sender).ok_or(Error::<T>::Unauthorized)?
         };
 
         let auth = Self::ensure_authorization(&target, auth_id)?;

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -35,7 +35,7 @@ use polymesh_common_utilities::identity::{
 use polymesh_common_utilities::multisig::MultiSigSubTrait as _;
 use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee as _, ProtocolOp};
 use polymesh_common_utilities::traits::{
-    AccountCallPermissionsData, CddAndFeeDetails, CheckAccountCallPermissions,
+    AccountCallPermissionsData, CheckAccountCallPermissions,
 };
 use polymesh_common_utilities::SystematicIssuers;
 use polymesh_primitives::identity::limits::{
@@ -689,10 +689,6 @@ impl<T: Config> Module<T> {
             ensure!(Self::has_valid_cdd(target_did), Error::<T>::TargetHasNoCdd);
             // Charge the protocol fee after all checks.
             T::ProtocolFee::charge_fee(ProtocolOp::IdentityAddSecondaryKeysWithAuthorization)?;
-            // Update current did of the transaction to the newly joined did.
-            // This comes handy when someone uses a batch transaction to leave their identity,
-            // join another identity, and then do something as the new identity.
-            T::CddHandler::set_current_identity(&target_did);
 
             Self::unsafe_join_identity(target_did, permissions, key);
             Ok(())

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -34,9 +34,7 @@ use polymesh_common_utilities::identity::{
 };
 use polymesh_common_utilities::multisig::MultiSigSubTrait as _;
 use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee as _, ProtocolOp};
-use polymesh_common_utilities::traits::{
-    AccountCallPermissionsData, CheckAccountCallPermissions,
-};
+use polymesh_common_utilities::traits::{AccountCallPermissionsData, CheckAccountCallPermissions};
 use polymesh_common_utilities::SystematicIssuers;
 use polymesh_primitives::identity::limits::{
     MAX_ASSETS, MAX_EXTRINSICS, MAX_PALLETS, MAX_PORTFOLIOS,

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -37,7 +37,7 @@ use polymesh_common_utilities::protocol_fee::{ChargeProtocolFee as _, ProtocolOp
 use polymesh_common_utilities::traits::{
     AccountCallPermissionsData, CddAndFeeDetails, CheckAccountCallPermissions,
 };
-use polymesh_common_utilities::{Context, SystematicIssuers};
+use polymesh_common_utilities::SystematicIssuers;
 use polymesh_primitives::identity::limits::{
     MAX_ASSETS, MAX_EXTRINSICS, MAX_PALLETS, MAX_PORTFOLIOS,
 };
@@ -870,7 +870,7 @@ impl<T: Config> Module<T> {
         origin: T::RuntimeOrigin,
     ) -> Result<(T::AccountId, IdentityId), DispatchError> {
         let sender = ensure_signed(origin)?;
-        let did = Context::current_identity_or::<Self>(&sender)?;
+        let did = Self::get_identity(&sender).ok_or(Error::<T>::MissingIdentity)?;
         Ok((sender, did))
     }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -126,9 +126,6 @@ decl_storage! {
         /// DID -> bool that indicates if secondary keys are frozen.
         pub IsDidFrozen get(fn is_did_frozen): map hasher(identity) IdentityId => bool;
 
-        /// It stores the current identity for current transaction.
-        pub CurrentDid: Option<IdentityId>;
-
         /// It stores the current gas fee payer for the current transaction
         pub CurrentPayer: Option<T::AccountId>;
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -593,8 +593,8 @@ decl_error! {
     pub enum Error for Module<T: Config> {
         /// One secondary or primary key can only belong to one DID
         AlreadyLinked,
-        /// Missing current identity on the transaction
-        MissingCurrentIdentity,
+        /// Caller is missing an identity.
+        MissingIdentity,
         /// Signatory is not pre authorized by the identity
         Unauthorized,
         /// Account Id cannot be extracted from signer

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -686,32 +686,12 @@ impl<T: Config> Module<T> {
     pub fn link_did(account: T::AccountId, did: IdentityId) {
         Self::add_key_record(&account, KeyRecord::PrimaryKey(did));
     }
-
-    #[cfg(feature = "runtime-benchmarks")]
-    /// Sets the current did in the context
-    pub fn set_context_did(did: Option<IdentityId>) {
-        polymesh_common_utilities::Context::set_current_identity::<Self>(did);
-    }
 }
 
 impl<T: Config> IdentityFnTrait<T::AccountId> for Module<T> {
     /// Fetches identity of a key.
     fn get_identity(key: &T::AccountId) -> Option<IdentityId> {
         Self::get_identity(key)
-    }
-
-    /// Fetches the caller's identity from the context.
-    fn current_identity() -> Option<IdentityId> {
-        CurrentDid::get()
-    }
-
-    /// Sets the caller's identity in the context.
-    fn set_current_identity(id: Option<IdentityId>) {
-        if let Some(id) = id {
-            CurrentDid::put(id);
-        } else {
-            CurrentDid::kill();
-        }
     }
 
     /// Fetches the fee payer from the context.

--- a/pallets/pips/src/lib.rs
+++ b/pallets/pips/src/lib.rs
@@ -1168,6 +1168,7 @@ impl<T: Config> Module<T> {
                         T::UpgradeCommitteeVMO::ensure_origin(origin).map(|_| Committee::Upgrade)
                     })
                     .map(Proposer::Committee)?;
+                // TODO: I think we should use a fixed DID for each of the committees.
                 let did = Context::current_identity::<Identity<T>>()
                     .ok_or_else(|| Error::<T>::MissingCurrentIdentity)?;
                 Ok((proposer, did))

--- a/pallets/runtime/common/src/fee_details.rs
+++ b/pallets/runtime/common/src/fee_details.rs
@@ -79,7 +79,6 @@ where
         // Check if the `did` has a valid CDD claim.
         let check_did_cdd = |did: &IdentityId| {
             if Module::<A>::has_valid_cdd(*did) {
-                Self::set_current_identity(did);
                 Ok(None)
             } else {
                 CDD_REQUIRED
@@ -216,7 +215,6 @@ where
 
     /// Clears context. Should be called in post_dispatch
     fn clear_context() {
-        Context::set_current_identity::<pallet_identity::Module<A>>(None);
         Self::set_payer_context(None);
     }
 
@@ -228,10 +226,6 @@ where
     /// Fetches fee payer for further payments (forwarded calls)
     fn get_payer_from_context() -> Option<AccountId> {
         Context::current_payer::<pallet_identity::Module<A>>()
-    }
-
-    fn set_current_identity(did: &IdentityId) {
-        Context::set_current_identity::<pallet_identity::Module<A>>(Some(*did));
     }
 }
 

--- a/pallets/runtime/tests/src/committee_test.rs
+++ b/pallets/runtime/tests/src/committee_test.rs
@@ -144,7 +144,11 @@ fn single_member_committee_works_we() {
     let hash = hash_enact_snapshot_results();
     let expected_event = EventRecord {
         phase: Phase::Initialization,
-        event: EventTest::PolymeshCommittee(CommitteeRawEvent::Executed(alice_did, hash, Ok(()))),
+        event: EventTest::PolymeshCommittee(CommitteeRawEvent::Executed(
+            Some(alice_did),
+            hash,
+            Ok(()),
+        )),
         topics: vec![],
     };
     assert_eq!(System::events().contains(&expected_event), true);
@@ -431,10 +435,9 @@ fn rage_quit_we() {
     // By quitting, only alice remains, so threshold passes, and therefore proposal is executed.
     check_scheduled(PipId(0));
     let hash = hash_enact_snapshot_results();
-    let did = IdentityId::default();
     let expected_event = EventRecord {
         phase: Phase::Initialization,
-        event: EventTest::PolymeshCommittee(CommitteeRawEvent::Executed(did, hash, Ok(()))),
+        event: EventTest::PolymeshCommittee(CommitteeRawEvent::Executed(None, hash, Ok(()))),
         topics: vec![],
     };
     assert_eq!(System::events().contains(&expected_event), true);

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -20,7 +20,7 @@ use crate::asset_pallet::setup::ISSUE_AMOUNT;
 
 use super::asset_pallet::setup::create_and_issue_sample_asset;
 use super::asset_test::set_timestamp;
-use super::storage::{set_curr_did, TestStorage, User};
+use super::storage::{TestStorage, User};
 use super::ExtBuilder;
 
 type Identity = pallet_identity::Module<TestStorage>;
@@ -591,22 +591,18 @@ fn pause_resume_asset_compliance_we() {
     // 5.1. Transfer should be cancelled.
     assert_invalid_transfer!(asset_id, owner.did, receiver.did, 10);
 
-    set_curr_did(Some(owner.did));
     // 5.2. Pause asset compliance, and run the transaction.
     assert_ok!(ComplianceManager::pause_asset_compliance(
         owner.origin(),
         asset_id
     ));
-    set_curr_did(None);
     assert_valid_transfer!(asset_id, owner.did, receiver.did, 10);
 
-    set_curr_did(Some(owner.did));
     // 5.3. Resume asset compliance, and new transfer should fail again.
     assert_ok!(ComplianceManager::resume_asset_compliance(
         owner.origin(),
         asset_id
     ));
-    set_curr_did(None);
     assert_invalid_transfer!(asset_id, owner.did, receiver.did, 10);
 }
 

--- a/pallets/runtime/tests/src/fee_details.rs
+++ b/pallets/runtime/tests/src/fee_details.rs
@@ -9,7 +9,6 @@ use pallet_identity as identity;
 use pallet_multisig as multisig;
 use pallet_test_utils as test_utils;
 use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
-use polymesh_common_utilities::Context;
 use polymesh_primitives::{Signatory, TransactionError};
 use polymesh_runtime_develop::runtime::{CddHandler, RuntimeCall};
 use sp_keyring::AccountKeyring;
@@ -48,9 +47,6 @@ fn cdd_checks() {
                 Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
-            // reset current identity context which is set as a side effect of get_valid_payer
-            Context::set_current_identity::<Identity>(None);
-
             // normal tx without cdd should fail
             assert_noop!(
                 CddHandler::get_valid_payer(
@@ -61,9 +57,6 @@ fn cdd_checks() {
                 ),
                 InvalidTransaction::Custom(TransactionError::CddRequired as u8)
             );
-
-            // reset current identity context which is set as a side effect of get_valid_payer
-            Context::set_current_identity::<Identity>(None);
 
             // call to accept being a multisig signer should fail when invalid auth
             assert_noop!(
@@ -91,9 +84,6 @@ fn cdd_checks() {
                 ),
                 InvalidTransaction::Custom(TransactionError::CddRequired as u8)
             );
-
-            // reset current identity context which is set as a side effect of get_valid_payer
-            Context::set_current_identity::<Identity>(None);
 
             // call to remove authorisation with issuer paying should fail if issuer does not have a valid cdd
             assert_noop!(
@@ -155,9 +145,6 @@ fn cdd_checks() {
                 Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
 
-            // reset current identity context which is set as a side effect of get_valid_payer
-            Context::set_current_identity::<Identity>(None);
-
             // create an authorisation where the target has a CDD claim and the issuer does not
             create_multisig_default_perms(
                 alice_account.clone(),
@@ -191,9 +178,6 @@ fn cdd_checks() {
                 ),
                 Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
-
-            // reset current identity context which is set as a side effect of get_valid_payer
-            Context::set_current_identity::<Identity>(None);
 
             // call to accept being a multisig signer should succeed when authorizer has a valid cdd but signer key does not
             // fee must be paid by multisig creator

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -603,7 +603,6 @@ fn do_add_secondary_keys_with_permissions_test() {
     assert_eq!(keys.len(), 1);
 
     // Try remove bob using alice
-    TestStorage::set_current_identity(&alice.did);
     assert_ok!(Identity::remove_secondary_keys(
         alice.origin(),
         vec![bob.acc()]
@@ -644,7 +643,6 @@ fn do_remove_secondary_keys_test() {
     assert_eq!(keys.len(), 2);
 
     // Try removing bob using alice.
-    TestStorage::set_current_identity(&alice.did);
     let remove_sk = |u: User| Identity::remove_secondary_keys(alice.origin(), vec![u.acc()]);
     assert_ok!(remove_sk(bob));
 
@@ -730,7 +728,6 @@ fn do_remove_secondary_keys_test_with_externalities() {
     assert_eq!(Identity::get_identity(&bob_key), Some(alice.did));
 
     // Try removing bob using charlie
-    TestStorage::set_current_identity(&charlie.did);
     assert_noop!(
         Identity::remove_secondary_keys(charlie.origin(), vec![bob.acc()]),
         Error::NotASigner
@@ -742,7 +739,6 @@ fn do_remove_secondary_keys_test_with_externalities() {
     assert_eq!(Identity::get_identity(&bob_key), Some(alice.did));
 
     // Try remove bob using alice
-    TestStorage::set_current_identity(&alice.did);
     assert_ok!(Identity::remove_secondary_keys(
         alice.origin(),
         vec![bob.acc()]

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -5,7 +5,6 @@ use frame_support::{
 
 use pallet_multisig::{self as multisig, AdminDid, ProposalStates, ProposalVoteCounts, Votes};
 use polymesh_common_utilities::constants::currency::POLY;
-use polymesh_common_utilities::traits::transaction_payment::CddAndFeeDetails;
 use polymesh_primitives::multisig::ProposalState;
 use polymesh_primitives::{AccountId, AuthorizationData, Permissions, SecondaryKey, Signatory};
 use sp_keyring::AccountKeyring;
@@ -179,7 +178,6 @@ fn join_multisig() {
 
         let ms_address =
             create_multisig_default_perms(alice.acc(), create_signers(vec![ms_address.clone()]), 1);
-        TestStorage::set_current_identity(&alice.did);
 
         // Testing that a multisig can't add itself as a signer.
         let ms_auth_id = Identity::add_auth(

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -105,7 +105,6 @@ fn setup_subsidy(user: User, payer: User, limit: Balance) {
     assert_subsidy(user, None);
 
     // `user` accepts the paying key.
-    TestStorage::set_current_identity(&user.did);
     let auth_id = get_last_auth_id(&Signatory::Account(user.acc()));
     assert_ok!(Relayer::accept_paying_key(user.origin(), auth_id));
 
@@ -137,7 +136,6 @@ fn do_basic_relayer_paying_key_test() {
     assert_subsidy(bob, None);
 
     // Bob accepts the paying key.
-    TestStorage::set_current_identity(&bob.did);
     let auth_id = get_last_auth_id(&Signatory::Account(bob.acc()));
     assert_ok!(Relayer::accept_paying_key(bob.origin(), auth_id));
 
@@ -156,7 +154,6 @@ fn do_basic_relayer_paying_key_test() {
     );
 
     // Alice updates the Polyx limit for Bob.  Allowed
-    TestStorage::set_current_identity(&alice.did);
     assert_ok!(Relayer::update_polyx_limit(
         alice.origin(),
         bob.acc(),
@@ -167,21 +164,18 @@ fn do_basic_relayer_paying_key_test() {
     assert_subsidy(bob, Some((alice, 10_000u128)));
 
     // Dave tries to remove the paying key from Bob's key.  Not allowed.
-    TestStorage::set_current_identity(&dave.did);
     assert_noop!(
         Relayer::remove_paying_key(dave.origin(), bob.acc(), alice.acc()),
         Error::NotAuthorizedForUserKey
     );
 
     // Dave tries to remove the wrong paying key from Bob's key.  Not allowed.
-    TestStorage::set_current_identity(&dave.did);
     assert_noop!(
         Relayer::remove_paying_key(dave.origin(), bob.acc(), dave.acc()),
         Error::NotPayingKey
     );
 
     // Alice tries to remove the paying key from Bob's key.  Allowed.
-    TestStorage::set_current_identity(&alice.did);
     assert_ok!(Relayer::remove_paying_key(
         alice.origin(),
         bob.acc(),
@@ -249,7 +243,6 @@ fn do_update_polyx_limit_test() {
     test_update(Sub, bob, 100, Err(Error::NotPayingKey), limit);
 
     // Alice updates the Polyx limit for Bob.  Allowed
-    TestStorage::set_current_identity(&alice.did);
     limit = 10_000;
     test_update(Set, alice, limit, Ok(()), limit);
 
@@ -291,11 +284,9 @@ fn do_accept_new_paying_key_test() {
     assert_subsidy(bob, Some((alice, 10u128)));
 
     // Add authorization for using Dave as the paying key for Bob.
-    TestStorage::set_current_identity(&dave.did);
     assert_ok!(Relayer::set_paying_key(dave.origin(), bob.acc(), 200u128));
 
     // Bob accepts Dave as his new subsidiser replacing Alice as the subsidiser.
-    TestStorage::set_current_identity(&bob.did);
     let auth_id = get_last_auth_id(&Signatory::Account(bob.acc()));
     assert_ok!(Relayer::accept_paying_key(bob.origin(), auth_id));
 
@@ -304,7 +295,6 @@ fn do_accept_new_paying_key_test() {
     assert_subsidy(bob, Some((dave, 200u128)));
 
     // Alice tries to remove the paying key from Bob's key.  Not allowed.
-    TestStorage::set_current_identity(&alice.did);
     assert_noop!(
         Relayer::remove_paying_key(alice.origin(), bob.acc(), dave.acc()),
         Error::NotAuthorizedForUserKey
@@ -325,7 +315,6 @@ fn do_user_remove_paying_key_test() {
     setup_subsidy(bob, alice, 2000);
 
     // Bob (user key) tries to remove the paying key from Bob's key.  Allowed.
-    TestStorage::set_current_identity(&bob.did);
     assert_ok!(Relayer::remove_paying_key(
         bob.origin(),
         bob.acc(),
@@ -351,7 +340,7 @@ fn relayer_user_key_missing_cdd_test() {
 fn do_relayer_user_key_missing_cdd_test() {
     let alice = User::new(AccountKeyring::Alice);
     let bob_acc = AccountKeyring::Bob.to_account_id();
-    let (bob_sign, bob_did) = make_account_without_cdd(bob_acc.clone()).unwrap();
+    let (bob_sign, _) = make_account_without_cdd(bob_acc.clone()).unwrap();
 
     // Add authorization for using Alice as the paying key for Bob.
     assert_ok!(Relayer::set_paying_key(
@@ -361,7 +350,6 @@ fn do_relayer_user_key_missing_cdd_test() {
     ));
 
     // Bob tries to accept the paying key, without having a CDD.
-    TestStorage::set_current_identity(&bob_did);
     let auth_id = get_last_auth_id(&Signatory::Account(bob_acc.clone()));
     assert_eq!(
         Relayer::accept_paying_key(bob_sign, auth_id),
@@ -386,7 +374,6 @@ fn do_relayer_paying_key_missing_cdd_test() {
 
     // Alice tries to accept the paying key, but the paying key
     // is without a CDD.
-    TestStorage::set_current_identity(&alice.did);
     let auth_id = get_last_auth_id(&Signatory::Account(alice.acc()));
     assert_eq!(
         Relayer::accept_paying_key(alice.origin(), auth_id),

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -377,7 +377,6 @@ impl CddAndFeeDetails<AccountId, Call> for Test {
     fn get_payer_from_context() -> Option<AccountId> {
         None
     }
-    fn set_current_identity(_: &IdentityId) {}
 }
 
 impl SubsidiserTrait<AccountId> for Test {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -524,7 +524,6 @@ impl CddAndFeeDetails<AccountId, RuntimeCall> for TestStorage {
     fn get_payer_from_context() -> Option<AccountId> {
         Context::current_payer::<Identity>()
     }
-    fn set_current_identity(_did: &IdentityId) {}
 }
 
 pub struct WeightToFee;

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -516,7 +516,6 @@ impl CddAndFeeDetails<AccountId, RuntimeCall> for TestStorage {
         Ok(Some(caller))
     }
     fn clear_context() {
-        Context::set_current_identity::<Identity>(None);
         Context::set_current_payer::<Identity>(None);
     }
     fn set_payer_context(payer: Option<AccountId>) {
@@ -525,9 +524,7 @@ impl CddAndFeeDetails<AccountId, RuntimeCall> for TestStorage {
     fn get_payer_from_context() -> Option<AccountId> {
         Context::current_payer::<Identity>()
     }
-    fn set_current_identity(did: &IdentityId) {
-        Context::set_current_identity::<Identity>(Some(*did));
-    }
+    fn set_current_identity(_did: &IdentityId) {}
 }
 
 pub struct WeightToFee;
@@ -925,10 +922,6 @@ pub fn make_remark_proposal() -> RuntimeCall {
         remark: vec![b'X'; 100],
     })
     .into()
-}
-
-pub(crate) fn set_curr_did(did: Option<IdentityId>) {
-    Context::set_current_identity::<Identity>(did);
 }
 
 #[macro_export]

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -71,7 +71,6 @@ use sp_std::vec;
 use pallet_asset::MandatoryMediators;
 use pallet_base::{ensure_string_limited, try_next_post};
 use polymesh_common_utilities::constants::queue_priority::SETTLEMENT_INSTRUCTION_EXECUTION_PRIORITY;
-use polymesh_common_utilities::traits::identity::IdentityFnTrait;
 use polymesh_common_utilities::traits::portfolio::PortfolioSubTrait;
 pub use polymesh_common_utilities::traits::settlement::{Event, RawEvent, WeightInfo};
 use polymesh_common_utilities::traits::{asset, compliance_manager, identity, nft, CommonConfig};
@@ -1996,7 +1995,7 @@ impl<T: Config> Module<T> {
         id: InstructionId,
         weight_meter: &mut WeightMeter,
     ) -> PostDispatchInfo {
-        let caller_did = Identity::<T>::current_identity().unwrap_or(SettlementDID.as_id());
+        let caller_did = SettlementDID.as_id();
         if let Err(e) = Self::execute_instruction_retryable(id, caller_did, weight_meter) {
             Self::deposit_event(RawEvent::FailedToExecuteInstruction(id, e));
         }
@@ -2551,7 +2550,7 @@ impl<T: Config> Module<T> {
 
     /// Returns an instance of [`ExecuteInstructionInfo`].
     pub fn execute_instruction_info(instruction_id: &InstructionId) -> ExecuteInstructionInfo {
-        let caller_did = Identity::<T>::current_identity().unwrap_or(SettlementDID.as_id());
+        let caller_did = SettlementDID.as_id();
         let instruction_asset_count = Self::get_instruction_asset_count(instruction_id);
         let mut weight_meter =
             WeightMeter::max_limit(Self::execute_scheduled_instruction_minimum_weight());

--- a/pallets/staking/src/pallet/impls.rs
+++ b/pallets/staking/src/pallet/impls.rs
@@ -1061,7 +1061,7 @@ impl<T: Config> Pallet<T> {
             // NOTE: ledger must be updated prior to calling `Self::weight_of`.
             Self::update_ledger(&controller, &ledger);
 
-            let did = T::IdentityFn::get_identity(&ledger.stash).unwrap_or_default();
+            let did = T::IdentityFn::get_identity(&controller).unwrap_or_default();
             Self::deposit_event(Event::<T>::Unbonded(did, ledger.stash.clone(), value));
         }
         Ok(())

--- a/pallets/staking/src/pallet/impls.rs
+++ b/pallets/staking/src/pallet/impls.rs
@@ -48,7 +48,7 @@ use sp_npos_elections::{
     to_support_map, Assignment, ElectionScore, EvaluateSupport, SupportMap, Supports,
 };
 
-use polymesh_common_utilities::Context;
+use polymesh_common_utilities::identity::IdentityFnTrait;
 use polymesh_primitives::IdentityId;
 
 use crate::_feps::NposSolution;
@@ -1061,7 +1061,7 @@ impl<T: Config> Pallet<T> {
             // NOTE: ledger must be updated prior to calling `Self::weight_of`.
             Self::update_ledger(&controller, &ledger);
 
-            let did = Context::current_identity::<T::IdentityFn>().unwrap_or_default();
+            let did = T::IdentityFn::get_identity(&ledger.stash).unwrap_or_default();
             Self::deposit_event(Event::<T>::Unbonded(did, ledger.stash.clone(), value));
         }
         Ok(())

--- a/pallets/staking/src/pallet/mod.rs
+++ b/pallets/staking/src/pallet/mod.rs
@@ -54,8 +54,8 @@ use sp_runtime::traits::{AccountIdConversion, Dispatchable, Saturating};
 use sp_runtime::Permill;
 
 use polymesh_common_utilities::constants::GC_PALLET_ID;
-use polymesh_common_utilities::identity::Config as IdentityConfig;
-use polymesh_common_utilities::{Context, GC_DID};
+use polymesh_common_utilities::identity::{Config as IdentityConfig, IdentityFnTrait};
+use polymesh_common_utilities::GC_DID;
 use polymesh_primitives::{storage_migration_ver, IdentityId};
 
 use crate::types::{
@@ -1054,7 +1054,7 @@ pub mod pallet {
 
             // Polymesh Change: Add `stash`'s DID to event.
             // -----------------------------------------------------------------
-            let did = Context::current_identity::<T::IdentityFn>().unwrap_or_default();
+            let did = T::IdentityFn::get_identity(&stash).unwrap_or_default();
             Self::deposit_event(Event::<T>::Bonded(did, stash.clone(), value));
             // -----------------------------------------------------------------
 
@@ -1118,7 +1118,7 @@ pub mod pallet {
 
                 // Polymesh Change: Add `stash`'s DID to event.
                 // -----------------------------------------------------------------
-                let did = Context::current_identity::<T::IdentityFn>().unwrap_or_default();
+                let did = T::IdentityFn::get_identity(&stash).unwrap_or_default();
                 Self::deposit_event(Event::<T>::Bonded(did, stash.clone(), extra));
                 // -----------------------------------------------------------------
             }

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -47,7 +47,7 @@ use frame_support::{
 use frame_system::ensure_root;
 use pallet_identity as identity;
 use polymesh_common_utilities::{
-    constants::TREASURY_PALLET_ID, traits::balances::Config as BalancesConfig, Context, GC_DID,
+    constants::TREASURY_PALLET_ID, traits::balances::Config as BalancesConfig, GC_DID,
 };
 use polymesh_primitives::{Beneficiary, IdentityId};
 use sp_runtime::traits::{AccountIdConversion, Saturating};

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -235,9 +235,7 @@ impl<T: Config> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
         let numeric_amount = amount.peek();
 
         let _ = T::Currency::resolve_creating(&Self::account_id(), amount);
-        // TODO: Should we use a fixed value here?
-        let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
-        Self::deposit_event(RawEvent::TreasuryReimbursement(current_did, numeric_amount));
+        Self::deposit_event(RawEvent::TreasuryReimbursement(GC_DID, numeric_amount));
     }
 }
 

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -235,6 +235,7 @@ impl<T: Config> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
         let numeric_amount = amount.peek();
 
         let _ = T::Currency::resolve_creating(&Self::account_id(), amount);
+        // TODO: Should we use a fixed value here?
         let current_did = Context::current_identity::<Identity<T>>().unwrap_or_default();
         Self::deposit_event(RawEvent::TreasuryReimbursement(current_did, numeric_amount));
     }

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -900,18 +900,9 @@ impl<T: Config> Pallet<T> {
                 _ => None,
             }
         };
-        let behalf_identity = behalf_account_id
-            .clone()
-            .and_then(|acc| Identity::<T>::get_identity(&acc));
 
         let dispatch_info = call.get_dispatch_info();
-        let call_result = Self::run_with_temporary_did_and_payer(
-            as_origin,
-            behalf_account_id,
-            behalf_identity,
-            call,
-            true,
-        );
+        let call_result = Self::run_with_temporary_payer(as_origin, behalf_account_id, call, true);
         // Get the actual weight of this call.
         let weight = extract_actual_weight(&call_result, &dispatch_info);
 
@@ -936,17 +927,10 @@ impl<T: Config> Pallet<T> {
         origin.set_caller_from(frame_system::RawOrigin::Signed(
             derivative_account_id.clone(),
         ));
-        // Get the identity of the derivative account id
-        let derivative_did = Identity::<T>::get_identity(&derivative_account_id);
 
         let dispatch_info = call.get_dispatch_info();
-        let call_result = Self::run_with_temporary_did_and_payer(
-            origin,
-            Some(derivative_account_id),
-            derivative_did,
-            call,
-            false,
-        );
+        let call_result =
+            Self::run_with_temporary_payer(origin, Some(derivative_account_id), call, false);
 
         // Always take into account the base weight of this call and add the real weight of the dispatch.
         let mut weight = <T as Config>::WeightInfo::as_derivative()
@@ -973,18 +957,15 @@ impl<T: Config> Pallet<T> {
 
     /// Dispatches `call` Setting CurrentDid and CurrentPayer to `did` and `account_id`.
     /// The values are reset once the call is done.
-    fn run_with_temporary_did_and_payer(
+    fn run_with_temporary_payer(
         origin: T::RuntimeOrigin,
         account_id: Option<T::AccountId>,
-        did: Option<IdentityId>,
         call: Box<<T as Config>::RuntimeCall>,
         bypass_filter: bool,
     ) -> Result<PostDispatchInfo, DispatchErrorWithPostInfo> {
-        // Hold the original value for payer and identity
+        // Hold the original value for payer.
         let original_payer = Context::current_payer::<Identity<T>>();
-        let original_did = Context::current_identity::<Identity<T>>();
-        // Temporarily change identity and payer
-        Context::set_current_identity::<Identity<T>>(did);
+        // Temporarily change payer
         Context::set_current_payer::<Identity<T>>(account_id);
         // dispatch the call
         let call_result = {
@@ -996,9 +977,8 @@ impl<T: Config> Pallet<T> {
                 }
             })
         };
-        // Restore the original payer and identity
+        // Restore the original payer
         Context::set_current_payer::<Identity<T>>(original_payer);
-        Context::set_current_identity::<Identity<T>>(original_did);
         call_result
     }
 }

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -955,8 +955,8 @@ impl<T: Config> Pallet<T> {
             .map_err(|_| Error::<T>::UnableToDeriveAccountId.into())
     }
 
-    /// Dispatches `call` Setting CurrentDid and CurrentPayer to `did` and `account_id`.
-    /// The values are reset once the call is done.
+    /// Dispatches `call` Setting CurrentPayer to `account_id`.
+    /// The value is reset once the call is done.
     fn run_with_temporary_payer(
         origin: T::RuntimeOrigin,
         account_id: Option<T::AccountId>,

--- a/primitives/src/secondary_key.rs
+++ b/primitives/src/secondary_key.rs
@@ -316,10 +316,10 @@ where
     AccountId: PartialEq,
 {
     /// Checks if Signatory is either a particular Identity or a particular key
-    pub fn eq_either(&self, other_identity: &IdentityId, other_key: &AccountId) -> bool {
+    pub fn eq_either(&self, other_identity: Option<IdentityId>, other_key: &AccountId) -> bool {
         match self {
             Signatory::Account(ref key) => key == other_key,
-            Signatory::Identity(ref id) => id == other_identity,
+            Signatory::Identity(ref id) => Some(*id) == other_identity,
         }
     }
 


### PR DESCRIPTION
## changelog

### modified external API

- Remove storage `CurrentDid` from identity pallet.  This value was only set during a transaction and cleared when the transaction finished (even on errors).

### modified events

- Changed the caller's DID to be optional in the following committee events: `FinalVotes`, `Approved`, `Rejected`, and `Executed`.
- Removed the caller's DID from committee event: `ReleaseCoordinatorUpdated`.

### other

- Remove internal `Context::current_identity*` API.
