### PR TITLE
Add `unlink_ticker_from_asset_id` extrinsic

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -752,4 +752,17 @@ benchmarks! {
         let asset_id = create_sample_asset::<T>(&alice, true);
         let ticker = reg_unique_ticker::<T>(alice.origin().into(), None);
     }: _(alice.origin, ticker, asset_id)
+
+    unlink_ticker_from_asset_id {
+        set_ticker_registration_config::<T>();
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let asset_id = create_sample_asset::<T>(&alice, true);
+        let ticker = reg_unique_ticker::<T>(alice.origin().into(), None);
+        Module::<T>::link_ticker_to_asset_id(
+            alice.clone().origin().into(),
+            ticker,
+            asset_id
+        )
+        .unwrap();
+    }: _(alice.origin, ticker, asset_id)
 }

--- a/pallets/asset/src/error.rs
+++ b/pallets/asset/src/error.rs
@@ -99,6 +99,10 @@ decl_error! {
         /// An unexpected error when generating a new asset ID.
         AssetIDGenerationError,
         /// The ticker doesn't belong to the caller.
-        TickerNotRegisteredToCaller
+        TickerNotRegisteredToCaller,
+        /// The given asset is already linked to a ticker.
+        AssetIsAlreadyLinkedToATicker,
+        /// The given ticker is not linked to the given asset.
+        TickerIsNotLinkedToTheAsset
     }
 }

