### PR TITLE
Nft fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "6.3.3"
+version = "6.3.4"
 dependencies = [
  "clap 4.4.11",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "6.3.3"
+version = "6.3.4"
 authors = ["PolymeshAssociation"]
 build = "build.rs"
 edition = "2021"

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -18,7 +18,7 @@ use polymesh_primitives::{IdentityId, PortfolioKind, WeightMeter};
 
 use crate::*;
 
-const MAX_COLLECTION_KEYS: u32 = 255;
+const MAX_COLLECTION_KEYS: u32 = 20;
 
 /// Creates an NFT collection with `n` global metadata keys.
 fn create_collection<T: Config>(

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -140,7 +140,7 @@ parameter_types! {
     pub MaxOutLen: u32 = 8 * 1024;
 
     // NFT:
-    pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;
+    pub const MaxNumberOfCollectionKeys: u8 = 20;
 
     // Portfolio:
     pub const MaxNumberOfFungibleMoves: u32 = 10;

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -57,7 +57,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_003_030,
+    spec_version: 6_003_040,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -53,7 +53,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_003_030,
+    spec_version: 6_003_040,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -135,7 +135,7 @@ parameter_types! {
     pub MaxOutLen: u32 = 8 * 1024;
 
     // NFT:
-    pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;
+    pub const MaxNumberOfCollectionKeys: u8 = 20;
 
     // Portfolio:
     pub const MaxNumberOfFungibleMoves: u32 = 10;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -138,7 +138,7 @@ parameter_types! {
     pub MaxOutLen: u32 = 8 * 1024;
 
     // NFT:
-    pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;
+    pub const MaxNumberOfCollectionKeys: u8 = 20;
 
     // Portfolio:
     pub const MaxNumberOfFungibleMoves: u32 = 10;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -55,7 +55,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 6_003_030,
+    spec_version: 6_003_040,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -226,7 +226,7 @@ parameter_types! {
     pub const MaxPeerDataEncodingSize: u32 = 1_000;
     pub const ReportLongevity: u64 =
         BondingDuration::get() as u64 * SessionsPerEra::get() as u64 * EpochDuration::get();
-    pub const MaxNumberOfCollectionKeys: u8 = u8::MAX;
+    pub const MaxNumberOfCollectionKeys: u8 = 20;
     pub const MaxNumberOfFungibleMoves: u32 = 10;
     pub const MaxNumberOfNFTsMoves: u32 = 100;
     pub const MaxNumberOfOffChainAssets: u32 = 10;

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -1252,9 +1252,12 @@ impl<T: Config> Module<T> {
             let instruction_details = InstructionDetails::<T>::take(instruction_id);
             Self::ensure_allowed_venue(&instruction_legs, instruction_details.venue_id)?;
 
-            // Attempts to release the locks and transfer all fungible an non fungible assets
+            // Attempts to release the locks
+            Self::release_locks(instruction_id, &instruction_legs)?;
+
+            // Transfer all fungible an non fungible assets
             let instruction_memo = InstructionMemos::get(&instruction_id);
-            match Self::release_asset_locks_and_transfer_pending_legs(
+            match Self::transfer_pending_legs(
                 instruction_id,
                 &instruction_legs,
                 instruction_memo,
@@ -1377,14 +1380,13 @@ impl<T: Config> Module<T> {
         Ok(())
     }
 
-    fn release_asset_locks_and_transfer_pending_legs(
+    fn transfer_pending_legs(
         instruction_id: InstructionId,
         instruction_legs: &[(LegId, Leg)],
         instruction_memo: Option<Memo>,
         caller_did: IdentityId,
         weight_meter: &mut WeightMeter,
     ) -> Result<(), LegId> {
-        Self::unchecked_release_locks(instruction_id, instruction_legs);
         for (leg_id, leg) in instruction_legs {
             if Self::instruction_leg_status(instruction_id, leg_id) == LegStatus::ExecutionPending {
                 match leg {
@@ -1520,17 +1522,13 @@ impl<T: Config> Module<T> {
         Ok(filtered_legs)
     }
 
-    fn unchecked_release_locks(id: InstructionId, instruction_legs: &[(LegId, Leg)]) {
+    fn release_locks(id: InstructionId, instruction_legs: &[(LegId, Leg)]) -> DispatchResult {
         for (leg_id, leg) in instruction_legs {
-            match Self::instruction_leg_status(id, leg_id) {
-                LegStatus::ExecutionPending => {
-                    // This can never return an error since the settlement module
-                    // must've locked these tokens when instruction was affirmed
-                    let _ = Self::unlock_via_leg(&leg);
-                }
-                LegStatus::ExecutionToBeSkipped(_, _) | LegStatus::PendingTokenLock => {}
+            if let LegStatus::ExecutionPending = Self::instruction_leg_status(id, leg_id) {
+                Self::unlock_via_leg(&leg)?;
             }
         }
+        Ok(())
     }
 
     /// Schedule a given instruction to be executed on the next block only if the
@@ -1911,7 +1909,7 @@ impl<T: Config> Module<T> {
             }
         };
         // All checks have been made - write to storage
-        Self::unchecked_release_locks(instruction_id, &legs);
+        Self::release_locks(instruction_id, &legs)?;
         let _ = T::Scheduler::cancel_named(instruction_id.execution_name());
         // Remove all data from storage
         Self::prune_rejected_instruction(instruction_id);


### PR DESCRIPTION
## changelog

### other

  - Do not allow NFTs locked in a settlement to be redeemed
  - Set a lower default value (20) for the number of metadata keys an NFT can have
  - Correctly determine the weight when redeeming NFTs