### PR TITLE
Invalidate Proposals After Multsig Change

### DIFF
--- a/pallets/common/src/traits/multisig.rs
+++ b/pallets/common/src/traits/multisig.rs
@@ -40,6 +40,7 @@ pub trait WeightInfo {
     fn create_join_identity() -> Weight;
     fn approve_join_identity() -> Weight;
     fn join_identity() -> Weight;
+    fn remove_admin() -> Weight;
 
     fn default_max_weight(max_weight: &Option<Weight>) -> Weight {
         max_weight.unwrap_or_else(|| {

--- a/pallets/multisig/src/benchmarking.rs
+++ b/pallets/multisig/src/benchmarking.rs
@@ -369,4 +369,9 @@ benchmarks! {
         MultiSig::<T>::approve_join_identity(users[0].origin().into(), multisig.clone(), auth_id).unwrap();
         // The second approval call just approves.
     }: approve_join_identity(users[1].origin(), multisig, auth_id)
+
+    remove_admin {
+        let (alice, multisig, _, _, multisig_origin) = generate_multisig_for_alice::<T>(2, 2).unwrap();
+        init_admin(&multisig, &alice);
+    }: _(multisig_origin)
 }

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -696,7 +696,7 @@ pub mod pallet {
         InvalidExpiryDate,
         /// The proposal has been invalidated after a multisg update.
         InvalidatedProposal,
-        /// Multisig has not admin.
+        /// Multisig has no admin.
         AdminNotFound,
     }
 

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -1319,7 +1319,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Returns `Ok` if `proposal_id` is valid. Otherwise, returns [`InvalidatedProposal`].
+    /// Returns `Ok` if `proposal_id` is valid. Otherwise, returns [`Error::InvalidatedProposal`].
     fn ensure_valid_proposal(multisig: &T::AccountId, proposal_id: u64) -> DispatchResult {
         if let Some(last_invalid_proposal) = Self::last_invalid_proposal(multisig) {
             ensure!(

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -1530,6 +1530,7 @@ fn invalidate_proposals_add_signer() {
         let bob_key = AccountKeyring::Bob.to_account_id();
         let ferdie_key = AccountKeyring::Ferdie.to_account_id();
         let ferdie = Origin::signed(ferdie_key.clone());
+        let charlie = Origin::signed(AccountKeyring::Charlie.to_account_id());
         let charlie_key = AccountKeyring::Charlie.to_account_id();
 
         let ms_address = setup_multisig(alice.acc(), 2, create_signers(vec![ferdie_key, bob_key]));
@@ -1548,7 +1549,15 @@ fn invalidate_proposals_add_signer() {
         assert_ok!(MultiSig::add_multisig_signers_via_admin(
             alice.origin(),
             ms_address.clone(),
-            create_signers(vec![charlie_key])
+            create_signers(vec![charlie_key.clone()])
+        ));
+
+        assert_eq!(LastInvalidProposal::<TestStorage>::get(&ms_address), None);
+
+        let charlie_auth_id = get_last_auth_id(&charlie_key);
+        assert_ok!(MultiSig::accept_multisig_signer(
+            charlie.clone(),
+            charlie_auth_id
         ));
 
         assert_eq!(

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -3,7 +3,9 @@ use frame_support::{
     dispatch::DispatchResult, BoundedVec,
 };
 
-use pallet_multisig::{self as multisig, AdminDid, ProposalStates, ProposalVoteCounts, Votes};
+use pallet_multisig::{
+    self as multisig, AdminDid, LastInvalidProposal, ProposalStates, ProposalVoteCounts, Votes,
+};
 use polymesh_common_utilities::constants::currency::POLY;
 use polymesh_primitives::multisig::ProposalState;
 use polymesh_primitives::{AccountId, AuthorizationData, Permissions, SecondaryKey, Signatory};
@@ -1391,6 +1393,261 @@ fn multisig_nesting_not_allowed() {
         assert_eq!(
             MultiSig::ms_signers(ms2_address.clone(), ms1_address.clone()),
             false
+        );
+    });
+}
+
+#[test]
+fn create_expired_proposal() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob_key = AccountKeyring::Bob.to_account_id();
+        let ferdie_key = AccountKeyring::Ferdie.to_account_id();
+        let ferdie = Origin::signed(ferdie_key.clone());
+        let charlie_key = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = setup_multisig(
+            alice.acc(),
+            3,
+            create_signers(vec![ferdie_key, bob_key, charlie_key]),
+        );
+
+        let expires_at = 100u64;
+        let call = Box::new(RuntimeCall::MultiSig(
+            multisig::Call::change_sigs_required { sigs_required: 2 },
+        ));
+
+        set_timestamp(expires_at);
+
+        assert_eq!(
+            MultiSig::create_proposal(ferdie.clone(), ms_address.clone(), call, Some(100u64),)
+                .unwrap_err()
+                .error,
+            Error::InvalidExpiryDate.into()
+        )
+    });
+}
+
+#[test]
+fn invalidate_proposals_change_sigs_required() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob_key = AccountKeyring::Bob.to_account_id();
+        let ferdie_key = AccountKeyring::Ferdie.to_account_id();
+        let ferdie = Origin::signed(ferdie_key.clone());
+        let charlie_key = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = setup_multisig(
+            alice.acc(),
+            3,
+            create_signers(vec![ferdie_key, bob_key, charlie_key]),
+        );
+
+        let call = Box::new(RuntimeCall::MultiSig(
+            multisig::Call::change_sigs_required { sigs_required: 2 },
+        ));
+
+        assert_ok!(MultiSig::create_proposal(
+            ferdie.clone(),
+            ms_address.clone(),
+            call,
+            None
+        ));
+
+        assert_ok!(MultiSig::change_sigs_required_via_admin(
+            alice.origin(),
+            ms_address.clone(),
+            2
+        ));
+
+        assert_eq!(
+            LastInvalidProposal::<TestStorage>::get(&ms_address),
+            Some(0)
+        );
+
+        assert_eq!(
+            MultiSig::approve(ferdie.clone(), ms_address.clone(), 0, None)
+                .unwrap_err()
+                .error,
+            Error::InvalidatedProposal.into()
+        );
+        assert_eq!(
+            MultiSig::reject(ferdie, ms_address, 0).unwrap_err().error,
+            Error::InvalidatedProposal.into()
+        );
+    });
+}
+
+#[test]
+fn invalidate_proposals_add_signer() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob_key = AccountKeyring::Bob.to_account_id();
+        let ferdie_key = AccountKeyring::Ferdie.to_account_id();
+        let ferdie = Origin::signed(ferdie_key.clone());
+        let charlie_key = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = setup_multisig(alice.acc(), 2, create_signers(vec![ferdie_key, bob_key]));
+
+        let call = Box::new(RuntimeCall::MultiSig(
+            multisig::Call::change_sigs_required { sigs_required: 2 },
+        ));
+
+        assert_ok!(MultiSig::create_proposal(
+            ferdie.clone(),
+            ms_address.clone(),
+            call,
+            None
+        ));
+
+        assert_ok!(MultiSig::add_multisig_signers_via_admin(
+            alice.origin(),
+            ms_address.clone(),
+            create_signers(vec![charlie_key])
+        ));
+
+        assert_eq!(
+            LastInvalidProposal::<TestStorage>::get(&ms_address),
+            Some(0)
+        );
+
+        assert_eq!(
+            MultiSig::approve(ferdie.clone(), ms_address.clone(), 0, None)
+                .unwrap_err()
+                .error,
+            Error::InvalidatedProposal.into()
+        );
+        assert_eq!(
+            MultiSig::reject(ferdie, ms_address, 0).unwrap_err().error,
+            Error::InvalidatedProposal.into()
+        );
+    });
+}
+
+#[test]
+fn invalidate_proposals_remove_signer() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob_key = AccountKeyring::Bob.to_account_id();
+        let ferdie_key = AccountKeyring::Ferdie.to_account_id();
+        let ferdie = Origin::signed(ferdie_key.clone());
+        let charlie_key = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = setup_multisig(
+            alice.acc(),
+            2,
+            create_signers(vec![ferdie_key, bob_key, charlie_key.clone()]),
+        );
+
+        let call = Box::new(RuntimeCall::MultiSig(
+            multisig::Call::change_sigs_required { sigs_required: 2 },
+        ));
+
+        assert_ok!(MultiSig::create_proposal(
+            ferdie.clone(),
+            ms_address.clone(),
+            call,
+            None
+        ));
+
+        assert_ok!(MultiSig::remove_multisig_signers_via_admin(
+            alice.origin(),
+            ms_address.clone(),
+            create_signers(vec![charlie_key])
+        ));
+
+        assert_eq!(
+            LastInvalidProposal::<TestStorage>::get(&ms_address),
+            Some(0)
+        );
+
+        assert_eq!(
+            MultiSig::approve(ferdie.clone(), ms_address.clone(), 0, None)
+                .unwrap_err()
+                .error,
+            Error::InvalidatedProposal.into()
+        );
+        assert_eq!(
+            MultiSig::reject(ferdie, ms_address, 0).unwrap_err().error,
+            Error::InvalidatedProposal.into()
+        );
+    });
+}
+
+#[test]
+fn invalidate_proposals_via_executed_proposal() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let bob = Origin::signed(AccountKeyring::Bob.to_account_id());
+        let bob_signer = AccountKeyring::Bob.to_account_id();
+        let charlie = Origin::signed(AccountKeyring::Charlie.to_account_id());
+        let charlie_signer = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = create_multisig_default_perms(
+            alice.acc(),
+            create_signers(vec![charlie_signer.clone(), bob_signer.clone()]),
+            2,
+        );
+
+        let charlie_auth_id = get_last_auth_id(&charlie_signer);
+        assert_ok!(MultiSig::accept_multisig_signer(
+            charlie.clone(),
+            charlie_auth_id
+        ));
+
+        let bob_auth_id = get_last_auth_id(&bob_signer);
+        assert_ok!(MultiSig::accept_multisig_signer(bob.clone(), bob_auth_id));
+
+        let call = Box::new(RuntimeCall::MultiSig(
+            multisig::Call::change_sigs_required { sigs_required: 1 },
+        ));
+        assert_ok!(MultiSig::create_proposal(
+            bob.clone(),
+            ms_address.clone(),
+            call.clone(),
+            None,
+        ));
+
+        assert_ok!(MultiSig::create_proposal(
+            bob.clone(),
+            ms_address.clone(),
+            call.clone(),
+            None,
+        ));
+
+        assert_ok!(MultiSig::create_proposal(
+            bob.clone(),
+            ms_address.clone(),
+            call,
+            None,
+        ));
+
+        assert_ok!(MultiSig::approve(
+            charlie.clone(),
+            ms_address.clone(),
+            0,
+            None
+        ));
+
+        // At this point the proposal of id 0 executes
+        next_block();
+
+        // All other proposals must have been invalidated
+        assert_eq!(
+            LastInvalidProposal::<TestStorage>::get(&ms_address),
+            Some(2)
+        );
+        assert_eq!(
+            MultiSig::approve(charlie.clone(), ms_address.clone(), 1, None)
+                .unwrap_err()
+                .error,
+            Error::InvalidatedProposal.into()
+        );
+        assert_eq!(
+            MultiSig::reject(charlie.clone(), ms_address, 2)
+                .unwrap_err()
+                .error,
+            Error::InvalidatedProposal.into()
         );
     });
 }

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -1255,6 +1255,48 @@ fn proposal_owner_rejection_denied() {
     });
 }
 
