### PR TITLE
Calculate staking UnsignedPhase from epoch duration.

### DIFF
--- a/pallets/runtime/common/src/lib.rs
+++ b/pallets/runtime/common/src/lib.rs
@@ -160,7 +160,6 @@ parameter_types! {
     pub const SignedDepositBase: Balance = 0;
     pub const SignedDepositByte: Balance = 0;
     // Unsigned phase
-    pub const UnsignedPhase: u32 = 1_200;
     pub BetterUnsignedThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
     pub const MultiPhaseUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2 - 1u64;
     // Fallback parameters

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -583,7 +583,7 @@ macro_rules! misc_pallet_impls {
             // Something that can estimate the fee of a call (used when submitting a solution for the signed phase)
             type EstimateCallFee = polymesh_runtime_common::impls::EstimateCallFeeMax;
             // Duration of the unsigned phase
-            type UnsignedPhase = polymesh_runtime_common::UnsignedPhase;
+            type UnsignedPhase = UnsignedPhase;
             #[cfg(not(feature = "runtime-benchmarks"))]
             // Duration of the signed phase
             type SignedPhase = polymesh_runtime_common::SignedPhase;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -176,7 +176,7 @@ parameter_types! {
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
-    pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
+    pub const UnsignedPhase: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     // 0.05%. The higher the value, the more strict solution acceptance becomes.

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -166,7 +166,7 @@ parameter_types! {
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
-    pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
+    pub const UnsignedPhase: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     // 0.05%. The higher the value, the more strict solution acceptance becomes.

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -174,7 +174,7 @@ parameter_types! {
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;
     pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
-    pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
+    pub const UnsignedPhase: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub const MaxValidatorPerIdentity: Permill = Permill::from_percent(33);
     // 0.05%. The higher the value, the more strict solution acceptance becomes.

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -204,7 +204,7 @@ parameter_types! {
     pub const SessionsPerEra: sp_staking::SessionIndex = 3;
     pub const BondingDuration: EraIndex = 7;
     pub const SlashDeferDuration: EraIndex = 4;
-    pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
+    pub const UnsignedPhase: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
     pub const MaxIterations: u32 = 10;
     pub MinSolutionScoreBump: Perbill = Perbill::from_rational(5u32, 10_000);
     pub const MaxNominatorRewardedPerValidator: u32 = 2048;


### PR DESCRIPTION
## changelog

### modified external API

- `electionProviderMultiPhase.unsignedPhase` constant is now 1/4 of the Epoch duration.
