### PR TITLE
Remove From Storage; Add Extrinsic; Remove Check

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -763,4 +763,17 @@ benchmarks! {
         )
         .unwrap();
     }: _(alice.origin, ticker, asset_id)
+
+    update_global_metadata_spec {
+        let asset_metadata_name = make_metadata_name::<T>();
+        let asset_metadata_spec = make_metadata_spec::<T>();
+
+        Pallet::<T>::register_asset_metadata_global_type(
+            RawOrigin::Root.into(),
+            asset_metadata_name.clone(),
+            asset_metadata_spec.clone()
+        )
+        .unwrap();
+    }: _(RawOrigin::Root, asset_metadata_name, asset_metadata_spec)
+
 }

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -120,8 +120,8 @@ use polymesh_primitives::settlement::InstructionId;
 use polymesh_primitives::traits::{AssetFnConfig, AssetFnTrait, ComplianceFnConfig, NFTTrait};
 use polymesh_primitives::{
     extract_auth, storage_migrate_on, storage_migration_ver, AssetIdentifier, Balance, Document,
-    DocumentId, IdentityId, Memo, PortfolioId, PortfolioKind, PortfolioUpdateReason, SecondaryKey,
-    Ticker, WeightMeter,
+    DocumentId, IdentityId, Memo, PortfolioId, PortfolioKind, PortfolioUpdateReason, Ticker,
+    WeightMeter,
 };
 
 pub use types::{
@@ -327,6 +327,9 @@ pub mod pallet {
         /// An identity has unlinked a ticker from an asset.
         /// Parameters: [`IdentityId`] of caller, unlinked [`Ticker`], the asset identifier [`AssetId`].
         TickerUnlinkedFromAsset(IdentityId, Ticker, AssetId),
+        /// Asset Global Metadata Spec has been Updated.
+        /// Parameters: [`AssetMetadataName`] of the metadata, [`AssetMetadataSpec`] of the metadata.
+        GlobalMetadataSpecUpdated(AssetMetadataName, AssetMetadataSpec),
     }
 
     /// Map each [`Ticker`] to its registration details ([`TickerRegistration`]).
@@ -1563,6 +1566,30 @@ pub mod pallet {
             Self::base_unlink_ticker_from_asset_id(origin, ticker, asset_id)?;
             Ok(())
         }
+
+        /// Updates the global metadata specification.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which can be the primary or secondary key of an identity.
+        /// * `asset_metadata_name` - The [`AssetMetadataName`] associated with the global metadata.
+        /// * `asset_metadata_spec` - The new [`AssetMetadataSpec`] that will be associated with the global metadata.
+        ///
+        /// # Events
+        /// * `GlobalMetadataSpecUpdated` - When the global metadata specification is successfully updated.
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the origin is not authorized.
+        /// * `TooLong` - If the metadata url or description length exceeds the maximum allowed length.
+        /// * `AssetMetadataTypeDefMaxLengthExceeded` - If the metadata type definition length exceeds the maximum allowed length.
+        #[pallet::call_index(33)]
+        #[pallet::weight(<T as Config>::WeightInfo::update_global_metadata_spec())]
+        pub fn update_global_metadata_spec(
+            origin: OriginFor<T>,
+            asset_metadata_name: AssetMetadataName,
+            asset_metadata_spec: AssetMetadataSpec,
+        ) -> DispatchResult {
+            Self::base_update_global_metadata_spec(origin, asset_metadata_name, asset_metadata_spec)
+        }
     }
 
     #[pallet::error]
@@ -1701,6 +1728,7 @@ pub mod pallet {
         fn remove_mandatory_mediators(n: u32) -> Weight;
         fn link_ticker_to_asset_id() -> Weight;
         fn unlink_ticker_from_asset_id() -> Weight;
+        fn update_global_metadata_spec() -> Weight;
     }
 }
 
@@ -2520,6 +2548,37 @@ impl<T: AssetConfig> Pallet<T> {
         Self::deposit_event(Event::TickerUnlinkedFromAsset(caller_did, ticker, asset_id));
         Ok(())
     }
+
+    /// Updates the global metadata spec. This function is only callable by the root account.
+    fn base_update_global_metadata_spec(
+        origin: T::RuntimeOrigin,
+        asset_metadata_name: AssetMetadataName,
+        asset_metadata_spec: AssetMetadataSpec,
+    ) -> DispatchResult {
+        ensure_root(origin)?;
+
+        let metadata_key = AssetMetadataGlobalNameToKey::<T>::get(&asset_metadata_name)
+            .ok_or(Error::<T>::AssetMetadataKeyIsMissing)?;
+
+        Self::ensure_asset_metadata_spec_limited(&asset_metadata_spec)?;
+
+        AssetMetadataGlobalSpecs::<T>::try_mutate(metadata_key, |spec| -> DispatchResult {
+            match spec {
+                Some(spec) => {
+                    *spec = asset_metadata_spec.clone();
+                    Ok(())
+                }
+                None => Err(Error::<T>::AssetMetadataKeyIsMissing.into()),
+            }
+        })?;
+
+        Self::deposit_event(Event::GlobalMetadataSpecUpdated(
+            asset_metadata_name,
+            asset_metadata_spec,
+        ));
+
+        Ok(())
+    }
 }
 
 //==========================================================================