+#[test]
+fn remove_admin_successfully() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Multisig creator
+        let alice = User::new(AccountKeyring::Alice);
+        // Multisig signers
+        let ferdie_signer = AccountKeyring::Ferdie.to_account_id();
+        let bob_signer = AccountKeyring::Bob.to_account_id();
+        let charlie_signer = AccountKeyring::Charlie.to_account_id();
+
+        let ms_address = create_multisig_default_perms(
+            alice.acc(),
+            create_signers(vec![ferdie_signer, bob_signer.clone(), charlie_signer]),
+            2,
+        );
+        assert!(AdminDid::<TestStorage>::get(&ms_address).is_some());
+
+        assert_ok!(MultiSig::remove_admin(Origin::signed(ms_address.clone())));
+        assert!(AdminDid::<TestStorage>::get(ms_address).is_none())
+    });
+}
+
+#[test]
+fn remove_admin_not_multsig() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Multisig creator
+        let alice = User::new(AccountKeyring::Alice);
+        // Multisig signers
+        let ferdie_signer = AccountKeyring::Ferdie.to_account_id();
+        let bob_signer = AccountKeyring::Bob.to_account_id();
+        let charlie_signer = AccountKeyring::Charlie.to_account_id();
+
+        create_multisig_default_perms(
+            alice.acc(),
+            create_signers(vec![ferdie_signer, bob_signer.clone(), charlie_signer]),
+            2,
+        );
+
+        assert_noop!(MultiSig::remove_admin(alice.origin()), Error::NoSuchMultisig);
+    });
+}
+
 fn expired_proposals() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = User::new(AccountKeyring::Alice);

