### PR TITLE
Make asset ids valid standard UUIDs.

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2224,8 +2224,9 @@ impl<T: Config> Module<T> {
     }
 
     pub fn generate_asset_id(caller_acc: T::AccountId, update: bool) -> AssetID {
+        let genesis_hash = frame_system::Pallet::<T>::block_hash(T::BlockNumber::zero());
         let nonce = Self::get_nonce(&caller_acc, update);
-        blake2_128(&(b"modlpy/pallet_asset", caller_acc, nonce).encode()).into()
+        blake2_128(&(b"modlpy/pallet_asset", genesis_hash, caller_acc, nonce).encode()).into()
     }
 
     fn get_nonce(caller_acc: &T::AccountId, update: bool) -> u64 {

--- a/primitives/src/asset.rs
+++ b/primitives/src/asset.rs
@@ -32,7 +32,11 @@ use polymesh_primitives_derive::VecU8StrongTyped;
 pub struct AssetID([u8; 16]);
 
 impl From<[u8; 16]> for AssetID {
-    fn from(value: [u8; 16]) -> Self {
+    fn from(mut value: [u8; 16]) -> Self {
+        // Version 8.
+        value[6] = (value[6] & 0x0f) | 0x80;
+        // Standard RFC4122 variant (bits 10xx)
+        value[8] = (value[8] & 0x3f) | 0x80;
         AssetID(value)
     }
 }
@@ -40,7 +44,7 @@ impl From<[u8; 16]> for AssetID {
 impl AssetID {
     /// Creates a new [`AssetID`] instance;
     pub fn new(value: [u8; 16]) -> Self {
-        AssetID(value)
+        value.into()
     }
 
     /// Converts [`AssetID`] type into a shared reference of bytes.


### PR DESCRIPTION
## changelog

### new features

- Force AssetIds to be valid UUIDs (v8 custom).
- Include the chain genesis hash when generating AssetIds (to avoid clashes on multiple networks).
