### PR TITLE
Rename ProtocolOp variant

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2254,7 +2254,7 @@ impl<T: Config> Module<T> {
 
 impl<T: Config> Module<T> {
     /// All storage writes for registering `ticker` to `owner` with an optional `expiry`.
-    /// Note: If `charge_fee` is `true` one fee is charged ([`ProtocolOp::AssetRegisterTicker`]).
+    /// Note: If `charge_fee` is `true` one fee is charged ([`ProtocolOp::AssetRegisterUniqueTicker`]).
     fn unverified_register_ticker(
         ticker: Ticker,
         owner: IdentityId,
@@ -2262,7 +2262,7 @@ impl<T: Config> Module<T> {
         charge_fee: bool,
     ) -> DispatchResult {
         if charge_fee {
-            T::ProtocolFee::charge_fee(ProtocolOp::AssetRegisterTicker)?;
+            T::ProtocolFee::charge_fee(ProtocolOp::AssetRegisterUniqueTicker)?;
         }
 
         // If the ticker was already registered, removes the previous owner
@@ -2289,7 +2289,7 @@ impl<T: Config> Module<T> {
     }
 
     /// All storage writes for creating an asset.
-    /// Note: two fees are charged ([`ProtocolOp::AssetCreateAsset`] and [`ProtocolOp::AssetRegisterTicker`]).
+    /// Note: two fees are charged ([`ProtocolOp::AssetCreateAsset`] and [`ProtocolOp::AssetRegisterUniqueTicker`]).
     fn unverified_create_asset(
         caller_did: IdentityId,
         asset_id: AssetId,

--- a/pallets/common/src/protocol_fee.rs
+++ b/pallets/common/src/protocol_fee.rs
@@ -24,7 +24,7 @@ use sp_runtime::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ProtocolOp {
-    AssetRegisterTicker,
+    AssetRegisterUniqueTicker,
     AssetIssue,
     AssetAddDocuments,
     AssetCreateAsset,

--- a/pallets/protocol-fee/src/benchmarking.rs
+++ b/pallets/protocol-fee/src/benchmarking.rs
@@ -27,6 +27,6 @@ benchmarks! {
 
     change_base_fee {
         let origin = RawOrigin::Root;
-        let op = ProtocolOp::AssetRegisterTicker;
+        let op = ProtocolOp::AssetRegisterUniqueTicker;
     }: _(origin, op, 0)
 }

--- a/pallets/runtime/tests/src/ext_builder.rs
+++ b/pallets/runtime/tests/src/ext_builder.rs
@@ -59,7 +59,7 @@ pub struct MockProtocolBaseFees(pub Vec<(ProtocolOp, u128)>);
 impl Default for MockProtocolBaseFees {
     fn default() -> Self {
         let ops = vec![
-            ProtocolOp::AssetRegisterTicker,
+            ProtocolOp::AssetRegisterUniqueTicker,
             ProtocolOp::AssetIssue,
             ProtocolOp::AssetAddDocuments,
             ProtocolOp::AssetCreateAsset,

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -629,11 +629,11 @@ fn do_relayer_batched_subsidy_calls_test() {
     let transaction_fee = TransactionPayment::compute_fee(len as u32, &call_info, 0);
     assert!(transaction_fee > 0);
     let protocol_fee = ProtocolFee::compute_fee(&[
-        ProtocolOp::AssetRegisterTicker,
-        ProtocolOp::AssetRegisterTicker,
-        ProtocolOp::AssetRegisterTicker,
-        ProtocolOp::AssetRegisterTicker,
-        ProtocolOp::AssetRegisterTicker,
+        ProtocolOp::AssetRegisterUniqueTicker,
+        ProtocolOp::AssetRegisterUniqueTicker,
+        ProtocolOp::AssetRegisterUniqueTicker,
+        ProtocolOp::AssetRegisterUniqueTicker,
+        ProtocolOp::AssetRegisterUniqueTicker,
     ]);
     assert!(protocol_fee > 0);
     let total_fee = transaction_fee + protocol_fee;

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -529,7 +529,7 @@ fn do_relayer_transaction_and_protocol_fees_test() {
     // 0. Calculate fees for registering an asset ticker.
     let transaction_fee = TransactionPayment::compute_fee(len as u32, &call_info, 0);
     assert!(transaction_fee > 0);
-    let protocol_fee = ProtocolFee::compute_fee(&[ProtocolOp::AssetRegisterTicker]);
+    let protocol_fee = ProtocolFee::compute_fee(&[ProtocolOp::AssetRegisterUniqueTicker]);
     assert!(protocol_fee > 0);
     let total_fee = transaction_fee + protocol_fee;
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -428,7 +428,7 @@ macro_rules! committee {
 fn protocol_fees() -> Vec<(ProtocolOp, u128)> {
     vec![
         (ProtocolOp::AssetCreateAsset, 2_500 * 1_000_000),
-        (ProtocolOp::AssetRegisterTicker, 500 * 1_000_000),
+        (ProtocolOp::AssetRegisterUniqueTicker, 500 * 1_000_000),
     ]
 }
 


### PR DESCRIPTION
## changelog

### modified external API

- Adds `ProtocolOp::AssetRegisterUniqueTicker`;