--- a/pallets/common/src/traits/asset.rs
+++ b/pallets/common/src/traits/asset.rs
@@ -218,6 +218,7 @@ pub trait WeightInfo {
     fn add_mandatory_mediators(n: u32) -> Weight;
     fn remove_mandatory_mediators(n: u32) -> Weight;
     fn link_ticker_to_asset_id() -> Weight;
+    fn unlink_ticker_from_asset_id() -> Weight;
 }
 
 pub trait AssetFnTrait<Account, Origin> {

--- a/pallets/runtime/tests/src/asset_pallet/link_ticker_to_asset.rs
+++ b/pallets/runtime/tests/src/asset_pallet/link_ticker_to_asset.rs
@@ -1,0 +1,238 @@
+use frame_support::StorageMap;
+use frame_support::{assert_noop, assert_ok};
+use sp_keyring::AccountKeyring;
+
+use pallet_asset::{AssetIDTicker, TickerAssetID};
+use polymesh_primitives::Ticker;
+
+use crate::asset_test::{now, set_timestamp};
+use crate::storage::User;
+use crate::{ExtBuilder, TestStorage};
+
+type Asset = pallet_asset::Module<TestStorage>;
+type AssetError = pallet_asset::Error<TestStorage>;
+type ExternalAgentsError = pallet_external_agents::Error<TestStorage>;
+
+#[test]
+fn link_ticker_to_asset_id_successfully() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_eq!(TickerAssetID::get(ticker), Some(asset_id));
+        assert_eq!(AssetIDTicker::get(asset_id), Some(ticker));
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_id_ticker_not_registered_to_caller() {
+    ExtBuilder::default().build().execute_with(|| {
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(dave.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            dave.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_noop!(
+            Asset::link_ticker_to_asset_id(dave.origin(), ticker, asset_id),
+            AssetError::TickerNotRegisteredToCaller
+        );
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_id_ticker_unauthorized_agent() {
+    ExtBuilder::default().build().execute_with(|| {
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(dave.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            dave.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_noop!(
+            Asset::link_ticker_to_asset_id(alice.origin(), ticker, asset_id),
+            ExternalAgentsError::UnauthorizedAgent
+        );
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_id_expired_ticker() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        set_timestamp(now() + 10001);
+        assert_noop!(
+            Asset::link_ticker_to_asset_id(alice.origin(), ticker, asset_id),
+            AssetError::TickerRegistrationExpired
+        );
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_id_ticker_already_linked() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_noop!(
+            Asset::link_ticker_to_asset_id(alice.origin(), ticker, asset_id),
+            AssetError::TickerIsAlreadyLinkedToAnAsset
+        );
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_asset_already_linked() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+        let ticker_1: Ticker = Ticker::from_slice_truncated(b"TICKER1");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker_1,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_noop!(
+            Asset::link_ticker_to_asset_id(alice.origin(), ticker_1, asset_id),
+            AssetError::AssetIsAlreadyLinkedToATicker
+        );
+    });
+}
+
+#[test]
+fn link_ticker_to_asset_id_after_unlink() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+        let ticker_1: Ticker = Ticker::from_slice_truncated(b"TICKER1");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker_1,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_ok!(Asset::unlink_ticker_from_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker_1,
+            asset_id
+        ));
+
+        assert_eq!(TickerAssetID::get(ticker_1), Some(asset_id));
+        assert_eq!(AssetIDTicker::get(asset_id), Some(ticker_1));
+    });
+}

--- a/pallets/runtime/tests/src/asset_pallet/mod.rs
+++ b/pallets/runtime/tests/src/asset_pallet/mod.rs
@@ -2,7 +2,9 @@ mod accept_ticker_transfer;
 mod base_transfer;
 mod controller_transfer;
 mod issue;
+mod link_ticker_to_asset;
 mod register_metadata;
 mod register_ticker;
+mod unlink_ticker_from_asset;
 
 pub(crate) mod setup;

--- a/pallets/runtime/tests/src/asset_pallet/register_ticker.rs
+++ b/pallets/runtime/tests/src/asset_pallet/register_ticker.rs
@@ -152,7 +152,7 @@ fn register_ticker_too_long() {
 }
 
 #[test]
-fn register_ticker_already_expired() {
+fn register_ticker_already_registered() {
     ExtBuilder::default().build().execute_with(|| {
         let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER00");
         let bob = User::new(AccountKeyring::Bob);

--- a/pallets/runtime/tests/src/asset_pallet/unlink_ticker_from_asset.rs
+++ b/pallets/runtime/tests/src/asset_pallet/unlink_ticker_from_asset.rs
@@ -1,0 +1,191 @@
+use frame_support::{assert_noop, assert_ok};
+use frame_support::{StorageDoubleMap, StorageMap};
+use sp_keyring::AccountKeyring;
+
+use pallet_asset::{AssetIDTicker, TickerAssetID, TickersOwnedByUser, UniqueTickerRegistration};
+use polymesh_primitives::agent::AgentGroup;
+use polymesh_primitives::{AuthorizationData, Signatory, Ticker};
+
+use crate::storage::User;
+use crate::{ExtBuilder, TestStorage};
+
+type Asset = pallet_asset::Module<TestStorage>;
+type AssetError = pallet_asset::Error<TestStorage>;
+type ExternalAgents = pallet_external_agents::Module<TestStorage>;
+type ExternalAgentsError = pallet_external_agents::Error<TestStorage>;
+type Identity = pallet_identity::Module<TestStorage>;
+
+#[test]
+fn unlink_ticker_from_asset_id_successfully() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_ok!(Asset::unlink_ticker_from_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_eq!(TickerAssetID::get(ticker), None);
+        assert_eq!(AssetIDTicker::get(asset_id), None);
+        assert_eq!(UniqueTickerRegistration::<TestStorage>::get(ticker), None);
+        assert_eq!(TickersOwnedByUser::get(alice.did, ticker), false);
+    });
+}
+
+#[test]
+fn unlink_ticker_from_asset_id_unauthorized_agent() {
+    ExtBuilder::default().build().execute_with(|| {
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_noop!(
+            Asset::unlink_ticker_from_asset_id(dave.origin(), ticker, asset_id),
+            ExternalAgentsError::UnauthorizedAgent
+        );
+    });
+}
+
+#[test]
+fn unlink_ticker_from_asset_id_ticker_registration_not_found() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+        let ticker_1: Ticker = Ticker::from_slice_truncated(b"TICKER1");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_noop!(
+            Asset::unlink_ticker_from_asset_id(alice.origin(), ticker_1, asset_id),
+            AssetError::TickerRegistrationNotFound
+        );
+    });
+}
+
+#[test]
+fn unlink_ticker_from_asset_id_ticker_not_registered_to_caller() {
+    ExtBuilder::default().build().execute_with(|| {
+        let bob = User::new(AccountKeyring::Bob);
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        let auth_id = Identity::add_auth(
+            alice.did,
+            Signatory::from(bob.did),
+            AuthorizationData::BecomeAgent(asset_id, AgentGroup::Full),
+            None,
+        )
+        .unwrap();
+        assert_ok!(ExternalAgents::accept_become_agent(bob.origin(), auth_id));
+
+        assert_noop!(
+            Asset::unlink_ticker_from_asset_id(bob.origin(), ticker, asset_id),
+            AssetError::TickerNotRegisteredToCaller
+        );
+    });
+}
+
+#[test]
+fn unlink_ticker_from_asset_id_ticker_not_linked() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(AccountKeyring::Alice);
+        let asset_id = Asset::generate_asset_id(alice.acc(), false);
+        let ticker: Ticker = Ticker::from_slice_truncated(b"TICKER");
+        let ticker_1: Ticker = Ticker::from_slice_truncated(b"TICKER1");
+
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker,));
+        assert_ok!(Asset::register_unique_ticker(alice.origin(), ticker_1,));
+
+        assert_ok!(Asset::create_asset(
+            alice.origin(),
+            b"MyAsset".into(),
+            true,
+            Default::default(),
+            Vec::new(),
+            None,
+        ));
+
+        assert_ok!(Asset::link_ticker_to_asset_id(
+            alice.origin(),
+            ticker,
+            asset_id
+        ));
+
+        assert_noop!(
+            Asset::unlink_ticker_from_asset_id(alice.origin(), ticker_1, asset_id),
+            AssetError::TickerIsNotLinkedToTheAsset
+        );
+    });
+}

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -740,4 +740,26 @@ impl pallet_asset::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(7))
             .saturating_add(DbWeight::get().writes(3))
     }
