### PR TITLE
MESH-2160:remove-old-events

### DIFF
--- a/pallets/common/src/traits/settlement.rs
+++ b/pallets/common/src/traits/settlement.rs
@@ -47,8 +47,6 @@ decl_event!(
         VenuesBlocked(IdentityId, AssetId, Vec<VenueId>),
         /// Execution of a leg failed (did, instruction_id, leg_id)
         LegFailedExecution(IdentityId, InstructionId, LegId),
-        /// Instruction failed execution (did, instruction_id)
-        InstructionFailed(IdentityId, InstructionId),
         /// Instruction executed successfully(did, instruction_id)
         InstructionExecuted(IdentityId, InstructionId),
         /// Venue not part of the token's allow list (did, AssetId, venue_id)

--- a/pallets/runtime/tests/src/settlement_pallet/execute_instruction.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/execute_instruction.rs
@@ -189,13 +189,6 @@ fn execute_instruction_storage_rollback() {
         );
         assert_eq!(
             system_events.pop().unwrap().event,
-            crate::storage::EventTest::Settlement(RawEvent::InstructionFailed(
-                SettlementDID.as_id(),
-                instruction_id
-            ))
-        );
-        assert_eq!(
-            system_events.pop().unwrap().event,
             crate::storage::EventTest::Settlement(RawEvent::LegFailedExecution(
                 SettlementDID.as_id(),
                 instruction_id,

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -1322,7 +1322,6 @@ impl<T: Config> Module<T> {
                 instruction_id,
                 failed_leg_id,
             ));
-            Self::deposit_event(RawEvent::InstructionFailed(caller_did, instruction_id));
         }
 
         tx_result


### PR DESCRIPTION
## changelog

### modified events
- Removes `InstructionFailed`event;
