### PR TITLE
Settlement Locking Feature - Part 1

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2905,8 +2905,8 @@ impl<T: AssetConfig> Pallet<T> {
         // Verifies that all compliance rules are being respected
         if !T::ComplianceManager::is_compliant(
             &asset_id,
-            sender_portfolio.did,
-            receiver_portfolio.did,
+            Some(sender_portfolio.did),
+            Some(receiver_portfolio.did),
             weight_meter,
         )? {
             return Err(Error::<T>::InvalidTransferComplianceFailure.into());
@@ -3009,8 +3009,8 @@ impl<T: AssetConfig> Pallet<T> {
 
         match T::ComplianceManager::is_compliant(
             asset_id,
-            sender_portfolio.did,
-            receiver_portfolio.did,
+            Some(sender_portfolio.did),
+            Some(receiver_portfolio.did),
             weight_meter,
         ) {
             Ok(is_compliant) => {

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -97,6 +97,7 @@ use frame_support::BoundedBTreeSet;
 use frame_system::ensure_root;
 use sp_io::hashing::blake2_128;
 use sp_runtime::traits::Zero;
+use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::prelude::*;
 
@@ -3114,6 +3115,20 @@ impl<T: AssetConfig> Pallet<T> {
         }
 
         nonce
+    }
+
+    pub fn ensure_valid_statistics(
+        asset_id: AssetId,
+        total_rcv_per_did: &BTreeMap<IdentityId, Balance>,
+        total_sent_per_did: &BTreeMap<IdentityId, Balance>,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        Statistics::<T>::ensure_valid_statistics(
+            asset_id,
+            total_rcv_per_did,
+            total_sent_per_did,
+            weight_meter,
+        )
     }
 }
 

--- a/pallets/compliance-manager/src/benchmarking.rs
+++ b/pallets/compliance-manager/src/benchmarking.rs
@@ -606,8 +606,8 @@ benchmarks! {
             !Pallet::<T>::is_any_requirement_compliant(
                 &asset_id,
                 &requirements,
-                alice.did(),
-                bob.did(),
+                Some(alice.did()),
+                Some(bob.did()),
                 &mut weight_meter
             )
             .unwrap()

--- a/pallets/compliance-manager/src/lib.rs
+++ b/pallets/compliance-manager/src/lib.rs
@@ -715,10 +715,17 @@ impl<T: Config> Pallet<T> {
     /// Loads the context for each condition in `conditions` and verifies that all of them evaluate to `true`.
     fn are_all_conditions_satisfied(
         asset_id: &AssetId,
-        did: IdentityId,
+        did: Option<IdentityId>,
         conditions: &[Condition],
         weight_meter: &mut WeightMeter,
     ) -> Result<bool, DispatchError> {
+        let did = {
+            match did {
+                Some(did) => did,
+                None => return Ok(true),
+            }
+        };
+
         let slot = &mut None;
         for condition in conditions {
             if !Self::is_condition_satisfied(asset_id, did, condition, slot, weight_meter)? {
@@ -864,8 +871,8 @@ impl<T: Config> Pallet<T> {
     fn is_any_requirement_compliant(
         asset_id: &AssetId,
         requirements: &[ComplianceRequirement],
-        sender_did: IdentityId,
-        receiver_did: IdentityId,
+        sender_did: Option<IdentityId>,
+        receiver_did: Option<IdentityId>,
         weight_meter: &mut WeightMeter,
     ) -> Result<bool, DispatchError> {
         for requirement in requirements {
@@ -892,8 +899,8 @@ impl<T: Config> Pallet<T> {
 impl<T: Config> ComplianceFnConfig for Pallet<T> {
     fn is_compliant(
         asset_id: &AssetId,
-        sender_did: IdentityId,
-        receiver_did: IdentityId,
+        sender_did: Option<IdentityId>,
+        receiver_did: Option<IdentityId>,
         weight_meter: &mut WeightMeter,
     ) -> Result<bool, DispatchError> {
         let asset_compliance = AssetCompliances::<T>::get(asset_id);

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -659,8 +659,8 @@ impl<T: Config> Pallet<T> {
         // Verifies that all compliance rules are being respected
         if !T::Compliance::is_compliant(
             nfts.asset_id(),
-            sender_portfolio.did,
-            receiver_portfolio.did,
+            Some(sender_portfolio.did),
+            Some(receiver_portfolio.did),
             weight_meter.ok_or(Error::<T>::InvalidNFTTransferComplianceFailure)?,
         )? {
             return Err(Error::<T>::InvalidNFTTransferComplianceFailure.into());
@@ -821,8 +821,8 @@ impl<T: Config> Pallet<T> {
 
         match T::Compliance::is_compliant(
             nfts.asset_id(),
-            sender_portfolio.did,
-            receiver_portfolio.did,
+            Some(sender_portfolio.did),
+            Some(receiver_portfolio.did),
             weight_meter,
         ) {
             Ok(is_compliant) => {

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -1145,35 +1145,20 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
-    /// Locks some user tokens so that they can not be used for transfers.
-    /// This is used internally by the settlement engine to prevent users from using the same funds
-    /// in multiple ongoing settlements
-    ///
-    /// # Errors
-    /// * `InsufficientPortfolioBalance` if the portfolio does not have enough free balance to lock
     fn lock_tokens(portfolio: &PortfolioId, asset_id: &AssetId, amount: Balance) -> DispatchResult {
         Self::ensure_sufficient_balance(portfolio, asset_id, amount)?;
         Self::unchecked_lock_tokens(portfolio, asset_id, amount);
         Ok(())
     }
 
-    /// Unlocks some locked tokens of a user.
-    /// Since this is only ever called by the settlement engine,
-    /// it will never be called under circumstances when it has to return an error.
-    /// We are being defensive with the checks anyway.
-    ///
-    /// # Errors
-    /// * `InsufficientTokensLocked` if the portfolio does not have enough locked tokens to unlock
     fn unlock_tokens(
         portfolio: &PortfolioId,
         asset_id: &AssetId,
         amount: Balance,
     ) -> DispatchResult {
-        // 1. Ensure portfolio has enough locked tokens
         let locked = PortfolioLockedAssets::<T>::get(portfolio, asset_id);
         ensure!(locked >= amount, Error::<T>::InsufficientTokensLocked);
 
-        // 2. Unlock tokens. Can not underflow due to above ensure.
         if (locked - amount) == 0 {
             PortfolioLockedAssets::<T>::remove(portfolio, asset_id);
         } else {
@@ -1183,18 +1168,14 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
         Ok(())
     }
 
-    /// Ensure that the `portfolio` exists.
     fn ensure_portfolio_validity(portfolio: &PortfolioId) -> DispatchResult {
         Self::ensure_portfolio_validity(portfolio)
     }
 
-    /// Ensures that the portfolio's custody is with the provided identity
     fn ensure_portfolio_custody(portfolio: PortfolioId, custodian: IdentityId) -> DispatchResult {
         Self::ensure_portfolio_custody(portfolio, custodian)
     }
 
-    /// Ensures that the portfolio's custody is with the provided identity
-    /// And the secondary key has the relevant portfolio permission
     fn ensure_portfolio_custody_and_permission(
         portfolio: PortfolioId,
         custodian: IdentityId,
@@ -1203,41 +1184,25 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
         Self::ensure_portfolio_custody_and_permission(portfolio, custodian, secondary_key)
     }
 
-    /// Locks the given nft. This prevents transfering the same NFT more than once.
-    ///
-    /// # Errors
-    /// * `NFTAlreadyLocked` if the given nft is already locked.
-    /// * `NFTNotFoundInPortfolio` if the given nft was not found in the portfolio.
     fn lock_nft(portfolio_id: &PortfolioId, asset_id: &AssetId, nft_id: &NFTId) -> DispatchResult {
-        // Verifies if the portfolio contains the NFT
         ensure!(
             PortfolioNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
             Error::<T>::NFTNotFoundInPortfolio
         );
-        // Verifies if the nft is not locked
         ensure!(
             !PortfolioLockedNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
             Error::<T>::NFTAlreadyLocked
         );
-        // Locks the nft
         PortfolioLockedNFT::<T>::insert(portfolio_id, (asset_id, nft_id), true);
         Ok(())
     }
 
-    /// Unlocks the given nft.
-    ///
-    /// # Errors
-    /// * `NFTNotFoundInPortfolio` if the given nft was not found in the portfolio.
     fn unlock_nft(
         portfolio_id: &PortfolioId,
         asset_id: &AssetId,
         nft_id: &NFTId,
     ) -> DispatchResult {
-        // Verifies if the locked NFT exist.
-        ensure!(
-            PortfolioLockedNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
-            Error::<T>::NFTNotLocked
-        );
+        Self::ensure_nft_is_locked(portfolio_id, asset_id, nft_id)?;
         PortfolioLockedNFT::<T>::remove(portfolio_id, (asset_id, nft_id));
         Ok(())
     }
@@ -1254,5 +1219,41 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
             return true;
         }
         PreApprovedPortfolios::<T>::get(portfolio_id, asset_id)
+    }
+
+    fn ensure_tokens_are_locked(
+        portfolio: &PortfolioId,
+        asset_id: &AssetId,
+        amount: Balance,
+    ) -> DispatchResult {
+        ensure!(
+            PortfolioLockedAssets::<T>::get(portfolio, asset_id) >= amount,
+            Error::<T>::InsufficientTokensLocked
+        );
+        Ok(())
+    }
+
+    fn ensure_nft_is_locked(
+        portfolio_id: &PortfolioId,
+        asset_id: &AssetId,
+        nft_id: &NFTId,
+    ) -> DispatchResult {
+        ensure!(
+            PortfolioLockedNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
+            Error::<T>::NFTNotLocked
+        );
+        Ok(())
+    }
+
+    fn ensure_portfolio_balance(
+        portfolio_id: &PortfolioId,
+        asset_id: &AssetId,
+        amount: Balance,
+    ) -> DispatchResult {
+        ensure!(
+            PortfolioAssetBalances::<T>::get(portfolio_id, asset_id) >= amount,
+            Error::<T>::InsufficientPortfolioBalance
+        );
+        Ok(())
     }
 }

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -1202,7 +1202,10 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
         asset_id: &AssetId,
         nft_id: &NFTId,
     ) -> DispatchResult {
-        Self::ensure_nft_is_locked(portfolio_id, asset_id, nft_id)?;
+        ensure!(
+            PortfolioLockedNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
+            Error::<T>::NFTNotLocked
+        );
         PortfolioLockedNFT::<T>::remove(portfolio_id, (asset_id, nft_id));
         Ok(())
     }
@@ -1229,18 +1232,6 @@ impl<T: Config> PortfolioSubTrait<T::AccountId> for Pallet<T> {
         ensure!(
             PortfolioLockedAssets::<T>::get(portfolio, asset_id) >= amount,
             Error::<T>::InsufficientTokensLocked
-        );
-        Ok(())
-    }
-
-    fn ensure_nft_is_locked(
-        portfolio_id: &PortfolioId,
-        asset_id: &AssetId,
-        nft_id: &NFTId,
-    ) -> DispatchResult {
-        ensure!(
-            PortfolioLockedNFT::<T>::contains_key(portfolio_id, (asset_id, nft_id)),
-            Error::<T>::NFTNotLocked
         );
         Ok(())
     }

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -556,6 +556,7 @@ macro_rules! misc_pallet_impls {
             type MaxNumberOfPortfolios = MaxNumberOfPortfolios;
             type MaxNumberOfVenueSigners = MaxNumberOfVenueSigners;
             type MaxInstructionMediators = MaxInstructionMediators;
+            type MaximumLockPeriod = MaximumLockPeriod;
         }
 
         impl pallet_sto::Config for Runtime {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -94,6 +94,7 @@ parameter_types! {
     pub const MaxNumberOfPortfolios: u32 = (10 + 100) * 2;
     pub const MaxNumberOfVenueSigners: u32 = 50;
     pub const MaxInstructionMediators: u32 = 4;
+    pub const MaximumLockPeriod: Moment = 1_440_000; // 24 hours
 
     // Multisig
     pub const MaxMultiSigSigners: u32 = 50;

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -92,6 +92,7 @@ parameter_types! {
     pub const MaxNumberOfPortfolios: u32 = (10 + 100) * 2;
     pub const MaxNumberOfVenueSigners: u32 = 50;
     pub const MaxInstructionMediators: u32 = 4;
+    pub const MaximumLockPeriod: Moment = 1_440_000; // 24 hours
 
     // Multisig
     pub const MaxMultiSigSigners: u32 = 50;

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -95,6 +95,7 @@ parameter_types! {
     pub const MaxNumberOfPortfolios: u32 = (10 + 100) * 2;
     pub const MaxNumberOfVenueSigners: u32 = 50;
     pub const MaxInstructionMediators: u32 = 4;
+    pub const MaximumLockPeriod: Moment = 1_440_000; // 24 hours
 
     // Multisig
     pub const MaxMultiSigSigners: u32 = 50;

--- a/pallets/runtime/tests/src/compliance_manager_test.rs
+++ b/pallets/runtime/tests/src/compliance_manager_test.rs
@@ -1469,7 +1469,12 @@ fn can_verify_restriction_with_primary_issuance_agent_we() {
     // No compliance requirement is present, compliance should pass
     let mut weight_meter = WeightMeter::max_limit_no_minimum();
     assert_ok!(
-        ComplianceManager::is_compliant(&asset_id, issuer.did, other.did, &mut weight_meter),
+        ComplianceManager::is_compliant(
+            &asset_id,
+            Some(issuer.did),
+            Some(other.did),
+            &mut weight_meter
+        ),
         true
     );
 
@@ -1490,7 +1495,7 @@ fn can_verify_restriction_with_primary_issuance_agent_we() {
     ));
 
     let verify = |from: User, to: User, weight_meter: &mut WeightMeter| {
-        ComplianceManager::is_compliant(&asset_id, from.did, to.did, weight_meter)
+        ComplianceManager::is_compliant(&asset_id, Some(from.did), Some(to.did), weight_meter)
     };
 
     // From primary issuance agent to the random guy should succeed

--- a/pallets/runtime/tests/src/staking/mock.rs
+++ b/pallets/runtime/tests/src/staking/mock.rs
@@ -460,6 +460,22 @@ impl PortfolioSubTrait<AccountId> for Test {
     fn skip_portfolio_affirmation(_: &PortfolioId, _: &AssetId) -> bool {
         unimplemented!()
     }
+
+    fn ensure_tokens_are_locked(
+        _portfolio: &PortfolioId,
+        _asset_id: &AssetId,
+        _amount: polymesh_primitives::Balance,
+    ) -> DispatchResult {
+        unimplemented!()
+    }
+
+    fn ensure_portfolio_balance(
+        _portfolio_id: &PortfolioId,
+        _asset_id: &AssetId,
+        _amount: polymesh_primitives::Balance,
+    ) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
 impl CheckCdd<AccountId> for Test {

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -214,6 +214,7 @@ parameter_types! {
     pub const MaxNumberOfFungibleAssets: u32 = 100;
     pub const MaxNumberOfNFTsPerLeg: u32 = 10;
     pub const MaxNumberOfNFTs: u32 = 100;
+    pub const MaximumLockPeriod: Moment = 1_440_000;
 
     // Multisig
     pub const MaxMultiSigSigners: u32 = 50;

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -15,33 +15,49 @@
 
 //! # Settlement Module
 //!
-//! Settlement module manages all kinds of transfers and settlements of assets
+//! The Settlement module manages all kinds of transfers and settlements of assets.
 //!
 //! ## Overview
 //!
-//! The settlement module provides functionality to settle onchain as well as offchain trades between multiple parties.
-//! All trades are settled under venues. An appropriately permissioned external agent
-//! can allow/block certain venues from settling trades that involve their tokens.
-//! An atomic settlement is called an Instruction. An instruction can contain multiple legs. Legs are essentially simple one to one transfers.
-//! When an instruction is settled, either all legs are executed successfully or none are. In other words, if one of the leg fails due to
-//! compliance failure, all other legs will also fail.
+//! The settlement module provides functionality to settle both on-chain and off-chain trades between multiple parties.
+//! All trades are settled under venues. An appropriately permissioned external agent can allow or block certain venues
+//! from settling trades that involve their tokens. An atomic settlement is called an Instruction. An instruction can
+//! contain multiple legs, which are essentially simple one-to-one transfers. When an instruction is settled, either all
+//! legs are executed successfully or none are. In other words, if one of the legs fails due to compliance failure, all
+//! other legs will also fail.
 //!
-//! An instruction must be authorized by all the counter parties involved for it to be executed.
-//! An instruction can be set to automatically execute in the next block when all authorizations are received or at a particular block number.
+//! An instruction must be authorized by all the counter parties involved for it to be executed. An instruction can be
+//! set to automatically execute in the next block when all authorizations are received or at a particular block number.
 //!
-//! Offchain settlements are represented via receipts. If a leg has a receipt attached to it, it will not be executed onchain.
-//! All other legs will be executed onchain during settlement.
+//! Off-chain settlements are represented via receipts. If a leg has a receipt attached to it, it will not be executed
+//! on-chain. All other legs will be executed on-chain during settlement.
 //!
 //! ## Dispatchable Functions
 //!
 //! - `create_venue` - Registers a new venue.
-//! - `add_instruction` - Adds a new instruction.
-//! - `affirm_instruction` - Affirms an existing instruction.
-//! - `withdraw_affirmation` - Withdraw an existing affirmation to the given instruction.
-//! - `reject_instruction` - Rejects an existing instruction.
-//! - `set_venue_filtering` - Enables or disabled venue filtering for a token.
+//! - `update_venue_details` - Updates the details of an existing venue.
+//! - `update_venue_type` - Updates the type of an existing venue.
+//! - `affirm_with_receipts` - Affirms an instruction using receipts for off-chain transfers.
+//! - `set_venue_filtering` - Enables or disables venue filtering for a token.
 //! - `allow_venues` - Allows additional venues to create instructions involving an asset.
 //! - `disallow_venues` - Revokes permission given to venues for creating instructions involving a particular asset.
+//! - `update_venue_signers` - Updates the signers of a venue.
+//! - `execute_manual_instruction` - Manually executes an instruction.
+//! - `add_instruction` - Adds a new instruction.
+//! - `add_and_affirm_instruction` - Adds and affirms a new instruction.
+//! - `affirm_instruction` - Provides affirmation to an existing instruction.
+//! - `withdraw_affirmation` - Withdraws an affirmation for a given instruction.
+//! - `reject_instruction` - Rejects an existing instruction.
+//! - `execute_scheduled_instruction` - Executes a scheduled instruction.
+//! - `affirm_with_receipts_with_count` - Affirms an instruction using receipts for off-chain transfers with a specified count.
+//! - `affirm_instruction_with_count` - Provides affirmation to an existing instruction with a specified count.
+//! - `reject_instruction_with_count` - Rejects an existing instruction with a specified count.
+//! - `withdraw_affirmation_with_count` - Withdraws an affirmation for a given instruction with a specified count.
+//! - `add_instruction_with_mediators` - Adds a new instruction with mediators.
+//! - `add_and_affirm_with_mediators` - Adds and affirms a new instruction with mediators.
+//! - `affirm_instruction_as_mediator` - Affirms the instruction as a mediator.
+//! - `withdraw_affirmation_as_mediator` - Removes the mediator's affirmation for the instruction.
+//! - `reject_instruction_as_mediator` - Rejects an existing instruction as a mediator.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
@@ -61,27 +77,29 @@ use frame_support::weights::Weight;
 use frame_support::{ensure, BoundedBTreeSet};
 use frame_system::pallet_prelude::*;
 use frame_system::{ensure_root, RawOrigin};
+use polymesh_primitives::{nft, weight_meter, NFTId};
 use sp_runtime::traits::{One, Verify};
+use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::convert::TryFrom;
 use sp_std::prelude::*;
 use sp_std::vec;
 
-use pallet_asset::MandatoryMediators;
+use pallet_asset::{BalanceOf, Frozen, MandatoryMediators};
 use pallet_base::{ensure_string_limited, try_next_post};
 use polymesh_primitives::asset::AssetId;
 use polymesh_primitives::constants::queue_priority::SETTLEMENT_INSTRUCTION_EXECUTION_PRIORITY;
 use polymesh_primitives::settlement::{
     AffirmationCount, AffirmationStatus, AssetCount, ExecuteInstructionInfo, FilteredLegs,
-    Instruction, InstructionId, InstructionInfo, InstructionStatus, Leg, LegId, LegStatus,
-    MediatorAffirmationStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType, Venue,
-    VenueDetails, VenueId, VenueType,
+    FungibleTxSummary, Instruction, InstructionId, InstructionInfo, InstructionStatus, Leg, LegId,
+    LegStatus, MediatorAffirmationStatus, Receipt, ReceiptDetails, ReceiptMetadata, SettlementType,
+    Venue, VenueDetails, VenueId, VenueType,
 };
-use polymesh_primitives::with_transaction;
+use polymesh_primitives::traits::ComplianceFnConfig;
 use polymesh_primitives::SystematicIssuers::Settlement as SettlementDID;
 use polymesh_primitives::{
-    storage_migration_ver, traits::PortfolioSubTrait, Balance, IdentityId, Memo, NFTs, PortfolioId,
-    SecondaryKey, WeightMeter,
+    storage_migration_ver, traits::PortfolioSubTrait, with_transaction, Balance, IdentityId, Memo,
+    NFTs, PortfolioId, SecondaryKey, WeightMeter,
 };
 
 type System<T> = frame_system::Pallet<T>;
@@ -451,6 +469,10 @@ pub mod pallet {
         /// Maximum number mediators in the instruction level (this does not include asset mediators).
         #[pallet::constant]
         type MaxInstructionMediators: Get<u32>;
+
+        /// The maximum time period that an instruction can be held in the `LockedForExecution` status.
+        #[pallet::constant]
+        type MaximumLockPeriod: Get<Self::Moment>;
     }
 
     #[pallet::error]
@@ -543,6 +565,20 @@ pub mod pallet {
         MediatorAffirmationExpired,
         /// Offchain assets must have a venue.
         OffChainAssetsMustHaveAVenue,
+        /// Instructions of type `SettleOnComplianceCheck` must have at least one mediator.
+        SettlementTypeRequiresMediators,
+        /// The instruction has a frozen asset.
+        InstructionWithAFrozenAsset,
+        /// The instruction has an identity with an invalid CDD claim.
+        InstructionWithAnInvalidCDDClaim,
+        /// One of the instruction receivers is not compliant.
+        IntructionReceiverIsNotCompliant,
+        /// One of the instruction senders is not compliant.
+        IntructionSenderIsNotCompliant,
+        /// Of of the sender doesn't have enough balance to execute the instruction.
+        SenderHasInsufficientBalance,
+        /// The instruction is trying to transfer the same nft more than once.
+        DuplicatedNFTId,
     }
 
     storage_migration_ver!(3);
@@ -1359,6 +1395,18 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             Self::base_reject_instruction(origin, instruction_id, None, number_of_assets)
         }
+
+        #[pallet::weight(Weight::zero())]
+        #[pallet::call_index(24)]
+        pub fn lock_instruction(
+            origin: OriginFor<T>,
+            instruction_id: InstructionId,
+            weight_limit: Option<Weight>,
+        ) -> DispatchResult {
+            let mut weight_meter = unimplemented!();
+            Self::base_lock_instruction(origin, instruction_id, &mut weight_meter)?;
+            Ok(())
+        }
     }
 }
 
@@ -1458,6 +1506,12 @@ impl<T: Config> Pallet<T> {
         // Adds the instruction mediators
         if let Some(mediators) = mediators {
             instruction_info.extend_mediators(mediators.into())
+        }
+
+        if settlement_type == SettlementType::SettleOnComplianceCheck
+            && instruction_info.mediators().is_empty()
+        {
+            return Err(Error::<T>::SettlementTypeRequiresMediators.into());
         }
 
         // Advance and get next `instruction_id`.
@@ -1743,7 +1797,7 @@ impl<T: Config> Pallet<T> {
                 Error::<T>::InvalidInstructionStatusForExecution
             );
             // Ensures all mediator's affirmations are still valid
-            Self::ensure_non_expired_affirmations(&instruction_id)?;
+            Self::validate_mediators_affirmations(&instruction_id)?;
 
             // The order of execution of the legs matter in some edge cases around compliance.
             let mut instruction_legs: Vec<(LegId, Leg)> =
@@ -1815,12 +1869,49 @@ impl<T: Config> Pallet<T> {
         tx_result
     }
 
-    /// Returns `Ok` if all mediator's affirmation are still valid. Otherwise, returns an error.
-    /// This call also removes all elements from the `InstructionMediatorsAffirmations` storage.
-    fn ensure_non_expired_affirmations(instruction_id: &InstructionId) -> DispatchResult {
+    /// Returns `Ok` if all conditions for executing the instruction are met.
+    /// The conditions for executing an instruction are:
+    ///     - All affirmations have been received
+    ///     - Instruction is pending or has failed at least one time
+    ///     - All mediator's affirmations are still valid
+    ///     - All assets are in the allowed venue list
+    ///     - All senders have the right amount of assets being transferred
+    ///     - All senders and receivers are compliant and have valid CDD claims
+    ///     - All assets' statistics are still valid
+    ///     - There are no frozen assets
+    fn validate_execute_instruction_conditions(
+        instruction_id: &InstructionId,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        ensure!(
+            InstructionAffirmsPending::<T>::get(instruction_id) == 0,
+            Error::<T>::NotAllAffirmationsHaveBeenReceived
+        );
+
+        Self::ensure_instruction_is_pending_or_failed(instruction_id)?;
+
+        Self::validate_mediators_affirmations(instruction_id)?;
+
+        let mut instruction_legs: Vec<_> =
+            InstructionLegs::<T>::iter_prefix(instruction_id).collect();
+
+        Self::ensure_no_missing_affirmation(instruction_id, &instruction_legs)?;
+
+        // Ensures the venue is allowed for all tickers in the instruction
+        let instruction_details = InstructionDetails::<T>::get(instruction_id);
+        Self::ensure_allowed_venue(&instruction_legs, instruction_details.venue_id)?;
+
+        Self::ensure_assets_can_be_transferred(instruction_id, &instruction_legs, weight_meter)?;
+
+        Ok(())
+    }
+
+    /// Returns `Ok` if all mediator's affirmation are still valid.
+    fn validate_mediators_affirmations(instruction_id: &InstructionId) -> DispatchResult {
         let current_timestamp = <pallet_timestamp::Pallet<T>>::get();
-        for (_, mediator_affirmation) in
-            InstructionMediatorsAffirmations::<T>::drain_prefix(instruction_id)
+
+        for mediator_affirmation in
+            InstructionMediatorsAffirmations::<T>::iter_prefix_values(instruction_id)
         {
             match mediator_affirmation {
                 MediatorAffirmationStatus::Affirmed { expiry, .. } => {
@@ -1839,8 +1930,8 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Returns `Ok` if all affirmations have been received. Otherwise, returns an error.
-    /// This call also removes all elements from `UserAffirmations`, `AffirmsReceived` and `OffChainAffirmations` storage.
+    /// Returns `Ok` if all affirmations have been received.
+    #[rustfmt::skip]
     fn ensure_no_missing_affirmation(
         instruction_id: &InstructionId,
         instruction_legs: &[(LegId, Leg)],
@@ -1849,21 +1940,17 @@ impl<T: Config> Pallet<T> {
 
         for (leg_id, leg) in instruction_legs {
             match leg {
-                Leg::Fungible {
-                    sender, receiver, ..
-                }
-                | Leg::NonFungible {
-                    sender, receiver, ..
-                } => {
+                Leg::Fungible { sender, receiver, .. }
+                | Leg::NonFungible { sender, receiver, .. } => {
                     if unique_portfolios.insert(sender) {
                         let sdr_affirmation_status =
-                            UserAffirmations::<T>::take(sender, instruction_id);
+                            UserAffirmations::<T>::get(sender, instruction_id);
                         ensure!(
                             sdr_affirmation_status == AffirmationStatus::Affirmed,
                             Error::<T>::NotAllAffirmationsHaveBeenReceived
                         );
                         let sdr_affirmation_status =
-                            AffirmsReceived::<T>::take(instruction_id, sender);
+                            AffirmsReceived::<T>::get(instruction_id, sender);
                         ensure!(
                             sdr_affirmation_status == AffirmationStatus::Affirmed,
                             Error::<T>::NotAllAffirmationsHaveBeenReceived
@@ -1871,13 +1958,13 @@ impl<T: Config> Pallet<T> {
                     }
                     if unique_portfolios.insert(receiver) {
                         let rcv_affirmation_status =
-                            UserAffirmations::<T>::take(receiver, instruction_id);
+                            UserAffirmations::<T>::get(receiver, instruction_id);
                         ensure!(
                             rcv_affirmation_status == AffirmationStatus::Affirmed,
                             Error::<T>::NotAllAffirmationsHaveBeenReceived
                         );
                         let rcv_affirmation_status =
-                            AffirmsReceived::<T>::take(instruction_id, receiver);
+                            AffirmsReceived::<T>::get(instruction_id, receiver);
                         ensure!(
                             rcv_affirmation_status == AffirmationStatus::Affirmed,
                             Error::<T>::NotAllAffirmationsHaveBeenReceived
@@ -1886,7 +1973,7 @@ impl<T: Config> Pallet<T> {
                 }
                 Leg::OffChain { .. } => {
                     ensure!(
-                        OffChainAffirmations::<T>::take(instruction_id, leg_id)
+                        OffChainAffirmations::<T>::get(instruction_id, leg_id)
                             == AffirmationStatus::Affirmed,
                         Error::<T>::NotAllAffirmationsHaveBeenReceived,
                     );
@@ -1894,6 +1981,205 @@ impl<T: Config> Pallet<T> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Returns `Ok` if all assets can be transferred.
+    #[rustfmt::skip]
+    fn ensure_assets_can_be_transferred(
+        id: &InstructionId,
+        instruction_legs: &[(LegId, Leg)],
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        let mut nfts_transferred = BTreeMap::new();
+        let mut fungible_tx_summary = FungibleTxSummary::new();
+
+        // Aggregates the total amount of assets sent and received per DID and per Portfolio
+        for (leg_id, leg) in instruction_legs {
+            match leg {
+                Leg::Fungible { sender, receiver, asset_id, amount } => {
+                    ensure!(
+                        InstructionLegStatus::<T>::get(id, leg_id) == LegStatus::ExecutionPending,
+                        Error::<T>::UnexpectedLegStatus
+                    );
+                    instruction_tx_summary
+                        .add_fungible_transfer(*sender, *receiver, *asset_id, *amount);
+                },
+                Leg::NonFungible { sender, receiver, nfts } => {
+                    ensure!(
+                        InstructionLegStatus::<T>::get(id, leg_id) == LegStatus::ExecutionPending,
+                        Error::<T>::UnexpectedLegStatus
+                    );
+                    Self::ensure_valid_nft_transfer(
+                        sender,
+                        receiver,
+                        nfts,
+                        &mut nfts_transferred,
+                        weight_meter
+                    )?;
+                },
+                Leg::OffChain { .. } => {
+                    if let LegStatus::ExecutionToBeSkipped(_, _) =
+                        InstructionLegStatus::<T>::get(id, leg_id)
+                    {
+                        continue;
+                    }
+                    return Err(Error::<T>::UnexpectedLegStatus.into());
+                }
+            }
+        }
+
+        Self::ensure_valid_fungible_transfers(&instruction_tx_summary, weight_meter)?;
+        Ok(())
+    }
+
+    /// Returns `Ok` if the nfts can be transferred. Adds the nfts to the `nfts_transferred` map.
+    fn ensure_valid_nft_transfer(
+        sender_pid: &PortfolioId,
+        receiver_pid: &PortfolioId,
+        nfts: &NFTs,
+        nfts_transferred: &mut BTreeMap<AssetId, BTreeSet<NFTId>>,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        for nft_id in nfts.ids() {
+            // It should not be possible to transfer the same NFT twice in the same instruction
+            if let Some(transferred_ids) = nfts_transferred.get(nfts.asset_id()) {
+                ensure!(
+                    !transferred_ids.contains(nft_id),
+                    Error::<T>::DuplicatedNFTId
+                );
+            }
+
+            Nft::<T>::validate_nft_transfer(
+                sender_pid,
+                receiver_pid,
+                nfts,
+                false,
+                Some(weight_meter),
+            )?;
+
+            nfts_transferred
+                .entry(*nfts.asset_id())
+                .and_modify(|nft_ids| {
+                    nft_ids.insert(*nft_id);
+                })
+                .or_insert(BTreeSet::from([*nft_id]));
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if all non fungible transfers are valid.
+    fn ensure_valid_fungible_transfers(
+        fungible_tx_summary: &FungibleTxSummary,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        Self::ensure_assets_are_not_frozen(fungible_tx_summary.assets())?;
+        Self::ensure_valid_cdd_claims(fungible_tx_summary.unique_dids())?;
+        Self::ensure_receivers_are_compliant_and_their_portfolios_exist(
+            fungible_tx_summary.total_rcv_per_did(),
+            fungible_tx_summary.rcv_portfolios(),
+            weight_meter,
+        )?;
+        Self::ensure_ensure_senders_are_compliant_and_funded(
+            fungible_tx_summary.total_sent_per_did(),
+            fungible_tx_summary.total_sent_per_portfolio(),
+            weight_meter,
+        )?;
+        Self::ensure_valid_statistics(fungible_tx_summary, weight_meter)?;
+        Ok(())
+    }
+
+    /// Returns `Ok` if all assets are not frozen.
+    fn ensure_assets_are_not_frozen(unique_assets: &BTreeSet<AssetId>) -> DispatchResult {
+        for asset_id in unique_assets {
+            ensure!(
+                Frozen::<T>::get(asset_id),
+                Error::<T>::InstructionWithAFrozenAsset
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if all identities have a valid CDD claim.
+    fn ensure_valid_cdd_claims(unique_dids: &BTreeSet<IdentityId>) -> DispatchResult {
+        for did in unique_dids {
+            ensure!(
+                pallet_identity::Pallet::<T>::has_valid_cdd(*did),
+                Error::<T>::InstructionWithAnInvalidCDDClaim
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if all receivers are compliant and their portfolios exist.
+    fn ensure_receivers_are_compliant_and_their_portfolios_exist(
+        total_rcv_per_did: &BTreeMap<(AssetId, IdentityId), Balance>,
+        rcv_portfolios: &BTreeSet<PortfolioId>,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        for portfolio_id in rcv_portfolios {
+            T::Portfolio::ensure_portfolio_validity(portfolio_id)?;
+        }
+
+        for ((asset_id, did), _) in total_rcv_per_did.iter() {
+            if !pallet_compliance_manager::Pallet::<T>::is_compliant(
+                asset_id,
+                None,
+                Some(*did),
+                weight_meter,
+            )? {
+                return Err(Error::<T>::IntructionReceiverIsNotCompliant.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns `Ok` if all sender's portfolio have the right balance, the tokens are locked and they are compliant.
+    fn ensure_senders_are_compliant_and_funded(
+        total_sent_per_did: &BTreeMap<(AssetId, IdentityId), Balance>,
+        total_sent_per_portfolio: &BTreeMap<(AssetId, PortfolioId), Balance>,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        // Each individual portfolio must have all tokens locked and their amount
+        for ((asset_id, portfolio_id), balance) in total_sent_per_portfolio.iter() {
+            T::Portfolio::ensure_tokens_are_locked(portfolio_id, asset_id, *balance)?;
+            T::Portfolio::ensure_portfolio_balance(portfolio_id, asset_id, *balance)?;
+        }
+
+        // The aggregate balance of the sender must be equal or greater than the total amount of tokens sent
+        for ((asset_id, did), amount) in total_sent_per_did.iter() {
+            ensure!(
+                BalanceOf::<T>::get(asset_id, did) >= *amount,
+                Error::<T>::SenderHasInsufficientBalance
+            );
+
+            if !pallet_compliance_manager::Pallet::<T>::is_compliant(
+                asset_id,
+                Some(*did),
+                None,
+                weight_meter,
+            )? {
+                return Err(Error::<T>::IntructionSenderIsNotCompliant.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns `Ok` if the statistics requirements of all assets are met.
+    fn ensure_valid_statistics(
+        instruction_tx_summary: &FungibleTxSummary,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        for asset_id in instruction_tx_summary.assets() {
+            Asset::<T>::ensure_valid_statistics(
+                asset_id,
+                instruction_tx_summary.total_rcv_per_did_given_asset(asset_id),
+                instruction_tx_summary.total_sent_per_did_given_asset(asset_id),
+                weight_meter,
+            )?;
+        }
         Ok(())
     }
 
@@ -2930,18 +3216,7 @@ impl<T: Config> Pallet<T> {
         let (caller_did, _, instruction) =
             Self::ensure_origin_perm_and_instruction_validity(origin, instruction_id, false)?;
 
-        // Verifies if the caller is a mediator and has already affirmed the instruction
-        let mediator_affirmation_status =
-            InstructionMediatorsAffirmations::<T>::get(instruction_id, caller_did);
-        match mediator_affirmation_status {
-            MediatorAffirmationStatus::Unknown => {
-                return Err(Error::<T>::CallerIsNotAMediator.into())
-            }
-            MediatorAffirmationStatus::Pending => {
-                return Err(Error::<T>::UnexpectedAffirmationStatus.into())
-            }
-            MediatorAffirmationStatus::Affirmed { .. } => {}
-        }
+        Self::ensure_mediator_has_affirmed_instruction(&caller_did, &instruction_id)?;
 
         // Updates the mediator's affirmation status to pending and add one to the number of pending affirmations
         InstructionMediatorsAffirmations::<T>::insert(
@@ -2966,6 +3241,56 @@ impl<T: Config> Pallet<T> {
             instruction_id,
         ));
         Ok(())
+    }
+
+    /// If the caller is a mediator and all conditions for executing the instruction are met, 
+    /// updates the instruction status to `LockedForExecution`.
+    fn base_lock_instruction(
+        origin: OriginFor<T>,
+        instruction_id: InstructionId,
+        weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        let caller_did = pallet_identity::Pallet::<T>::ensure_perms(origin.clone())?;
+
+        Self::ensure_mediator_has_affirmed_instruction(&did, instruction_id)?;
+
+        Self::validate_execute_instruction_conditions(&instruction_id, weight_meter)?;
+
+        InstructionStatuses::<T>::insert(instruction_id, InstructionStatus::LockedForExecution);
+
+        Ok(())
+    }
+
+    /// Returns `Ok` if `did` is a mediator and has affirmed the instruction.
+    fn ensure_mediator_has_affirmed_instruction(
+        did: &IdentityId,
+        instruction_id: &InstructionId,
+    ) -> DispatchResult {
+        let mediator_affirmation_status =
+            InstructionMediatorsAffirmations::<T>::get(instruction_id, did);
+
+        match mediator_affirmation_status {
+            MediatorAffirmationStatus::Affirmed { .. } => Ok(()),
+            MediatorAffirmationStatus::Unknown => Err(Error::<T>::CallerIsNotAMediator.into()),
+            MediatorAffirmationStatus::Pending => {
+                Err(Error::<T>::UnexpectedAffirmationStatus.into())
+            }
+        }
+    }
+
+    /// Returns `Ok` if the instruction status is `Pending` or `Failed`.
+    fn ensure_instruction_is_pending_or_failed(instruction_id: &InstructionId) -> DispatchResult {
+        let instruction_status = InstructionStatuses::<T>::get(instruction_id);
+
+        match instruction_status {
+            InstructionStatus::Pending | InstructionStatus::Failed => Ok(()),
+            InstructionStatus::Unknown
+            | InstructionStatus::Success(_)
+            | InstructionStatus::Rejected(_)
+            | InstructionStatus::LockedForExecution => {
+                Err(Error::<T>::InvalidInstructionStatusForExecution.into())
+            }
+        }
     }
 
     /// Returns the worst case weight for an instruction with `f` fungible legs, `n` nfts being transferred and `o` offchain assets.
@@ -3151,7 +3476,7 @@ impl<T: Config> Pallet<T> {
             execution_errors.push(Error::<T>::NotAllAffirmationsHaveBeenReceived.into());
         }
 
-        if let Err(e) = Self::ensure_non_expired_affirmations(&instruction_id) {
+        if let Err(e) = Self::validate_mediators_affirmations(&instruction_id) {
             execution_errors.push(e);
         }
 
@@ -3161,7 +3486,9 @@ impl<T: Config> Pallet<T> {
             | InstructionStatus::Rejected(_) => {
                 execution_errors.push(Error::<T>::InvalidInstructionStatusForExecution.into());
             }
-            InstructionStatus::Pending | InstructionStatus::Failed => {}
+            InstructionStatus::Pending
+            | InstructionStatus::Failed
+            | InstructionStatus::LockedForExecution => {}
         }
 
         let instruction_legs: Vec<(LegId, Leg)> =

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -77,7 +77,7 @@ use frame_support::weights::Weight;
 use frame_support::{ensure, BoundedBTreeSet};
 use frame_system::pallet_prelude::*;
 use frame_system::{ensure_root, RawOrigin};
-use polymesh_primitives::{nft, weight_meter, NFTId};
+use polymesh_primitives::NFTId;
 use sp_runtime::traits::{One, Verify};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
@@ -1396,15 +1396,33 @@ pub mod pallet {
             Self::base_reject_instruction(origin, instruction_id, None, number_of_assets)
         }
 
+        /// Moves the instruction status to `LockedForExecution`. This function must be called by a
+        /// mediator of the instruction and will only suceed if the following conditions are met:
+        ///     - All affirmations have been received.
+        ///     - Instruction is pending or has failed at least one time.
+        ///     - All mediator's affirmations are still valid.
+        ///     - All assets are in the allowed venue list.
+        ///     - All senders have the right amount of assets being transferred.
+        ///     - All senders and receivers are compliant and have valid CDD claims.
+        ///     - All assets' statistics are still valid.
+        ///     - There are no frozen assets.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, specifying the caller.
+        /// * `instruction_id` - The [`InstructionId`] of the instruction to be locked.
+        /// * `weight_limit` - An optional maximum [`Weight`] value to be charged for locking the instruction.
         #[pallet::weight(Weight::zero())]
         #[pallet::call_index(24)]
         pub fn lock_instruction(
             origin: OriginFor<T>,
             instruction_id: InstructionId,
-            weight_limit: Option<Weight>,
+            _weight_limit: Option<Weight>,
         ) -> DispatchResult {
-            let mut weight_meter = unimplemented!();
-            Self::base_lock_instruction(origin, instruction_id, &mut weight_meter)?;
+            Self::base_lock_instruction(
+                origin,
+                instruction_id,
+                &mut WeightMeter::max_limit(Weight::zero()),
+            )?;
             Ok(())
         }
     }
@@ -1892,12 +1910,10 @@ impl<T: Config> Pallet<T> {
 
         Self::validate_mediators_affirmations(instruction_id)?;
 
-        let mut instruction_legs: Vec<_> =
-            InstructionLegs::<T>::iter_prefix(instruction_id).collect();
+        let instruction_legs: Vec<_> = InstructionLegs::<T>::iter_prefix(instruction_id).collect();
 
         Self::ensure_no_missing_affirmation(instruction_id, &instruction_legs)?;
 
-        // Ensures the venue is allowed for all tickers in the instruction
         let instruction_details = InstructionDetails::<T>::get(instruction_id);
         Self::ensure_allowed_venue(&instruction_legs, instruction_details.venue_id)?;
 
@@ -2002,7 +2018,7 @@ impl<T: Config> Pallet<T> {
                         InstructionLegStatus::<T>::get(id, leg_id) == LegStatus::ExecutionPending,
                         Error::<T>::UnexpectedLegStatus
                     );
-                    instruction_tx_summary
+                    fungible_tx_summary
                         .add_fungible_transfer(*sender, *receiver, *asset_id, *amount);
                 },
                 Leg::NonFungible { sender, receiver, nfts } => {
@@ -2029,7 +2045,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        Self::ensure_valid_fungible_transfers(&instruction_tx_summary, weight_meter)?;
+        Self::ensure_valid_fungible_transfers(&fungible_tx_summary, weight_meter)?;
         Ok(())
     }
 
@@ -2074,13 +2090,13 @@ impl<T: Config> Pallet<T> {
         weight_meter: &mut WeightMeter,
     ) -> DispatchResult {
         Self::ensure_assets_are_not_frozen(fungible_tx_summary.assets())?;
-        Self::ensure_valid_cdd_claims(fungible_tx_summary.unique_dids())?;
+        Self::ensure_valid_cdd_claims(fungible_tx_summary.dids())?;
         Self::ensure_receivers_are_compliant_and_their_portfolios_exist(
             fungible_tx_summary.total_rcv_per_did(),
             fungible_tx_summary.rcv_portfolios(),
             weight_meter,
         )?;
-        Self::ensure_ensure_senders_are_compliant_and_funded(
+        Self::ensure_senders_are_compliant_and_funded(
             fungible_tx_summary.total_sent_per_did(),
             fungible_tx_summary.total_sent_per_portfolio(),
             weight_meter,
@@ -2174,9 +2190,9 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         for asset_id in instruction_tx_summary.assets() {
             Asset::<T>::ensure_valid_statistics(
-                asset_id,
-                instruction_tx_summary.total_rcv_per_did_given_asset(asset_id),
-                instruction_tx_summary.total_sent_per_did_given_asset(asset_id),
+                *asset_id,
+                &instruction_tx_summary.total_rcv_per_did_given_asset(asset_id),
+                &instruction_tx_summary.total_sent_per_did_given_asset(asset_id),
                 weight_meter,
             )?;
         }
@@ -3243,7 +3259,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// If the caller is a mediator and all conditions for executing the instruction are met, 
+    /// If the caller is a mediator and all conditions for executing the instruction are met,
     /// updates the instruction status to `LockedForExecution`.
     fn base_lock_instruction(
         origin: OriginFor<T>,
@@ -3252,7 +3268,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         let caller_did = pallet_identity::Pallet::<T>::ensure_perms(origin.clone())?;
 
-        Self::ensure_mediator_has_affirmed_instruction(&did, instruction_id)?;
+        Self::ensure_mediator_has_affirmed_instruction(&caller_did, &instruction_id)?;
 
         Self::validate_execute_instruction_conditions(&instruction_id, weight_meter)?;
 

--- a/pallets/statistics/src/lib.rs
+++ b/pallets/statistics/src/lib.rs
@@ -15,8 +15,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use pallet::*;
-
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
@@ -26,18 +24,22 @@ use frame_support::traits::Get;
 use frame_support::weights::Weight;
 use frame_support::BoundedBTreeSet;
 use frame_system::pallet_prelude::*;
-use sp_std::{collections::btree_set::BTreeSet, vec, vec::Vec};
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::{vec, vec::Vec};
 
 use pallet_external_agents::Config as EAConfig;
 use polymesh_primitives::asset::AssetId;
 use polymesh_primitives::statistics::{
-    Percentage, Stat1stKey, Stat2ndKey, StatOpType, StatType, StatUpdate,
+    IncomingInvestorsUpdate, Percentage, Stat1stKey, Stat2ndKey, StatOpType, StatType, StatUpdate,
 };
 use polymesh_primitives::traits::{AssetFnConfig, AssetFnTrait};
 use polymesh_primitives::transfer_compliance::{
     AssetTransferCompliance, TransferCondition, TransferConditionExemptKey,
 };
 use polymesh_primitives::{storage_migration_ver, Balance, IdentityId, WeightMeter};
+
+pub use pallet::*;
 
 type ExternalAgents<T> = pallet_external_agents::Pallet<T>;
 
@@ -131,6 +133,22 @@ pub mod pallet {
         TransferConditionLimitReached,
         /// The maximum weight limit for executing the function was exceeded.
         WeightLimitExceeded,
+        /// The new number of investors would execeed the maximum allowed.
+        ExceededMaxInvestorCount,
+        /// At least of investors would execeed the maximum ownership percentage.
+        ExceededMaxInvestorOwnership,
+        /// The new number of investors would be below the minimum allowed.
+        NumberofInvestorsBelowMinimum,
+        /// The new number of investors would be above the maximum allowed.
+        NumberofInvestorsAboveMaximum,
+        /// The asset ownership percentage would be below the minimum allowed.
+        BelowMinimumOwnershipClaim,
+        /// The asset ownership percentage would be above the minimum allowed.
+        ExceededMaximumOwnershipClaim,
+        /// The number of investors is in an invalid state.
+        UnexpectedInvestorCount,
+        /// The balance of the asset is in an invalid state.
+        UnexpectedBalance,
     }
 
     #[pallet::pallet]
@@ -1091,6 +1109,290 @@ impl<T: Config> Pallet<T> {
         }
 
         Ok(failed_conditions)
+    }
+
+    /// Returns `Ok` if all statistics requirements are met.
+    pub fn ensure_valid_statistics(
+        asset_id: AssetId,
+        total_rcv_per_did: &BTreeMap<IdentityId, Balance>,
+        total_sent_per_did: &BTreeMap<IdentityId, Balance>,
+        _weight_meter: &mut WeightMeter,
+    ) -> DispatchResult {
+        let asset_compliance = AssetTransferCompliances::<T>::get(&asset_id);
+
+        // If the requirements are paused, the conditions are not checked
+        if asset_compliance.paused {
+            return Ok(());
+        }
+
+        let investors_update =
+            Self::calculate_investors_balance(&asset_id, total_rcv_per_did, total_sent_per_did)?;
+
+        let current_investor_count = AssetStats::<T>::get(
+            Stat1stKey::investor_count(asset_id.clone()),
+            Stat2ndKey::NoClaimStat,
+        );
+        let new_investor_count = current_investor_count
+            .saturating_add(investors_update.number_of_new_investors())
+            .checked_sub(investors_update.number_of_old_investors())
+            .ok_or(Error::<T>::UnexpectedInvestorCount)?;
+
+        let asset_total_supply = T::AssetFn::asset_total_supply(&asset_id)?;
+
+        for condition in asset_compliance.requirements {
+            match condition {
+                TransferCondition::MaxInvestorCount(max_investors) => {
+                    Self::ensure_max_investor_count(
+                        current_investor_count,
+                        new_investor_count,
+                        max_investors as u128,
+                    )?;
+                }
+                TransferCondition::MaxInvestorOwnership(max_ownership_percentage) => {
+                    Self::ensure_max_investor_ownership(
+                        total_rcv_per_did.keys(),
+                        investors_update.dids_final_balance(),
+                        asset_total_supply,
+                        max_ownership_percentage,
+                    )?;
+                }
+                TransferCondition::ClaimCount(claim, _, min, max) => {
+                    Self::ensure_claim_count(
+                        investors_update.old_investors(),
+                        investors_update.new_investors(),
+                        current_investor_count,
+                        new_investor_count,
+                        min as u128,
+                        max.map(|v| v as u128),
+                        &Stat1stKey::new(asset_id, condition.get_stat_type()),
+                        &Stat2ndKey::from(claim),
+                    )?;
+                }
+                TransferCondition::ClaimOwnership(claim, _, min, max) => {
+                    Self::ensure_claim_ownership(
+                        investors_update.dids_current_balance(),
+                        investors_update.dids_final_balance(),
+                        asset_total_supply,
+                        min,
+                        max,
+                        &Stat1stKey::new(asset_id, condition.get_stat_type()),
+                        &Stat2ndKey::from(claim),
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Calculates the final balance for each identity in the instruction.
+    fn calculate_investors_balance(
+        asset_id: &AssetId,
+        total_rcv_per_did: &BTreeMap<IdentityId, Balance>,
+        total_sent_per_did: &BTreeMap<IdentityId, Balance>,
+    ) -> Result<IncomingInvestorsUpdate, DispatchError> {
+        let mut investors_update = IncomingInvestorsUpdate::new();
+
+        for did in total_sent_per_did.keys().chain(total_rcv_per_did.keys()) {
+            let current_did_balance = T::AssetFn::asset_balance(asset_id, did);
+            let incoming_balance = total_rcv_per_did.get(did).cloned().unwrap_or(0);
+            let outgoing_balance = total_sent_per_did.get(did).cloned().unwrap_or(0);
+
+            let did_final_balance = current_did_balance
+                .saturating_add(incoming_balance)
+                .checked_sub(outgoing_balance)
+                .ok_or(Error::<T>::UnexpectedBalance)?;
+
+            if current_did_balance == 0 && did_final_balance > 0 {
+                investors_update.add_new_investor(*did);
+            }
+
+            if current_did_balance != 0 && did_final_balance == 0 {
+                investors_update.add_old_investor(*did);
+            }
+
+            investors_update.add_did_final_balance(*did, did_final_balance);
+            investors_update.add_did_current_balance(*did, current_did_balance);
+        }
+
+        Ok(investors_update)
+    }
+
+    /// Returns `Ok` if the number of investors is not increasing or is less or equal to `max_investors`.
+    fn ensure_max_investor_count(
+        current_investor_count: u128,
+        new_investor_count: u128,
+        max_investors: u128,
+    ) -> DispatchResult {
+        if new_investor_count > current_investor_count {
+            if new_investor_count > max_investors {
+                return Err(Error::<T>::ExceededMaxInvestorCount.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if the balance of all identities receiving the asset is less or equal to `max_ownership_percentage`.
+    fn ensure_max_investor_ownership<'a>(
+        receivers_did: impl Iterator<Item = &'a IdentityId>,
+        dids_final_balance: &BTreeMap<IdentityId, Balance>,
+        asset_total_supply: Balance,
+        max_ownership_percentage: Percentage,
+    ) -> DispatchResult {
+        for rcv_did in receivers_did {
+            let rcv_final_balance = dids_final_balance
+                .get(rcv_did)
+                .copied()
+                .ok_or(Error::<T>::UnexpectedBalance)?;
+            let new_percentage =
+                sp_arithmetic::Permill::from_rational(rcv_final_balance, asset_total_supply);
+            if new_percentage > max_ownership_percentage {
+                return Err(Error::<T>::ExceededMaxInvestorOwnership.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if any of the following conditions are met:
+    ///
+    /// 1. The number of investors has not changed.
+    /// 2. If the number of investors has decreased:
+    ///    - If the number of invertors is still above or equal to the minimum.
+    ///    - If it's less than the minimum and none of the old investors had the claim count.
+    /// 3. If the number of investors has increased:
+    ///    - If the number of investors is still below or equal to the maximum.
+    ///    - If it's more than the maximum and none of the new investors have a claim count.
+    fn ensure_claim_count(
+        old_investors: &BTreeSet<IdentityId>,
+        new_investors: &BTreeSet<IdentityId>,
+        current_investor_count: u128,
+        new_investor_count: u128,
+        min: u128,
+        max: Option<u128>,
+        stat_fist_key: &Stat1stKey,
+        stat_second_key: &Stat2ndKey,
+    ) -> DispatchResult {
+        // The number of investors has not changed
+        if new_investor_count == current_investor_count {
+            return Ok(());
+        }
+
+        // The number of investors has decreased
+        if current_investor_count > new_investor_count {
+            if new_investor_count < min {
+                Self::ensure_old_investors_claim_count(
+                    old_investors,
+                    stat_fist_key,
+                    stat_second_key,
+                )?;
+            }
+        }
+
+        // The number of investors has increased
+        if new_investor_count > current_investor_count {
+            if let Some(max) = max {
+                if new_investor_count > max {
+                    Self::ensure_new_investors_claim_count(
+                        new_investors,
+                        stat_fist_key,
+                        stat_second_key,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns `Ok` if none of the identities sending all their balance have claim count restrictions.
+    fn ensure_old_investors_claim_count(
+        old_investors: &BTreeSet<IdentityId>,
+        stat_fist_key: &Stat1stKey,
+        stat_second_key: &Stat2ndKey,
+    ) -> DispatchResult {
+        for did in old_investors {
+            if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
+                return Err(Error::<T>::NumberofInvestorsBelowMinimum.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if none of the new investors have claim count restrictions.
+    fn ensure_new_investors_claim_count(
+        new_investors: &BTreeSet<IdentityId>,
+        stat_fist_key: &Stat1stKey,
+        stat_second_key: &Stat2ndKey,
+    ) -> DispatchResult {
+        for did in new_investors {
+            if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
+                return Err(Error::<T>::NumberofInvestorsAboveMaximum.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns `Ok` if any of the following conditions are met:
+    ///
+    /// 1. The transfer amount of all identites that have the claim has not changed.
+    /// 2. If transfer amount of all identites that have the claim has decreased:
+    ///    - The new claim balance percentage must be above or equal to the minimum.
+    /// 3. If transfer amount of all identites that have the claim has increased:
+    ///    - The new claim balance percentage must be below or equal to the minimum.
+    fn ensure_claim_ownership(
+        dids_current_balance: &BTreeMap<IdentityId, Balance>,
+        dids_final_balance: &BTreeMap<IdentityId, Balance>,
+        asset_total_supply: Balance,
+        min_percentage: Percentage,
+        max_percentage: Percentage,
+        stat_fist_key: &Stat1stKey,
+        stat_second_key: &Stat2ndKey,
+    ) -> DispatchResult {
+        let mut increased_value = 0;
+        let mut decreased_value = 0;
+
+        for (did, curent_balance) in dids_current_balance {
+            if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
+                let final_balance = dids_final_balance
+                    .get(did)
+                    .copied()
+                    .ok_or(Error::<T>::UnexpectedBalance)?;
+
+                if final_balance > *curent_balance {
+                    increased_value += final_balance - *curent_balance;
+                }
+
+                if final_balance < *curent_balance {
+                    decreased_value += *curent_balance - final_balance;
+                }
+            }
+        }
+
+        if increased_value == decreased_value {
+            return Ok(());
+        }
+
+        let claim_balance = AssetStats::<T>::get(stat_fist_key, stat_second_key);
+        let new_percentage = sp_arithmetic::Permill::from_rational(
+            claim_balance
+                .saturating_add(increased_value)
+                .saturating_sub(decreased_value),
+            asset_total_supply,
+        );
+
+        if increased_value > decreased_value {
+            if new_percentage > max_percentage {
+                return Err(Error::<T>::ExceededMaximumOwnershipClaim.into());
+            }
+        }
+
+        if decreased_value > increased_value {
+            if new_percentage < min_percentage {
+                return Err(Error::<T>::BelowMinimumOwnershipClaim.into());
+            }
+        }
+
+        Ok(())
     }
 
     /// Consumes from `weight_meter` the given `weight`.

--- a/pallets/statistics/src/lib.rs
+++ b/pallets/statistics/src/lib.rs
@@ -37,7 +37,7 @@ use polymesh_primitives::traits::{AssetFnConfig, AssetFnTrait};
 use polymesh_primitives::transfer_compliance::{
     AssetTransferCompliance, TransferCondition, TransferConditionExemptKey,
 };
-use polymesh_primitives::{storage_migration_ver, Balance, IdentityId, WeightMeter};
+use polymesh_primitives::{storage_migration_ver, Balance, ClaimType, IdentityId, WeightMeter};
 
 pub use pallet::*;
 
@@ -135,7 +135,7 @@ pub mod pallet {
         WeightLimitExceeded,
         /// The new number of investors would execeed the maximum allowed.
         ExceededMaxInvestorCount,
-        /// At least of investors would execeed the maximum ownership percentage.
+        /// At least one investors would execeed the maximum ownership percentage.
         ExceededMaxInvestorOwnership,
         /// The new number of investors would be below the minimum allowed.
         NumberofInvestorsBelowMinimum,
@@ -1150,6 +1150,7 @@ impl<T: Config> Pallet<T> {
                 }
                 TransferCondition::MaxInvestorOwnership(max_ownership_percentage) => {
                     Self::ensure_max_investor_ownership(
+                        asset_id.clone(),
                         total_rcv_per_did.keys(),
                         investors_update.dids_final_balance(),
                         asset_total_supply,
@@ -1234,6 +1235,7 @@ impl<T: Config> Pallet<T> {
 
     /// Returns `Ok` if the balance of all identities receiving the asset is less or equal to `max_ownership_percentage`.
     fn ensure_max_investor_ownership<'a>(
+        asset_id: AssetId,
         receivers_did: impl Iterator<Item = &'a IdentityId>,
         dids_final_balance: &BTreeMap<IdentityId, Balance>,
         asset_total_supply: Balance,
@@ -1247,7 +1249,9 @@ impl<T: Config> Pallet<T> {
             let new_percentage =
                 sp_arithmetic::Permill::from_rational(rcv_final_balance, asset_total_supply);
             if new_percentage > max_ownership_percentage {
-                return Err(Error::<T>::ExceededMaxInvestorOwnership.into());
+                if !Self::is_exempt_from_condition(rcv_did, asset_id, StatOpType::Balance, None) {
+                    return Err(Error::<T>::ExceededMaxInvestorOwnership.into());
+                }
             }
         }
         Ok(())
@@ -1312,7 +1316,14 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         for did in old_investors {
             if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
-                return Err(Error::<T>::NumberofInvestorsBelowMinimum.into());
+                if !Self::is_exempt_from_condition(
+                    did,
+                    stat_fist_key.asset_id,
+                    StatOpType::Count,
+                    stat_second_key.claim_type(),
+                ) {
+                    return Err(Error::<T>::NumberofInvestorsBelowMinimum.into());
+                }
             }
         }
         Ok(())
@@ -1326,7 +1337,14 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         for did in new_investors {
             if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
-                return Err(Error::<T>::NumberofInvestorsAboveMaximum.into());
+                if !Self::is_exempt_from_condition(
+                    did,
+                    stat_fist_key.asset_id,
+                    StatOpType::Count,
+                    stat_second_key.claim_type(),
+                ) {
+                    return Err(Error::<T>::NumberofInvestorsAboveMaximum.into());
+                }
             }
         }
         Ok(())
@@ -1350,6 +1368,8 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         let mut increased_value = 0;
         let mut decreased_value = 0;
+        let mut senders = BTreeSet::new();
+        let mut receivers = BTreeSet::new();
 
         for (did, curent_balance) in dids_current_balance {
             if Self::has_matching_claim(did, stat_fist_key, stat_second_key) {
@@ -1360,10 +1380,12 @@ impl<T: Config> Pallet<T> {
 
                 if final_balance > *curent_balance {
                     increased_value += final_balance - *curent_balance;
+                    receivers.insert(did);
                 }
 
                 if final_balance < *curent_balance {
                     decreased_value += *curent_balance - final_balance;
+                    senders.insert(did);
                 }
             }
         }
@@ -1382,17 +1404,46 @@ impl<T: Config> Pallet<T> {
 
         if increased_value > decreased_value {
             if new_percentage > max_percentage {
-                return Err(Error::<T>::ExceededMaximumOwnershipClaim.into());
+                for did in receivers {
+                    if !Self::is_exempt_from_condition(
+                        &did,
+                        stat_fist_key.asset_id,
+                        StatOpType::Balance,
+                        stat_second_key.claim_type(),
+                    ) {
+                        return Err(Error::<T>::ExceededMaximumOwnershipClaim.into());
+                    }
+                }
             }
         }
 
         if decreased_value > increased_value {
             if new_percentage < min_percentage {
-                return Err(Error::<T>::BelowMinimumOwnershipClaim.into());
+                for did in senders {
+                    if !Self::is_exempt_from_condition(
+                        &did,
+                        stat_fist_key.asset_id,
+                        StatOpType::Balance,
+                        stat_second_key.claim_type(),
+                    ) {
+                        return Err(Error::<T>::ExceededMaximumOwnershipClaim.into());
+                    }
+                }
             }
         }
 
         Ok(())
+    }
+
+    /// Returns `true` if the identity is exempt from the transfer condition requirement.
+    fn is_exempt_from_condition(
+        did: &IdentityId,
+        asset_id: AssetId,
+        stat_op_type: StatOpType,
+        claim_type: Option<ClaimType>,
+    ) -> bool {
+        let exemption_key = TransferConditionExemptKey::new(asset_id, stat_op_type, claim_type);
+        TransferConditionExemptEntities::<T>::get(&exemption_key, did)
     }
 
     /// Consumes from `weight_meter` the given `weight`.

--- a/pallets/statistics/src/lib.rs
+++ b/pallets/statistics/src/lib.rs
@@ -1121,7 +1121,7 @@ impl<T: Config> Pallet<T> {
         let asset_compliance = AssetTransferCompliances::<T>::get(&asset_id);
 
         // If the requirements are paused, the conditions are not checked
-        if asset_compliance.paused {
+        if asset_compliance.paused || asset_compliance.requirements.is_empty() {
             return Ok(());
         }
 

--- a/primitives/src/settlement.rs
+++ b/primitives/src/settlement.rs
@@ -23,6 +23,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::weights::Weight;
 use scale_info::prelude::string::String;
 use scale_info::TypeInfo;
+use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::vec::Vec;
 
@@ -44,19 +45,8 @@ impl_checked_inc!(VenueId);
 pub struct VenueDetails(Vec<u8>);
 
 /// Status of an instruction
-#[derive(
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum InstructionStatus<BlockNumber> {
     /// Invalid instruction or details pruned
     #[default]
@@ -69,23 +59,13 @@ pub enum InstructionStatus<BlockNumber> {
     Success(BlockNumber),
     /// Instruction has been rejected.
     Rejected(BlockNumber),
+    /// Instruction is locked for execution.
+    LockedForExecution,
 }
 
 /// Type of the venue. Used for offchain filtering.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum VenueType {
     /// Default type - used for mixed and unknown types
     #[default]
@@ -99,20 +79,8 @@ pub enum VenueType {
 }
 
 /// Status of a leg
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum LegStatus<AccountId> {
     /// It is waiting for affirmation
     #[default]
@@ -124,19 +92,8 @@ pub enum LegStatus<AccountId> {
 }
 
 /// Status of an affirmation
-#[derive(
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum AffirmationStatus {
     /// Invalid affirmation
     #[default]
@@ -148,20 +105,8 @@ pub enum AffirmationStatus {
 }
 
 /// Type of settlement
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum SettlementType<BlockNumber> {
     /// Instruction should be settled in the next block as soon as all affirmations are received.
     #[default]
@@ -170,6 +115,8 @@ pub enum SettlementType<BlockNumber> {
     SettleOnBlock(BlockNumber),
     /// Instruction must be settled manually on or after BlockNumber.
     SettleManual(BlockNumber),
+    /// Instruction will be settled after compliance check.
+    SettleOnComplianceCheck,
 }
 
 /// A per-Instruction leg ID.
@@ -277,17 +224,8 @@ pub struct Venue {
 }
 
 /// An offchain transaction receipt.
-#[derive(
-    Encode,
-    Decode,
-    MaxEncodedLen,
-    Clone,
-    PartialEq,
-    Eq,
-    Debug,
-    PartialOrd,
-    Ord
-)]
+#[derive(Encode, Decode, MaxEncodedLen)]
+#[derive(Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub struct Receipt<Balance> {
     /// Unique receipt number set by the signer for their receipts.
     uid: u64,
@@ -334,18 +272,8 @@ impl<Balance> Receipt<Balance> {
 pub struct ReceiptMetadata([u8; 32]);
 
 /// Details about an offchain transaction receipt.
-#[derive(
-    Encode,
-    Decode,
-    MaxEncodedLen,
-    TypeInfo,
-    Clone,
-    PartialEq,
-    Eq,
-    Debug,
-    PartialOrd,
-    Ord
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ReceiptDetails<AccountId, OffChainSignature> {
     /// Unique receipt number set by the signer for their receipts
     uid: u64,
@@ -414,18 +342,8 @@ impl<AccountId, OffChainSignature> ReceiptDetails<AccountId, OffChainSignature> 
 
 /// Stores the number of fungible, non fungible and offchain transfers in a set of legs.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Decode,
-    MaxEncodedLen,
-    Default,
-    Encode,
-    Eq,
-    PartialEq,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AssetCount {
     fungible: u32,
     non_fungible: u32,
@@ -718,18 +636,8 @@ impl FilteredLegs {
 
 /// Holds the [`AssetCount`] for both the sender and receiver side and the number of offchain assets.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    PartialEq,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AffirmationCount {
     /// The [`AssetCount`] for sender side.
     sender_asset_count: AssetCount,
@@ -813,17 +721,8 @@ impl ExecuteInstructionInfo {
 }
 
 /// The status of the mediator's affirmation.
-#[derive(
-    Clone,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    MaxEncodedLen,
-    Eq,
-    PartialEq,
-    TypeInfo
-)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum MediatorAffirmationStatus<T> {
     /// Invalid affirmation status
     #[default]
@@ -835,4 +734,119 @@ pub enum MediatorAffirmationStatus<T> {
         /// Sets an expiration date for the affirmation.
         expiry: Option<T>,
     },
+}
+
+/// A summary of the amount of fungible tokens being exchanged in an instruction.
+pub struct FungibleTxSummary {
+    /// All unique fungible assets in the instruction.
+    assets: BTreeSet<AssetId>,
+    /// All unique identities exchanging fungible assets in the instruction.
+    dids: BTreeSet<IdentityId>,
+    /// All unique portfolios that receive fungible assets in the instruction.
+    rcv_portfolios: BTreeSet<PortfolioId>,
+    /// Total amount of each fungible asset received per identity.
+    total_rcv_per_did: BTreeMap<(AssetId, IdentityId), Balance>,
+    /// Total amount of each fungible asset sent per identity.
+    total_sent_per_did: BTreeMap<(AssetId, IdentityId), Balance>,
+    /// Total amount of each fungible asset sent per portfolio.
+    total_sent_per_portfolio: BTreeMap<(AssetId, PortfolioId), Balance>,
+}
+
+impl FungibleTxSummary {
+    /// Creates a new instance of [`FungibleTxSummary`].
+    pub fn new() -> Self {
+        FungibleTxSummary {
+            assets: BTreeSet::new(),
+            dids: BTreeSet::new(),
+            rcv_portfolios: BTreeSet::new(),
+            total_rcv_per_did: BTreeMap::new(),
+            total_sent_per_did: BTreeMap::new(),
+            total_sent_per_portfolio: BTreeMap::new(),
+        }
+    }
+
+    /// Returns all assets in the instruction.
+    pub fn assets(&self) -> &BTreeSet<AssetId> {
+        &self.assets
+    }
+
+    /// Returns all identities in the instruction.
+    pub fn dids(&self) -> &BTreeSet<IdentityId> {
+        &self.dids
+    }
+
+    /// Returns all portfolios that receive assets in the instruction.
+    pub fn rcv_portfolios(&self) -> &BTreeSet<PortfolioId> {
+        &self.rcv_portfolios
+    }
+
+    /// Returns the total amount of each asset received per identity.
+    pub fn total_rcv_per_did(&self) -> &BTreeMap<(AssetId, IdentityId), Balance> {
+        &self.total_rcv_per_did
+    }
+
+    /// Returns a [`BTreeMap<IdentityId, Balance>`] containing the total amount received per identity for the given asset.
+    pub fn total_rcv_per_did_given_asset(
+        &self,
+        asset_id: &AssetId,
+    ) -> BTreeMap<IdentityId, Balance> {
+        self.total_rcv_per_did
+            .iter()
+            .filter(|((a, _), _)| a == asset_id)
+            .map(|((_, did), amount)| (*did, *amount))
+            .collect()
+    }
+
+    /// Returns the total amount of each asset sent per identity.
+    pub fn total_sent_per_did(&self) -> &BTreeMap<(AssetId, IdentityId), Balance> {
+        &self.total_sent_per_did
+    }
+
+    /// Returns a [`BTreeMap<IdentityId, Balance>`] containing the total amount sent per identity for the given asset.
+    pub fn total_sent_per_did_given_asset(
+        &self,
+        asset_id: &AssetId,
+    ) -> BTreeMap<IdentityId, Balance> {
+        self.total_sent_per_did
+            .iter()
+            .filter(|((a, _), _)| a == asset_id)
+            .map(|((_, did), amount)| (*did, *amount))
+            .collect()
+    }
+
+    /// Returns the total amount of each asset sent per portfolio.
+    pub fn total_sent_per_portfolio(&self) -> &BTreeMap<(AssetId, PortfolioId), Balance> {
+        &self.total_sent_per_portfolio
+    }
+
+    /// Updates the amount of tokens sent and receiver by each party in a fungible transfer.
+    pub fn add_fungible_transfer(
+        &mut self,
+        sender_pid: PortfolioId,
+        receiver_pid: PortfolioId,
+        asset_id: AssetId,
+        amount: Balance,
+    ) {
+        self.assets.insert(asset_id);
+
+        self.dids.insert(sender_pid.did);
+        self.dids.insert(receiver_pid.did);
+
+        self.rcv_portfolios.insert(receiver_pid);
+
+        self.total_rcv_per_did
+            .entry((asset_id, receiver_pid.did))
+            .and_modify(|v| *v += amount)
+            .or_insert(amount);
+
+        self.total_sent_per_did
+            .entry((asset_id, sender_pid.did))
+            .and_modify(|v| *v += amount)
+            .or_insert(amount);
+
+        self.total_sent_per_portfolio
+            .entry((asset_id, sender_pid))
+            .and_modify(|v| *v += amount)
+            .or_insert(amount);
+    }
 }

--- a/primitives/src/statistics.rs
+++ b/primitives/src/statistics.rs
@@ -139,6 +139,14 @@ impl Stat2ndKey {
             _ => Self::NoClaimStat,
         }
     }
+
+    /// Returns the claim type if any, ortherwise `None`.
+    pub fn claim_type(&self) -> Option<ClaimType> {
+        match self {
+            Stat2ndKey::Claim(claim) => Some(claim.claim_type()),
+            _ => None,
+        }
+    }
 }
 
 impl From<Option<Claim>> for Stat2ndKey {

--- a/primitives/src/statistics.rs
+++ b/primitives/src/statistics.rs
@@ -13,13 +13,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::asset::AssetId;
-use crate::{Claim, ClaimType, CountryCode, IdentityId, Scope};
-use codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use sp_runtime::{Deserialize, Serialize};
-use sp_std::{hash::Hash, hash::Hasher, ops::Deref, ops::DerefMut, prelude::*};
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::prelude::*;
+
+use crate::asset::AssetId;
+use crate::{Balance, Claim, ClaimType, CountryCode, IdentityId, Scope};
 
 /// Transfer manager percentage
 pub type Percentage = sp_arithmetic::Permill;
@@ -76,6 +80,14 @@ pub struct Stat1stKey {
 }
 
 impl Stat1stKey {
+    /// Creates a new [`Stat1stKey`] instance.
+    pub fn new(asset_id: AssetId, stat_type: StatType) -> Self {
+        Self {
+            asset_id,
+            stat_type,
+        }
+    }
+
     /// Returns a [`Stat1stKey`] instance where [`Stat1stKey::asset_id`] is set to `asset_id` and
     /// [`Stat1stKey::stat_type`] is set to [`StatType::investor_count`].
     pub fn investor_count(asset_id: AssetId) -> Self {
@@ -156,6 +168,12 @@ impl From<&StatClaim> for Stat2ndKey {
     }
 }
 
+impl From<StatClaim> for Stat2ndKey {
+    fn from(claim: StatClaim) -> Stat2ndKey {
+        Stat2ndKey::Claim(claim)
+    }
+}
+
 /// Stats supported claims.
 ///
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -202,67 +220,76 @@ pub struct StatUpdate {
     pub value: Option<u128>,
 }
 
-/// Older v1 Transfer Managers.
-pub mod v1 {
-    use super::*;
+/// Holds the incoming balance update for each investor.
+pub struct IncomingInvestorsUpdate {
+    /// All identities that were investors, but are not anymore.
+    old_investors: BTreeSet<IdentityId>,
+    /// All identities that were not investors, but are now.
+    new_investors: BTreeSet<IdentityId>,
+    /// The current balance of all identities in the instruction.
+    dids_current_balance: BTreeMap<IdentityId, Balance>,
+    /// The final balance of all identities in the instruction.
+    dids_final_balance: BTreeMap<IdentityId, Balance>,
+}
 
-    /// Transfer manager counter.
-    pub type Counter = u64;
-    /// Transfer manager percentage.
-    pub type Percentage = HashablePermill;
-
-    /// Wrapper around `sp_arithmetic::Permill`
-    #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Decode, Encode, TypeInfo)]
-    #[derive(Copy, Clone, Debug, Eq, PartialOrd, Ord, Default)]
-    pub struct HashablePermill(pub sp_arithmetic::Permill);
-
-    impl Hash for HashablePermill {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            state.write(&self.0.deconstruct().to_le_bytes())
+impl IncomingInvestorsUpdate {
+    /// Creates a new [`IncomingStats`] instance.
+    pub fn new() -> Self {
+        Self {
+            old_investors: BTreeSet::new(),
+            new_investors: BTreeSet::new(),
+            dids_current_balance: BTreeMap::new(),
+            dids_final_balance: BTreeMap::new(),
         }
     }
 
-    // Keep clippy happy.
-    impl PartialEq for HashablePermill {
-        fn eq(&self, other: &Self) -> bool {
-            self.0.eq(&other.0)
-        }
+    /// Adds an identity to the list of old investors.
+    pub fn add_old_investor(&mut self, did: IdentityId) {
+        self.old_investors.insert(did);
     }
 
-    impl Deref for HashablePermill {
-        type Target = sp_arithmetic::Permill;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
+    /// Returns a reference to the identities of all old investors.
+    pub fn old_investors(&self) -> &BTreeSet<IdentityId> {
+        &self.old_investors
     }
 
-    impl DerefMut for HashablePermill {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
+    /// Returns the number of old investors.
+    pub fn number_of_old_investors(&self) -> u128 {
+        self.old_investors.len() as u128
     }
 
-    /// Transfer managers that can be attached to a Token for compliance.
-    #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Decode, Encode, TypeInfo)]
-    #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-    pub enum TransferManager {
-        /// CTM limits the number of active investors in a Token.
-        CountTransferManager(Counter),
-        /// PTM limits the percentage of token owned by a single Identity.
-        PercentageTransferManager(Percentage),
+    /// Adds an identity to the list of new investors.
+    pub fn add_new_investor(&mut self, did: IdentityId) {
+        self.new_investors.insert(did);
     }
 
-    /// Result of a transfer manager check.
-    #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Decode, Encode, TypeInfo)]
-    #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct TransferManagerResult {
-        /// Transfer manager that was checked.
-        pub tm: TransferManager,
-        /// Final evaluation result.
-        pub result: bool,
+    /// Returns a reference to the identities of all new investors.
+    pub fn new_investors(&self) -> &BTreeSet<IdentityId> {
+        &self.new_investors
+    }
+
+    /// Returns the number of new investors.
+    pub fn number_of_new_investors(&self) -> u128 {
+        self.new_investors.len() as u128
+    }
+
+    /// Returns the current balance of the given `did`
+    pub fn dids_current_balance(&self) -> &BTreeMap<IdentityId, Balance> {
+        &self.dids_current_balance
+    }
+
+    /// Adds the current balance of the identity with the given `did`.
+    pub fn add_did_current_balance(&mut self, did: IdentityId, balance: Balance) {
+        self.dids_current_balance.insert(did, balance);
+    }
+
+    /// Returns the final balance of each identity in the instruction.
+    pub fn dids_final_balance(&self) -> &BTreeMap<IdentityId, Balance> {
+        &self.dids_final_balance
+    }
+
+    /// Adds the final balance of the identity with the given `did`.
+    pub fn add_did_final_balance(&mut self, did: IdentityId, balance: Balance) {
+        self.dids_final_balance.insert(did, balance);
     }
 }

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -96,17 +96,11 @@ pub trait PortfolioSubTrait<AccountId> {
     /// * `portfolio` - Portfolio to lock tokens
     /// * `asset_id` - [`AssetId`] of the token to lock
     /// * `amount` - Amount of tokens to lock
-
     fn lock_tokens(portfolio: &PortfolioId, asset_id: &AssetId, amount: Balance) -> DispatchResult;
 
-    /// Unlocks some tokens of a portfolio
-    ///
-    /// # Arguments
-    /// * `portfolio` - Portfolio to unlock tokens
-    /// * asset_id` - [`AssetId`] of the token to unlock
-    /// * `amount` - Amount of tokens to unlock
+    /// Unlocks `amount` tokens of `asset_id` from `portfolio_id`.
     fn unlock_tokens(
-        portfolio: &PortfolioId,
+        portfolio_id: &PortfolioId,
         asset_id: &AssetId,
         amount: Balance,
     ) -> DispatchResult;
@@ -143,6 +137,27 @@ pub trait PortfolioSubTrait<AccountId> {
 
     /// Returns `true` if the portfolio has pre-approved the receivement of `asset_id`, otherwise returns `false`.
     fn skip_portfolio_affirmation(portfolio_id: &PortfolioId, asset_id: &AssetId) -> bool;
+
+    /// Returns `Ok` if the given `amount` of `asset_id` tokens are locked in `portfolio_id`.
+    fn ensure_tokens_are_locked(
+        portfolio: &PortfolioId,
+        asset_id: &AssetId,
+        amount: Balance,
+    ) -> DispatchResult;
+
+    /// Returns `Ok` if the specified `nft_id` for a given `asset_id` is locked in `portfolio_id`.
+    fn ensure_nft_is_locked(
+        portfolio_id: &PortfolioId,
+        asset_id: &AssetId,
+        nft_id: &NFTId,
+    ) -> DispatchResult;
+
+    /// Returns `Ok` if the amount of `asset_id` tokens in `portfolio_id` is greater or equal to `amount`.
+    fn ensure_portfolio_balance(
+        portfolio_id: &PortfolioId,
+        asset_id: &AssetId,
+        amount: Balance,
+    ) -> DispatchResult;
 }
 
 pub trait ComplianceFnConfig {
@@ -150,8 +165,8 @@ pub trait ComplianceFnConfig {
     /// Otherwise, returns `false`.
     fn is_compliant(
         asset_id: &AssetId,
-        sender_did: IdentityId,
-        receiver_did: IdentityId,
+        sender_did: Option<IdentityId>,
+        receiver_did: Option<IdentityId>,
         weight_meter: &mut WeightMeter,
     ) -> Result<bool, DispatchError>;
 

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -145,13 +145,6 @@ pub trait PortfolioSubTrait<AccountId> {
         amount: Balance,
     ) -> DispatchResult;
 
-    /// Returns `Ok` if the specified `nft_id` for a given `asset_id` is locked in `portfolio_id`.
-    fn ensure_nft_is_locked(
-        portfolio_id: &PortfolioId,
-        asset_id: &AssetId,
-        nft_id: &NFTId,
-    ) -> DispatchResult;
-
     /// Returns `Ok` if the amount of `asset_id` tokens in `portfolio_id` is greater or equal to `amount`.
     fn ensure_portfolio_balance(
         portfolio_id: &PortfolioId,

--- a/primitives/src/traits/asset.rs
+++ b/primitives/src/traits/asset.rs
@@ -7,8 +7,10 @@ use crate::{
 #[cfg(feature = "runtime-benchmarks")]
 use sp_std::{collections::btree_set::BTreeSet, prelude::Vec};
 
-use crate::{asset::AssetId, Balance, IdentityId};
 use frame_support::dispatch::{DispatchError, DispatchResult};
+
+use crate::asset::AssetId;
+use crate::{Balance, IdentityId};
 
 pub trait AssetFnConfig: frame_system::Config {
     type AssetFn: AssetFnTrait<Self::AccountId>;

--- a/primitives/src/transfer_compliance.rs
+++ b/primitives/src/transfer_compliance.rs
@@ -14,7 +14,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::asset::AssetId;
-use crate::statistics::{v1, Percentage, StatClaim, StatOpType, StatType};
+use crate::statistics::{Percentage, StatClaim, StatOpType, StatType};
 use crate::{ClaimType, IdentityId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{pallet_prelude::Get, BoundedBTreeSet};
@@ -82,17 +82,6 @@ impl TransferCondition {
     }
 }
 
-impl From<v1::TransferManager> for TransferCondition {
-    fn from(old: v1::TransferManager) -> Self {
-        match old {
-            v1::TransferManager::CountTransferManager(max) => Self::MaxInvestorCount(max),
-            v1::TransferManager::PercentageTransferManager(max) => {
-                Self::MaxInvestorOwnership(max.0)
-            }
-        }
-    }
-}
-
 /// Result of a transfer condition check.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Decode, Encode, TypeInfo)]
@@ -102,15 +91,6 @@ pub struct TransferConditionResult {
     pub condition: TransferCondition,
     /// Final evaluation result.
     pub result: bool,
-}
-
-impl From<v1::TransferManagerResult> for TransferConditionResult {
-    fn from(old: v1::TransferManagerResult) -> Self {
-        Self {
-            condition: old.tm.into(),
-            result: old.result,
-        }
-    }
 }
 
 /// Transfer Condition Exempt key.
@@ -123,6 +103,17 @@ pub struct TransferConditionExemptKey {
     pub op: StatOpType,
     /// Claim type.
     pub claim_type: Option<ClaimType>,
+}
+
+impl TransferConditionExemptKey {
+    /// Create a new instance of [`TransferConditionExemptKey`]
+    pub fn new(asset_id: AssetId, op: StatOpType, claim_type: Option<ClaimType>) -> Self {
+        Self {
+            asset_id,
+            op,
+            claim_type,
+        }
+    }
 }
 
 /// List of transfer compliance requirements associated to an asset.


### PR DESCRIPTION
This is the first of two PRs for the settlement locking feature. This one focuses on adding the new statistics function to assess whether the requirements are satisfied and the new locking extrinsic; 

## changelog

### new features
 - Adds a new workflow that allows mediators to lock instruction before executing it.
### new external API
- Adds `lock_instruction` extrinsic;
### new events

### other