@@ -2626,8 +2685,6 @@ impl<T: AssetConfig> Pallet<T> {
 
     /// Returns [`TickerRegistrationStatus`] if all rules for creating an asset are satisfied.
     fn validate_asset_creation_rules(
-        caller_did: IdentityId,
-        secondary_key: Option<SecondaryKey<T::AccountId>>,
         asset_id: &AssetId,
         asset_name: &AssetName,
         asset_type: &AssetType,
@@ -2643,13 +2700,6 @@ impl<T: AssetConfig> Pallet<T> {
 
         // Ensure there's no pre-existing entry for the `asset_id`
         Self::ensure_new_asset_id(asset_id)?;
-
-        // Ensure that the caller has relevant portfolio permissions
-        Portfolio::<T>::ensure_portfolio_custody_and_permission(
-            PortfolioId::default_portfolio(caller_did),
-            caller_did,
-            secondary_key.as_ref(),
-        )?;
 
         Ok(())
     }
@@ -3017,8 +3067,6 @@ impl<T: AssetConfig> Pallet<T> {
         let asset_id = Self::generate_asset_id(caller_data.sender, true);
 
         Self::validate_asset_creation_rules(
-            caller_data.primary_did,
-            caller_data.secondary_key,
             &asset_id,
             &asset_name,
             &asset_type,

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1936,7 +1936,7 @@ impl<T: AssetConfig> Pallet<T> {
             Error::<T>::UnexpectedNonFungibleToken
         );
 
-        Portfolio::<T>::reduce_portfolio_balance(&portfolio, &asset_id, value)?;
+        Portfolio::<T>::reduce_portfolio_balance(portfolio, asset_id, value)?;
 
         asset_details.total_supply = asset_details
             .total_supply
@@ -3260,7 +3260,7 @@ impl<T: AssetConfig> Pallet<T> {
             Portfolio::<T>::portfolio_asset_balances(issuer_portfolio, asset_id) + amount_to_issue;
         Portfolio::<T>::set_portfolio_balance(
             issuer_portfolio,
-            &asset_id,
+            asset_id,
             new_issuer_portfolio_balance,
         );
 
@@ -3322,9 +3322,9 @@ impl<T: AssetConfig> Pallet<T> {
 
         // Updates the balances in the portfolio pallet
         Portfolio::<T>::unchecked_transfer_portfolio_balance(
-            &sender_portfolio,
-            &receiver_portfolio,
-            &asset_id,
+            sender_portfolio,
+            receiver_portfolio,
+            asset_id,
             transfer_value,
         );
 

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -737,13 +737,11 @@ impl<T: Config> Pallet<T> {
         let sender_old_balance = PortfolioAssetBalances::<T>::get(from, asset_id);
         let sender_new_balance = sender_old_balance.saturating_sub(amount);
         Self::set_portfolio_balance(from, asset_id, sender_new_balance);
-        Self::transition_asset_count(&from, sender_old_balance, sender_new_balance);
 
         // Adds the amount to the receiver
         let rcv_old_balance = PortfolioAssetBalances::<T>::get(to, asset_id);
         let rcv_new_balance = rcv_old_balance.saturating_add(amount);
         Self::set_portfolio_balance(to, asset_id, rcv_new_balance);
-        Self::transition_asset_count(&to, rcv_old_balance, rcv_new_balance);
     }
 
     /// Handle cases where the balance for an asset goes to and from 0.
@@ -871,7 +869,6 @@ impl<T: Config> Pallet<T> {
             .ok_or(Error::<T>::InsufficientPortfolioBalance)?;
 
         Self::set_portfolio_balance(pid, asset_id, remaining_balance);
-        Self::transition_asset_count(&pid, total_balance, remaining_balance);
         Ok(())
     }
 

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -696,12 +696,12 @@ impl<T: Config> Pallet<T> {
         Self::portfolio_asset_balances(PortfolioId::user_portfolio(did, num), asset_id)
     }
 
-    /// Sets the asset balance of the  portfolio to `new_balance`.
-    pub fn set_portfolio_balance(pid: PortfolioId, asset_id: &AssetId, new_balance: Balance) {
-        let old_balance = PortfolioAssetBalances::<T>::get(&pid, asset_id);
+    /// Sets the asset balance of the specified portfolio to `new_balance`.
+    pub fn set_portfolio_balance(pid: PortfolioId, asset_id: AssetId, new_balance: Balance) {
+        let old_balance = PortfolioAssetBalances::<T>::get(&pid, &asset_id);
 
         if new_balance.is_zero() {
-            PortfolioAssetBalances::<T>::remove(&pid, asset_id);
+            PortfolioAssetBalances::<T>::remove(&pid, &asset_id);
         } else {
             PortfolioAssetBalances::<T>::insert(pid, asset_id, new_balance);
         }
@@ -728,28 +728,22 @@ impl<T: Config> Pallet<T> {
     /// This function does not do any data validity checks.
     /// The caller must make sure that the portfolio, custodianship and free balance are valid before calling this function.
     pub fn unchecked_transfer_portfolio_balance(
-        from: &PortfolioId,
-        to: &PortfolioId,
-        asset_id: &AssetId,
+        from: PortfolioId,
+        to: PortfolioId,
+        asset_id: AssetId,
         amount: Balance,
     ) {
         // Subtracts the amount from the sender
         let sender_old_balance = PortfolioAssetBalances::<T>::get(from, asset_id);
         let sender_new_balance = sender_old_balance.saturating_sub(amount);
-        if sender_new_balance.is_zero() {
-            PortfolioAssetBalances::<T>::remove(from, asset_id);
-        } else {
-            PortfolioAssetBalances::<T>::insert(from, asset_id, sender_new_balance);
-        }
-        Self::transition_asset_count(from, sender_old_balance, sender_new_balance);
+        Self::set_portfolio_balance(from, asset_id, sender_new_balance);
+        Self::transition_asset_count(&from, sender_old_balance, sender_new_balance);
 
         // Adds the amount to the receiver
         let rcv_old_balance = PortfolioAssetBalances::<T>::get(to, asset_id);
         let rcv_new_balance = rcv_old_balance.saturating_add(amount);
-        if !rcv_new_balance.is_zero() {
-            PortfolioAssetBalances::<T>::insert(to, asset_id, rcv_new_balance);
-        }
-        Self::transition_asset_count(to, rcv_old_balance, rcv_new_balance);
+        Self::set_portfolio_balance(to, asset_id, rcv_new_balance);
+        Self::transition_asset_count(&to, rcv_old_balance, rcv_new_balance);
     }
 
     /// Handle cases where the balance for an asset goes to and from 0.
@@ -864,8 +858,8 @@ impl<T: Config> Pallet<T> {
     /// Reduces the balance of a portfolio.
     /// Throws an error if enough free balance is not available.
     pub fn reduce_portfolio_balance(
-        pid: &PortfolioId,
-        asset_id: &AssetId,
+        pid: PortfolioId,
+        asset_id: AssetId,
         amount: Balance,
     ) -> DispatchResult {
         // Ensure portfolio has enough free balance
@@ -876,15 +870,8 @@ impl<T: Config> Pallet<T> {
             .filter(|rb| rb >= &locked_balance)
             .ok_or(Error::<T>::InsufficientPortfolioBalance)?;
 
-        // Update portfolio balance.
-        if remaining_balance.is_zero() {
-            PortfolioAssetBalances::<T>::remove(pid, asset_id);
-        } else {
-            PortfolioAssetBalances::<T>::insert(pid, asset_id, remaining_balance);
-        }
-
-        Self::transition_asset_count(pid, total_balance, remaining_balance);
-
+        Self::set_portfolio_balance(pid, asset_id, remaining_balance);
+        Self::transition_asset_count(&pid, total_balance, remaining_balance);
         Ok(())
     }
 
@@ -1032,9 +1019,9 @@ impl<T: Config> Pallet<T> {
             match fund.description {
                 FundDescription::Fungible { asset_id, amount } => {
                     Self::unchecked_transfer_portfolio_balance(
-                        &sender_portfolio,
-                        &receiver_portfolio,
-                        &asset_id,
+                        sender_portfolio,
+                        receiver_portfolio,
+                        asset_id,
                         amount,
                     );
                     Self::deposit_event(Event::FundsMovedBetweenPortfolios(

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -696,12 +696,17 @@ impl<T: Config> Pallet<T> {
         Self::portfolio_asset_balances(PortfolioId::user_portfolio(did, num), asset_id)
     }
 
-    /// Sets the asset balance of the a portfolio to `new`.
-    pub fn set_portfolio_balance(pid: PortfolioId, asset_id: &AssetId, new: Balance) {
-        PortfolioAssetBalances::<T>::mutate(&pid, asset_id, |old| {
-            Self::transition_asset_count(&pid, *old, new);
-            *old = new;
-        });
+    /// Sets the asset balance of the  portfolio to `new_balance`.
+    pub fn set_portfolio_balance(pid: PortfolioId, asset_id: &AssetId, new_balance: Balance) {
+        let old_balance = PortfolioAssetBalances::<T>::get(&pid, asset_id);
+
+        if new_balance.is_zero() {
+            PortfolioAssetBalances::<T>::remove(&pid, asset_id);
+        } else {
+            PortfolioAssetBalances::<T>::insert(pid, asset_id, new_balance);
+        }
+
+        Self::transition_asset_count(&pid, old_balance, new_balance);
     }
 
     /// Returns the next portfolio number of a given identity and increments the stored number.
@@ -728,15 +733,23 @@ impl<T: Config> Pallet<T> {
         asset_id: &AssetId,
         amount: Balance,
     ) {
-        PortfolioAssetBalances::<T>::mutate(from, asset_id, |balance| {
-            let old = mem::replace(balance, balance.saturating_sub(amount));
-            Self::transition_asset_count(from, old, *balance);
-        });
+        // Subtracts the amount from the sender
+        let sender_old_balance = PortfolioAssetBalances::<T>::get(from, asset_id);
+        let sender_new_balance = sender_old_balance.saturating_sub(amount);
+        if sender_new_balance.is_zero() {
+            PortfolioAssetBalances::<T>::remove(from, asset_id);
+        } else {
+            PortfolioAssetBalances::<T>::insert(from, asset_id, sender_new_balance);
+        }
+        Self::transition_asset_count(from, sender_old_balance, sender_new_balance);
 
-        PortfolioAssetBalances::<T>::mutate(to, asset_id, |balance| {
-            let old = mem::replace(balance, balance.saturating_add(amount));
-            Self::transition_asset_count(to, old, *balance);
-        });
+        // Adds the amount to the receiver
+        let rcv_old_balance = PortfolioAssetBalances::<T>::get(to, asset_id);
+        let rcv_new_balance = rcv_old_balance.saturating_add(amount);
+        if !rcv_new_balance.is_zero() {
+            PortfolioAssetBalances::<T>::insert(to, asset_id, rcv_new_balance);
+        }
+        Self::transition_asset_count(to, rcv_old_balance, rcv_new_balance);
     }
 
     /// Handle cases where the balance for an asset goes to and from 0.
@@ -864,7 +877,12 @@ impl<T: Config> Pallet<T> {
             .ok_or(Error::<T>::InsufficientPortfolioBalance)?;
 
         // Update portfolio balance.
-        PortfolioAssetBalances::<T>::insert(pid, asset_id, remaining_balance);
+        if remaining_balance.is_zero() {
+            PortfolioAssetBalances::<T>::remove(pid, asset_id);
+        } else {
+            PortfolioAssetBalances::<T>::insert(pid, asset_id, remaining_balance);
+        }
+
         Self::transition_asset_count(pid, total_balance, remaining_balance);
 
         Ok(())
@@ -1182,7 +1200,12 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
         ensure!(locked >= amount, Error::<T>::InsufficientTokensLocked);
 
         // 2. Unlock tokens. Can not underflow due to above ensure.
-        PortfolioLockedAssets::<T>::insert(portfolio, asset_id, locked - amount);
+        if (locked - amount) == 0 {
+            PortfolioLockedAssets::<T>::remove(portfolio, asset_id);
+        } else {
+            PortfolioLockedAssets::<T>::insert(portfolio, asset_id, locked - amount);
+        }
+
         Ok(())
     }
 

--- a/pallets/weights/src/pallet_asset.rs
+++ b/pallets/weights/src/pallet_asset.rs
@@ -764,4 +764,14 @@ impl pallet_asset::WeightInfo for SubstrateWeight {
             .saturating_add(DbWeight::get().reads(6))
             .saturating_add(DbWeight::get().writes(4))
     }
+    // Storage: Asset AssetMetadataGlobalNameToKey (r:1 w:0)
+    // Proof Skipped: Asset AssetMetadataGlobalNameToKey (max_values: None, max_size: None, mode: Measured)
+    // Storage: Asset AssetMetadataGlobalSpecs (r:1 w:1)
+    // Proof Skipped: Asset AssetMetadataGlobalSpecs (max_values: None, max_size: None, mode: Measured)
+    fn update_global_metadata_spec() -> Weight {
+        // Minimum execution time: 40_469 nanoseconds.
+        Weight::from_ref_time(40_786_000)
+            .saturating_add(DbWeight::get().reads(2))
+            .saturating_add(DbWeight::get().writes(1))
+    }
 }


### PR DESCRIPTION
MESH-2135, MESH-2248, MESH-1951
## changelog

### new external API
- Adds `update_global_metadata_spec` extrinsic; 
### new events
- Adds `GlobalMetadataSpecUpdated`event;
### other
- Removes `custody_and_permission` check when creating an asset;
- Removes values from storage when balances go to zero;