--- a/pallets/runtime/tests/src/multisig.rs
+++ b/pallets/runtime/tests/src/multisig.rs
@@ -1293,7 +1293,10 @@ fn remove_admin_not_multsig() {
             2,
         );
 
-        assert_noop!(MultiSig::remove_admin(alice.origin()), Error::NoSuchMultisig);
+        assert_noop!(
+            MultiSig::remove_admin(alice.origin()),
+            Error::NoSuchMultisig
+        );
     });
 }
 

--- a/pallets/weights/src/pallet_multisig.rs
+++ b/pallets/weights/src/pallet_multisig.rs
@@ -471,4 +471,18 @@ impl pallet_multisig::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(8))
             .saturating_add(DbWeight::get().writes(2))
     }
+    // Storage: MultiSig MultiSigSignsRequired (r:1 w:0)
+    // Proof Skipped: MultiSig MultiSigSignsRequired (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: Identity IsDidFrozen (r:1 w:0)
+    // Proof Skipped: Identity IsDidFrozen (max_values: None, max_size: None, mode: Measured)
+    // Storage: MultiSig AdminDid (r:1 w:1)
+    // Proof Skipped: MultiSig AdminDid (max_values: None, max_size: None, mode: Measured)
+    fn remove_admin() -> Weight {
+        // Minimum execution time: 29_555 nanoseconds.
+        Weight::from_ref_time(29_694_000)
+            .saturating_add(DbWeight::get().reads(4))
+            .saturating_add(DbWeight::get().writes(1))
+    }
 }


### PR DESCRIPTION
## changelog

### new features
- Adds `remove_admin`extrinsic; 
 
### new external API
- Adds `remove_admin`extrinsic; 

### other
- Adding/Removing signers invalidates existing proposals;
- Changing number of required signatures invalidates existing proposals;
- Adding a proposal checks if the expiry date is in the future;