+    // Storage: Identity KeyRecords (r:1 w:0)
+    // Proof Skipped: Identity KeyRecords (max_values: None, max_size: None, mode: Measured)
+    // Storage: ExternalAgents GroupOfAgent (r:1 w:0)
+    // Proof Skipped: ExternalAgents GroupOfAgent (max_values: None, max_size: None, mode: Measured)
+    // Storage: Permissions CurrentPalletName (r:1 w:0)
+    // Proof Skipped: Permissions CurrentPalletName (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Permissions CurrentDispatchableName (r:1 w:0)
+    // Proof Skipped: Permissions CurrentDispatchableName (max_values: Some(1), max_size: None, mode: Measured)
+    // Storage: Asset UniqueTickerRegistration (r:1 w:1)
+    // Proof Skipped: Asset UniqueTickerRegistration (max_values: None, max_size: None, mode: Measured)
+    // Storage: Asset TickerAssetID (r:1 w:1)
+    // Proof Skipped: Asset TickerAssetID (max_values: None, max_size: None, mode: Measured)
+    // Storage: Asset TickersOwnedByUser (r:0 w:1)
+    // Proof Skipped: Asset TickersOwnedByUser (max_values: None, max_size: None, mode: Measured)
+    // Storage: Asset AssetIDTicker (r:0 w:1)
+    // Proof Skipped: Asset AssetIDTicker (max_values: None, max_size: None, mode: Measured)
+    fn unlink_ticker_from_asset_id() -> Weight {
+        // Minimum execution time: 50_587 nanoseconds.
+        Weight::from_ref_time(53_381_000)
+            .saturating_add(DbWeight::get().reads(6))
+            .saturating_add(DbWeight::get().writes(4))
+    }
 }


### PR DESCRIPTION
## changelog

### new features
- Adds `unlink_ticker_from_asset_id`extrinsic;
### other
- Removes duplicate code (function: ` ensure_security_token_exists`);
- Extrinsic `link_ticker_to_asset_id` returns an error if an asset is already linked to a ticker;