### PR TITLE
Move from 2048 to 1024 max nominators per validator

### DIFF
--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -174,7 +174,7 @@ parameter_types! {
     pub const BondingDuration: sp_staking::EraIndex = 7;
     pub const SlashDeferDuration: sp_staking::EraIndex = 4;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-    pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const MaxNominatorRewardedPerValidator: u32 = 1_024;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -164,7 +164,7 @@ parameter_types! {
     pub const BondingDuration: sp_staking::EraIndex = 28;
     pub const SlashDeferDuration: sp_staking::EraIndex = 14; // 1/2 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-    pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const MaxNominatorRewardedPerValidator: u32 = 1_024;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -172,7 +172,7 @@ parameter_types! {
     pub const BondingDuration: sp_staking::EraIndex = 28;
     pub const SlashDeferDuration: sp_staking::EraIndex = 14; // 1/2 the bonding duration.
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-    pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const MaxNominatorRewardedPerValidator: u32 = 1_024;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -207,7 +207,7 @@ parameter_types! {
     pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub MinSolutionScoreBump: Perbill = Perbill::from_rational(5u32, 10_000);
-    pub const MaxNominatorRewardedPerValidator: u32 = 2048;
+    pub const MaxNominatorRewardedPerValidator: u32 = 1_024;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub const IndexDeposit: Balance = DOLLARS;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;


### PR DESCRIPTION
## changelog

### other

- Modifies the maximum number of nominators that receive rewards, per validator, from 2,048 to 1,024.