### PR TITLE
Fixup staging asset id maps

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -292,6 +292,9 @@ decl_module! {
             storage_migrate_on!(StorageVersion, 5, {
                 migrations::migrate_to_v5::<T>();
             });
+            // Only needed on staging, but safe to run on other networks.
+            migrations::migrate_to_v5_fixup_asset_id_maps::<T>();
+
             Weight::zero()
         }
 

--- a/pallets/asset/src/migrations.rs
+++ b/pallets/asset/src/migrations.rs
@@ -93,12 +93,27 @@ mod v4 {
 
             // This storage has been removed.
             pub AssetMetadataNextGlobalKey get(fn asset_metadata_next_global_key): AssetMetadataGlobalKey;
+
+            pub AssetIDTicker get(fn asset_id_ticker): map hasher(blake2_128_concat) AssetId => Option<Ticker>;
+            pub TickerAssetID get(fn ticker_asset_id): map hasher(blake2_128_concat) Ticker => Option<AssetId>;
         }
     }
 
     decl_module! {
         pub struct Module<T: Config> for enum Call where origin: T::RuntimeOrigin { }
     }
+}
+
+pub(crate) fn migrate_to_v5_fixup_asset_id_maps<T: Config>() {
+    // Move renamed storage maps.
+    move_prefix(
+        &v4::AssetIDTicker::final_prefix(),
+        &AssetIdTicker::final_prefix(),
+    );
+    move_prefix(
+        &v4::TickerAssetID::final_prefix(),
+        &TickerAssetId::final_prefix(),
+    );
 }
 
 pub(crate) fn migrate_to_v5<T: Config>() {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -57,7 +57,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_000_002,
+    spec_version: 7_000_003,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -53,7 +53,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_000_002,
+    spec_version: 7_000_003,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -55,7 +55,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_000_002,
+    spec_version: 7_000_003,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,


### PR DESCRIPTION
## changelog

### data migration

- Move storage prefix `Asset.AssetIDTicker` to `Asset.AssetIdTicker` (lowercase d).
- Move storage prefix `Asset.TickerAssetID` to `Asset.TickerAssetId` (lowercase d).
