### PR TITLE
Soften CDD requirement

### DIFF
--- a/integration/tests/multisig_permissions.rs
+++ b/integration/tests/multisig_permissions.rs
@@ -5,6 +5,7 @@ use polymesh_api::{
         authorization::AuthorizationData,
         secondary_key::Signatory,
         settlement::{VenueDetails, VenueType},
+        identity_id::PortfolioName,
     },
     TransactionResults, WrappedCall,
 };
@@ -610,10 +611,10 @@ async fn ms_needs_to_be_linked_to_an_identity() -> Result<()> {
     let mut res = ms.leave_did().await?;
     res.wait_in_block().await?;
 
-    // Prepare `system.remark` call.
-    let remark_call = tester.api.call().system().remark(vec![])?;
+    // Prepare `create_portfolio` call.
+    let call = tester.api.call().portfolio().create_portfolio(PortfolioName(Vec::new()))?;
     // Shouldn't be allowed, since the MS doesn't have a DID.
-    let res = ms.run_proposal(remark_call).await;
+    let res = ms.run_proposal(call).await;
     assert!(res.is_err());
 
     Ok(())

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -976,6 +976,18 @@ impl<T: Config> Pallet<T> {
         }
         Ok(())
     }
+
+    /// Checks if the caller is permissioned to call the current extrinsic skipping CDD checks.
+    /// If `must_be_primary_key` ensures that the caller is a primary key.
+    pub fn ensure_valid_origin(
+        origin: T::RuntimeOrigin,
+        must_be_primary_key: bool,
+    ) -> Result<(T::AccountId, IdentityId), DispatchError> {
+        let caller_acc = ensure_signed(origin)?;
+        let caller_did =
+            pallet_permissions::Pallet::<T>::ensure_valid_origin(&caller_acc, must_be_primary_key)?;
+        Ok((caller_acc, caller_did))
+    }
 }
 
 impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Pallet<T> {
@@ -1021,9 +1033,46 @@ impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Pallet<T> {
 
                 Ok(data(did, Some(sk)))
             }
-            KeyRecord::MultiSigSignerKey(_) => {
-                Err(Error::<T>::UnauthorizedCallerMultisigKey.into())
-            }
+            KeyRecord::MultiSigSignerKey(_) => Err(Error::<T>::MissingIdentity.into()),
         }
+    }
+
+    fn ensure_valid_origin(
+        caller_acc: &T::AccountId,
+        must_be_primary_key: bool,
+        pallet_name: impl FnOnce() -> PalletName,
+        function_name: impl FnOnce() -> ExtrinsicName,
+    ) -> Result<IdentityId, DispatchError> {
+        let key_record = KeyRecords::<T>::get(&caller_acc).ok_or(Error::<T>::MissingIdentity)?;
+
+        if must_be_primary_key {
+            let did = key_record
+                .is_primary_key()
+                .ok_or(Error::<T>::KeyNotAllowed)?;
+            return Ok(did);
+        }
+
+        if let KeyRecord::PrimaryKey(did) = key_record {
+            return Ok(did);
+        }
+
+        let did = key_record
+            .is_secondary_key()
+            .ok_or(Error::<T>::KeyNotAllowed)?;
+
+        ensure!(
+            !IsDidFrozen::<T>::get(&did),
+            Error::<T>::UnauthorizedCallerFrozenDid
+        );
+
+        let permissions = Self::get_key_permissions(&caller_acc);
+        ensure!(
+            permissions
+                .extrinsic
+                .sufficient_for(&pallet_name(), &function_name()),
+            Error::<T>::UnauthorizedCallerMissingPermissions
+        );
+
+        Ok(did)
     }
 }

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -891,7 +891,8 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Ensures that `origin`'s key is the primary key of a DID.
+    /// Ensures that `origin`'s key is the primary key of a DID and has a valid CDD claim.
+    /// Returns the caller's account and DID.
     pub fn ensure_primary_key(
         origin: T::RuntimeOrigin,
     ) -> Result<(T::AccountId, IdentityId), DispatchError> {
@@ -899,15 +900,24 @@ impl<T: Config> Pallet<T> {
         let key_rec = KeyRecords::<T>::get(&sender)
             .ok_or(pallet_permissions::Error::<T>::UnauthorizedCaller)?;
         let did = key_rec.is_primary_key().ok_or(Error::<T>::KeyNotAllowed)?;
+        ensure!(
+            Self::has_valid_cdd(did),
+            Error::<T>::UnauthorizedCallerDidMissingCdd
+        );
         Ok((sender, did))
     }
 
-    /// Ensures that `origin`'s key is linked to a DID and returns both.
+    /// Ensures that `origin`'s key is linked to a DID and has a valid CDD claim.
+    /// Returns the caller's account and DID.
     pub fn ensure_did(
         origin: T::RuntimeOrigin,
     ) -> Result<(T::AccountId, IdentityId), DispatchError> {
         let sender = ensure_signed(origin)?;
         let did = Self::get_identity(&sender).ok_or(Error::<T>::MissingIdentity)?;
+        ensure!(
+            Self::has_valid_cdd(did),
+            Error::<T>::UnauthorizedCallerDidMissingCdd
+        );
         Ok((sender, did))
     }
 
@@ -969,32 +979,51 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Pallet<T> {
-    // For weighting purposes, the function reads 4 storage values.
     fn check_account_call_permissions(
         who: &T::AccountId,
         pallet_name: impl FnOnce() -> PalletName,
         function_name: impl FnOnce() -> ExtrinsicName,
-    ) -> Option<AccountCallPermissionsData<T::AccountId>> {
+    ) -> Result<AccountCallPermissionsData<T::AccountId>, DispatchError> {
         let data = |did, secondary_key| AccountCallPermissionsData {
             primary_did: did,
             secondary_key,
         };
 
-        match KeyRecords::<T>::get(who)? {
-            // Primary keys do not have / require further permission checks.
-            KeyRecord::PrimaryKey(did) => Some(data(did, None)),
-            // Secondary Key. Ensure DID isn't frozen + key has sufficient permissions.
-            KeyRecord::SecondaryKey(did) if !IsDidFrozen::<T>::get(&did) => {
-                let permissions = Self::get_key_permissions(who);
-                let sk = SecondaryKey {
-                    key: who.clone(),
-                    permissions,
-                };
-                sk.has_extrinsic_permission(&pallet_name(), &function_name())
-                    .then(|| data(did, Some(sk)))
+        let key_record = KeyRecords::<T>::get(who).ok_or(Error::<T>::MissingIdentity)?;
+
+        match key_record {
+            // Primary keys only require a valid CDD claim.
+            KeyRecord::PrimaryKey(did) => {
+                ensure!(
+                    Self::has_valid_cdd(did),
+                    Error::<T>::UnauthorizedCallerDidMissingCdd
+                );
+                Ok(data(did, None))
             }
-            // DIDs with frozen secondary keys, AKA frozen DIDs, are not permitted to call extrinsics.
-            _ => None,
+            // Secondary Key. Ensure DID isn't frozen + has a valid CDD claim + key has sufficient permissions.
+            KeyRecord::SecondaryKey(did) => {
+                ensure!(
+                    !IsDidFrozen::<T>::get(&did),
+                    Error::<T>::UnauthorizedCallerFrozenDid
+                );
+
+                ensure!(
+                    Self::has_valid_cdd(did),
+                    Error::<T>::UnauthorizedCallerDidMissingCdd
+                );
+
+                let permissions = Self::get_key_permissions(who);
+                let sk = SecondaryKey::new(who.clone(), permissions);
+                ensure!(
+                    sk.has_extrinsic_permission(&pallet_name(), &function_name()),
+                    Error::<T>::UnauthorizedCallerMissingPermissions
+                );
+
+                Ok(data(did, Some(sk)))
+            }
+            KeyRecord::MultiSigSignerKey(_) => {
+                Err(Error::<T>::UnauthorizedCallerMultisigKey.into())
+            }
         }
     }
 }

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -984,9 +984,11 @@ impl<T: Config> Pallet<T> {
         must_be_primary_key: bool,
     ) -> Result<(T::AccountId, IdentityId), DispatchError> {
         let caller_acc = ensure_signed(origin)?;
-        let caller_did =
-            pallet_permissions::Pallet::<T>::ensure_valid_origin(&caller_acc, must_be_primary_key)?;
-        Ok((caller_acc, caller_did))
+        let account_data = pallet_permissions::Pallet::<T>::ensure_valid_origin_permissions(
+            &caller_acc,
+            must_be_primary_key,
+        )?;
+        Ok((caller_acc, account_data.primary_did))
     }
 }
 
@@ -996,64 +998,34 @@ impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Pallet<T> {
         pallet_name: impl FnOnce() -> PalletName,
         function_name: impl FnOnce() -> ExtrinsicName,
     ) -> Result<AccountCallPermissionsData<T::AccountId>, DispatchError> {
-        let data = |did, secondary_key| AccountCallPermissionsData {
-            primary_did: did,
-            secondary_key,
-        };
+        let account_call_permissions_data =
+            Self::ensure_valid_origin_permissions(who, false, pallet_name, function_name)?;
 
-        let key_record = KeyRecords::<T>::get(who).ok_or(Error::<T>::MissingIdentity)?;
+        ensure!(
+            Self::has_valid_cdd(account_call_permissions_data.primary_did),
+            Error::<T>::UnauthorizedCallerDidMissingCdd
+        );
 
-        match key_record {
-            // Primary keys only require a valid CDD claim.
-            KeyRecord::PrimaryKey(did) => {
-                ensure!(
-                    Self::has_valid_cdd(did),
-                    Error::<T>::UnauthorizedCallerDidMissingCdd
-                );
-                Ok(data(did, None))
-            }
-            // Secondary Key. Ensure DID isn't frozen + has a valid CDD claim + key has sufficient permissions.
-            KeyRecord::SecondaryKey(did) => {
-                ensure!(
-                    !IsDidFrozen::<T>::get(&did),
-                    Error::<T>::UnauthorizedCallerFrozenDid
-                );
-
-                ensure!(
-                    Self::has_valid_cdd(did),
-                    Error::<T>::UnauthorizedCallerDidMissingCdd
-                );
-
-                let permissions = Self::get_key_permissions(who);
-                let sk = SecondaryKey::new(who.clone(), permissions);
-                ensure!(
-                    sk.has_extrinsic_permission(&pallet_name(), &function_name()),
-                    Error::<T>::UnauthorizedCallerMissingPermissions
-                );
-
-                Ok(data(did, Some(sk)))
-            }
-            KeyRecord::MultiSigSignerKey(_) => Err(Error::<T>::MissingIdentity.into()),
-        }
+        Ok(account_call_permissions_data)
     }
 
-    fn ensure_valid_origin(
+    fn ensure_valid_origin_permissions(
         caller_acc: &T::AccountId,
         must_be_primary_key: bool,
         pallet_name: impl FnOnce() -> PalletName,
         function_name: impl FnOnce() -> ExtrinsicName,
-    ) -> Result<IdentityId, DispatchError> {
+    ) -> Result<AccountCallPermissionsData<T::AccountId>, DispatchError> {
         let key_record = KeyRecords::<T>::get(&caller_acc).ok_or(Error::<T>::MissingIdentity)?;
 
         if must_be_primary_key {
             let did = key_record
                 .is_primary_key()
                 .ok_or(Error::<T>::KeyNotAllowed)?;
-            return Ok(did);
+            return Ok(AccountCallPermissionsData::new(did, None));
         }
 
         if let KeyRecord::PrimaryKey(did) = key_record {
-            return Ok(did);
+            return Ok(AccountCallPermissionsData::new(did, None));
         }
 
         let did = key_record
@@ -1072,7 +1044,8 @@ impl<T: Config> CheckAccountCallPermissions<T::AccountId> for Pallet<T> {
                 .sufficient_for(&pallet_name(), &function_name()),
             Error::<T>::UnauthorizedCallerMissingPermissions
         );
+        let sk = SecondaryKey::new(caller_acc.clone(), permissions);
 
-        Ok(did)
+        Ok(AccountCallPermissionsData::new(did, Some(sk)))
     }
 }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1088,6 +1088,14 @@ pub mod pallet {
         /// Auth identified by an `auth_id` for a given `target` does not exist.
         /// The `target` might be wrong or the `auth_id` was never created at all.
         InvalidAuthorization,
+        /// Frozen secondary key.
+        UnauthorizedCallerFrozenDid,
+        /// The DID is missing a CDD claim.
+        UnauthorizedCallerDidMissingCdd,
+        /// The key does not have permissions to execute the extrinsic.
+        UnauthorizedCallerMissingPermissions,
+        /// Multisig keys are not allowed for some extrinsics.
+        UnauthorizedCallerMultisigKey,
     }
 }
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1094,8 +1094,6 @@ pub mod pallet {
         UnauthorizedCallerDidMissingCdd,
         /// The key does not have permissions to execute the extrinsic.
         UnauthorizedCallerMissingPermissions,
-        /// Multisig keys are not allowed for some extrinsics.
-        UnauthorizedCallerMultisigKey,
     }
 }
 

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -719,12 +719,6 @@ pub mod pallet {
         AdminNotFound,
         /// The extrinsic expected a different `AuthorizationType` than what the `data.auth_type()` is.
         BadAuthorizationType,
-        /// The callers does not have an identity.
-        MissingIdentity,
-        /// The caller's key is not allowed to perform the action.
-        KeyNotAllowed,
-        /// The caller's does not have the required permissions.
-        UnauthorizedCallerMissingPermissions,
     }
 
     /// Nonce to ensure unique MultiSig addresses are generated; starts from 1.

--- a/pallets/multisig/src/lib.rs
+++ b/pallets/multisig/src/lib.rs
@@ -83,9 +83,7 @@ use sp_runtime::traits::{Dispatchable, Hash};
 use sp_std::convert::TryFrom;
 use sp_std::prelude::*;
 
-use pallet_identity::{
-    CddAuthForPrimaryKeyRotation, Config as IdentityConfig, PermissionedCallOriginData,
-};
+use pallet_identity::{CddAuthForPrimaryKeyRotation, Config as IdentityConfig};
 use pallet_permissions::with_call_metadata;
 use polymesh_primitives::multisig::{ProposalState, ProposalVoteCount};
 use polymesh_primitives::{
@@ -236,25 +234,17 @@ pub mod pallet {
             sigs_required: u64,
             permissions: Option<Permissions>,
         ) -> DispatchResultWithPostInfo {
-            let (caller, caller_did, permissions) = match permissions {
-                Some(permissions) => {
-                    // Only the primary key can add a secondary key with custom permissions.
-                    let (caller, did) = IdentityPallet::<T>::ensure_primary_key(origin)?;
-                    (caller, did, permissions)
-                }
-                None => {
-                    // Default to empty permissions for the new secondary key.
-                    let PermissionedCallOriginData {
-                        sender: caller,
-                        primary_did,
-                        ..
-                    } = IdentityPallet::<T>::ensure_origin_call_permissions(origin)?;
-                    (caller, primary_did, Permissions::empty())
-                }
-            };
+            let (caller, caller_did) =
+                IdentityPallet::<T>::ensure_valid_origin(origin, permissions.is_some())?;
             let signers_len: u64 = u64::try_from(signers.len()).unwrap_or_default();
             Self::ensure_sigs_in_bounds(signers_len, sigs_required)?;
-            Self::base_create_multisig(caller, caller_did, signers, sigs_required, permissions)?;
+            Self::base_create_multisig(
+                caller,
+                caller_did,
+                signers,
+                sigs_required,
+                permissions.unwrap_or(Permissions::empty()),
+            )?;
             Ok(().into())
         }
 
@@ -729,6 +719,12 @@ pub mod pallet {
         AdminNotFound,
         /// The extrinsic expected a different `AuthorizationType` than what the `data.auth_type()` is.
         BadAuthorizationType,
+        /// The callers does not have an identity.
+        MissingIdentity,
+        /// The caller's key is not allowed to perform the action.
+        KeyNotAllowed,
+        /// The caller's does not have the required permissions.
+        UnauthorizedCallerMissingPermissions,
     }
 
     /// Nonce to ensure unique MultiSig addresses are generated; starts from 1.

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -78,6 +78,16 @@ pub mod pallet {
             pallet_name: impl FnOnce() -> PalletName,
             function_name: impl FnOnce() -> ExtrinsicName,
         ) -> Result<AccountCallPermissionsData<AccountId>, DispatchError>;
+
+        /// Checks whether `who` can call the current extrinsic represented by `pallet_name` and
+        /// `function_name` skipping CDD checks. If `must_be_primary_key` is true, ensures that
+        /// the caller is a primary key.
+        fn ensure_valid_origin(
+            who: &AccountId,
+            must_be_primary_key: bool,
+            pallet_name: impl FnOnce() -> PalletName,
+            function_name: impl FnOnce() -> ExtrinsicName,
+        ) -> Result<IdentityId, DispatchError>;
     }
 
     #[pallet::pallet]
@@ -107,6 +117,20 @@ pub mod pallet {
         ) -> Result<AccountCallPermissionsData<T::AccountId>, DispatchError> {
             T::Checker::check_account_call_permissions(
                 who,
+                || CurrentPalletName::<T>::get(),
+                || CurrentDispatchableName::<T>::get(),
+            )
+        }
+
+        /// Checks if the caller is permissioned to call the current extrinsic skipping CDD checks.
+        /// If `must_be_primary_key` ensures that the caller is a primary key.
+        pub fn ensure_valid_origin(
+            who: &T::AccountId,
+            must_be_primary_key: bool,
+        ) -> Result<IdentityId, DispatchError> {
+            T::Checker::ensure_valid_origin(
+                who,
+                must_be_primary_key,
                 || CurrentPalletName::<T>::get(),
                 || CurrentDispatchableName::<T>::get(),
             )

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -61,6 +61,19 @@ pub mod pallet {
         pub secondary_key: Option<SecondaryKey<AccountId>>,
     }
 
+    impl<AccountId> AccountCallPermissionsData<AccountId> {
+        /// Constructs a new `AccountCallPermissionsData`.
+        pub fn new(
+            primary_did: IdentityId,
+            secondary_key: Option<SecondaryKey<AccountId>>,
+        ) -> Self {
+            Self {
+                primary_did,
+                secondary_key,
+            }
+        }
+    }
+
     /// A permission checker for calls from accounts to extrinsics.
     pub trait CheckAccountCallPermissions<AccountId> {
         /// Checks whether `who` can call the current extrinsic represented by `pallet_name` and
@@ -82,12 +95,12 @@ pub mod pallet {
         /// Checks whether `who` can call the current extrinsic represented by `pallet_name` and
         /// `function_name` skipping CDD checks. If `must_be_primary_key` is true, ensures that
         /// the caller is a primary key.
-        fn ensure_valid_origin(
+        fn ensure_valid_origin_permissions(
             who: &AccountId,
             must_be_primary_key: bool,
             pallet_name: impl FnOnce() -> PalletName,
             function_name: impl FnOnce() -> ExtrinsicName,
-        ) -> Result<IdentityId, DispatchError>;
+        ) -> Result<AccountCallPermissionsData<AccountId>, DispatchError>;
     }
 
     #[pallet::pallet]
@@ -124,11 +137,11 @@ pub mod pallet {
 
         /// Checks if the caller is permissioned to call the current extrinsic skipping CDD checks.
         /// If `must_be_primary_key` ensures that the caller is a primary key.
-        pub fn ensure_valid_origin(
+        pub fn ensure_valid_origin_permissions(
             who: &T::AccountId,
             must_be_primary_key: bool,
-        ) -> Result<IdentityId, DispatchError> {
-            T::Checker::ensure_valid_origin(
+        ) -> Result<AccountCallPermissionsData<T::AccountId>, DispatchError> {
+            T::Checker::ensure_valid_origin_permissions(
                 who,
                 must_be_primary_key,
                 || CurrentPalletName::<T>::get(),

--- a/pallets/permissions/src/lib.rs
+++ b/pallets/permissions/src/lib.rs
@@ -77,7 +77,7 @@ pub mod pallet {
             who: &AccountId,
             pallet_name: impl FnOnce() -> PalletName,
             function_name: impl FnOnce() -> ExtrinsicName,
-        ) -> Option<AccountCallPermissionsData<AccountId>>;
+        ) -> Result<AccountCallPermissionsData<AccountId>, DispatchError>;
     }
 
     #[pallet::pallet]
@@ -110,7 +110,6 @@ pub mod pallet {
                 || CurrentPalletName::<T>::get(),
                 || CurrentDispatchableName::<T>::get(),
             )
-            .ok_or_else(|| Error::<T>::UnauthorizedCaller.into())
         }
     }
 }

--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -314,11 +314,7 @@ impl<T: Config> Pallet<T> {
         user_key: T::AccountId,
         polyx_limit: Balance,
     ) -> DispatchResult {
-        let PermissionedCallOriginData {
-            sender: paying_key,
-            primary_did: paying_did,
-            ..
-        } = <Identity<T>>::ensure_origin_call_permissions(origin)?;
+        let (paying_key, paying_did) = Identity::<T>::ensure_valid_origin(origin, false)?;
 
         // Create authorization for `paying_key` to subsidise the `user_key`, with `polyx_limit` POLYX.
         Self::unverified_add_auth_for_paying_key(paying_did, user_key, paying_key, polyx_limit)?;

--- a/pallets/runtime/common/src/fee_details.rs
+++ b/pallets/runtime/common/src/fee_details.rs
@@ -34,42 +34,15 @@ where
     /// However, this does not set the payer context since that is meant to remain constant
     /// throughout the transaction. This function can also be used to simply check CDD and update identity context.
     fn get_valid_payer(call: &C, caller: &AccountId) -> ValidPayerResult {
-        // Check if the `did` has a valid CDD claim.
-        let check_did_cdd = |did: &IdentityId| {
-            if Identity::<A>::has_valid_cdd(*did) {
-                Ok(None)
-            } else {
-                CDD_REQUIRED
-            }
-        };
-
-        // Check if the `did` has a valid CDD claim
-        // and return the primary key as the payer.
-        let did_primary_pays = |did: &IdentityId| {
-            check_did_cdd(did)?;
-            Ok(Identity::<A>::get_primary_key(*did))
-        };
-
-        // Check if the `caller` key has a DID and a valid CDD claim.
-        // The caller is also the payer.
-        let caller_pays = |caller: &AccountId| {
-            match Identity::<A>::get_identity(caller) {
-                Some(did) => {
-                    check_did_cdd(&did)?;
-                    Ok(Some(caller.clone()))
-                }
-                // Return if there's no DID.
-                None => MISSING_ID,
-            }
-        };
+        // Return the primary key as the payer.
+        let did_primary_pays = |did: &IdentityId| Ok(Identity::<A>::get_primary_key(*did));
 
         let handle_multisig = |multisig: &AccountId, caller: &AccountId| {
             if pallet_multisig::MultiSigSigners::<A>::contains_key(multisig, caller) {
-                let ms_pays = caller_pays(multisig)?;
                 // If the `multisig` has a paying DID, then it's primary key pays.
                 match pallet_multisig::Pallet::<A>::get_paying_did(multisig) {
                     Some(did) => Ok(Identity::<A>::get_primary_key(did)),
-                    None => Ok(ms_pays),
+                    None => Ok(Some(multisig.clone())),
                 }
             } else {
                 MISSING_ID
@@ -198,10 +171,6 @@ enum CallType {
 }
 
 type ValidPayerResult = Result<Option<AccountId>, InvalidTransaction>;
-
-const CDD_REQUIRED: ValidPayerResult = Err(InvalidTransaction::Custom(
-    TransactionError::CddRequired as u8,
-));
 
 const MISSING_ID: ValidPayerResult = Err(InvalidTransaction::Custom(
     TransactionError::MissingIdentity as u8,

--- a/pallets/runtime/common/src/fee_details.rs
+++ b/pallets/runtime/common/src/fee_details.rs
@@ -164,10 +164,8 @@ where
                 | pallet_multisig::Call::approve { multisig, .. }
                 | pallet_multisig::Call::reject { multisig, .. },
             )) => handle_multisig(multisig, caller),
-            // All other calls.
-            //
-            // The external account must directly be linked to an identity with valid CDD.
-            _ => caller_pays(caller),
+            // All other calls
+            _ => Ok(Some(caller.clone())),
         }
     }
 

--- a/pallets/runtime/tests/src/contracts_test.rs
+++ b/pallets/runtime/tests/src/contracts_test.rs
@@ -175,7 +175,7 @@ fn chain_extension_calls() {
                 None,
                 register_ticker_input.clone()
             ),
-            pallet_permissions::Error::<TestStorage>::UnauthorizedCaller,
+            pallet_identity::Error::<TestStorage>::UnauthorizedCallerMissingPermissions,
         ));
         // Successfull call
         assert_ok!(Identity::set_secondary_key_permissions(

--- a/pallets/runtime/tests/src/fee_details.rs
+++ b/pallets/runtime/tests/src/fee_details.rs
@@ -55,7 +55,7 @@ fn cdd_checks() {
             );
 
             create_multisig_default_perms(
-                alice_account.clone(),
+                charlie_account.clone(),
                 create_signers(vec![alice_account.clone()]),
                 1,
             );
@@ -68,7 +68,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                Ok(Some(AccountKeyring::Alice.to_account_id()))
+                Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
 
             assert_eq!(
@@ -80,7 +80,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                Ok(Some(AccountKeyring::Alice.to_account_id()))
+                Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
 
             assert_eq!(

--- a/pallets/runtime/tests/src/fee_details.rs
+++ b/pallets/runtime/tests/src/fee_details.rs
@@ -54,19 +54,24 @@ fn cdd_checks() {
                 InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
             );
 
-            let alice_auth_id = 0;
-            assert_noop!(
+            create_multisig_default_perms(
+                alice_account.clone(),
+                create_signers(vec![alice_account.clone()]),
+                1,
+            );
+
+            let alice_auth_id = get_last_auth_id(&alice_signatory);
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::MultiSig(multisig::Call::accept_multisig_signer {
                         auth_id: alice_auth_id
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
-            // call to remove authorisation with issuer paying should fail if issuer does not have a valid cdd
-            assert_noop!(
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::Identity(identity::Call::remove_authorization {
                         target: alice_signatory.clone(),
@@ -75,7 +80,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
             assert_eq!(
@@ -110,7 +115,6 @@ fn cdd_checks() {
                 Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
-            // call to remove authorisation with issuer paying should succeed as issuer has CDD
             assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::Identity(identity::Call::remove_authorization {
@@ -123,10 +127,15 @@ fn cdd_checks() {
                 Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
 
-            let charlie_auth_id = 0;
+            // create an authorisation where the target has a CDD claim and the issuer does not
+            create_multisig_default_perms(
+                alice_account.clone(),
+                create_signers(vec![charlie_account.clone()]),
+                1,
+            );
+            let charlie_auth_id = get_last_auth_id(&charlie_signatory);
 
-            // call to remove authorisation with issuer paying should fail if issuer does not have a valid cdd
-            assert_noop!(
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::Identity(identity::Call::remove_authorization {
                         target: charlie_signatory.clone(),
@@ -135,7 +144,7 @@ fn cdd_checks() {
                     }),
                     &charlie_account
                 ),
-                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
             // call to remove authorisation with caller paying should succeed as caller has CDD

--- a/pallets/runtime/tests/src/fee_details.rs
+++ b/pallets/runtime/tests/src/fee_details.rs
@@ -1,16 +1,17 @@
-use super::{
-    multisig::{create_multisig_default_perms, create_signers},
-    storage::{get_last_auth_id, make_account_without_cdd, register_keyring_account, TestStorage},
-    ExtBuilder,
-};
 use frame_support::assert_noop;
+use sp_keyring::AccountKeyring;
+use sp_runtime::transaction_validity::InvalidTransaction;
+
 use pallet_balances as balances;
 use pallet_identity as identity;
 use pallet_multisig as multisig;
 use polymesh_primitives::{traits::CddAndFeeDetails, Signatory, TransactionError};
 use polymesh_runtime_develop::runtime::{CddHandler, RuntimeCall};
-use sp_keyring::AccountKeyring;
-use sp_runtime::transaction_validity::InvalidTransaction;
+
+use super::multisig::{create_multisig_default_perms, create_signers};
+use super::storage::{get_last_auth_id, make_account_without_cdd};
+use super::storage::{register_keyring_account, TestStorage};
+use super::ExtBuilder;
 
 type MultiSig = multisig::Pallet<TestStorage>;
 type Balances = balances::Pallet<TestStorage>;
@@ -34,15 +35,14 @@ fn cdd_checks() {
             let charlie_account = AccountKeyring::Charlie.to_account_id();
             let charlie_signatory = Signatory::Account(charlie_account.clone());
 
-            // normal tx without cdd should fail
-            assert_noop!(
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::MultiSig(multisig::Call::change_sigs_required {
                         sigs_required: 1
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
             // call to accept being a multisig signer should fail when invalid auth
@@ -54,14 +54,7 @@ fn cdd_checks() {
                 InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
             );
 
-            // call to accept being a multisig signer should fail when authorizer does not have a valid cdd (expired)
-            create_multisig_default_perms(
-                alice_account.clone(),
-                create_signers(vec![alice_account.clone()]),
-                1,
-            );
-
-            let alice_auth_id = get_last_auth_id(&alice_signatory);
+            let alice_auth_id = 0;
             assert_noop!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::MultiSig(multisig::Call::accept_multisig_signer {
@@ -69,7 +62,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
             );
 
             // call to remove authorisation with issuer paying should fail if issuer does not have a valid cdd
@@ -82,11 +75,10 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
             );
 
-            // call to remove authorisation with caller paying should fail if caller does not have a valid cdd
-            assert_noop!(
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::Identity(identity::Call::remove_authorization {
                         target: alice_signatory.clone(),
@@ -95,7 +87,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
             // check that authorisation can be removed correctly
@@ -106,8 +98,7 @@ fn cdd_checks() {
             );
             let alice_auth_id = get_last_auth_id(&alice_signatory);
 
-            // call to remove authorisation with caller paying should fail if caller does not have a valid cdd
-            assert_noop!(
+            assert_eq!(
                 CddHandler::get_valid_payer(
                     &RuntimeCall::Identity(identity::Call::remove_authorization {
                         target: alice_signatory.clone(),
@@ -116,7 +107,7 @@ fn cdd_checks() {
                     }),
                     &alice_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                Ok(Some(AccountKeyring::Alice.to_account_id()))
             );
 
             // call to remove authorisation with issuer paying should succeed as issuer has CDD
@@ -132,13 +123,7 @@ fn cdd_checks() {
                 Ok(Some(AccountKeyring::Charlie.to_account_id()))
             );
 
-            // create an authorisation where the target has a CDD claim and the issuer does not
-            create_multisig_default_perms(
-                alice_account.clone(),
-                create_signers(vec![charlie_account.clone()]),
-                1,
-            );
-            let charlie_auth_id = get_last_auth_id(&charlie_signatory);
+            let charlie_auth_id = 0;
 
             // call to remove authorisation with issuer paying should fail if issuer does not have a valid cdd
             assert_noop!(
@@ -150,7 +135,7 @@ fn cdd_checks() {
                     }),
                     &charlie_account
                 ),
-                InvalidTransaction::Custom(TransactionError::CddRequired as u8)
+                InvalidTransaction::Custom(TransactionError::InvalidAuthorization as u8)
             );
 
             // call to remove authorisation with caller paying should succeed as caller has CDD

--- a/pallets/runtime/tests/src/identity_test.rs
+++ b/pallets/runtime/tests/src/identity_test.rs
@@ -29,12 +29,11 @@ use polymesh_primitives::{
     AssetPermissions, AuthorizationData, AuthorizationType, Claim, ClaimType, CustomClaimTypeId,
     ExtrinsicName, ExtrinsicPermissions, IdentityClaim, IdentityId, KeyRecord, PalletName,
     PalletPermissions, Permissions, PortfolioId, PortfolioNumber, Scope, SecondaryKey, Signatory,
-    SubsetRestriction, SystematicIssuers, Ticker, TransactionError, GC_DID,
+    SubsetRestriction, SystematicIssuers, Ticker, GC_DID,
 };
 use polymesh_runtime_develop::runtime::{CddHandler, RuntimeCall};
 use sp_core::H512;
 use sp_keyring::AccountKeyring;
-use sp_runtime::transaction_validity::InvalidTransaction;
 use sp_std::iter;
 use std::convert::From;
 
@@ -454,7 +453,7 @@ fn frozen_secondary_keys_cdd_verification_test_we() {
         alice.clone()
     )));
 
-    // 4. Bob should NOT transfer any amount. SE is simulated.
+    // 4. Bob should be able to transfer any amount. SE is simulated.
     // Balances::transfer_with_memo(Origin::signed(bob), charlie, 1_000, None),
     let payer = CddHandler::get_valid_payer(
         &RuntimeCall::Balances(balances::Call::transfer_with_memo {
@@ -464,10 +463,7 @@ fn frozen_secondary_keys_cdd_verification_test_we() {
         }),
         &AccountKeyring::Bob.to_account_id(),
     );
-    assert_noop!(
-        payer,
-        InvalidTransaction::Custom(TransactionError::MissingIdentity as u8)
-    );
+    assert!(payer.is_ok());
 
     assert_eq!(Balances::free_balance(charlie.clone()), 1100);
 
@@ -1689,7 +1685,7 @@ fn invalidate_cdd_claims_we() {
     assert_eq!(Identity::has_valid_cdd(alice_id), true);
     assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd.clone()), bob_acc.clone(), vec![]),
-        Error::UnAuthorizedCddProvider
+        Error::UnauthorizedCallerDidMissingCdd
     );
 
     // Move to time 11 ... CDD_1 is expired: Its claims are invalid.
@@ -1697,7 +1693,7 @@ fn invalidate_cdd_claims_we() {
     assert_eq!(Identity::has_valid_cdd(alice_id), false);
     assert_noop!(
         Identity::cdd_register_did(Origin::signed(cdd), bob_acc, vec![]),
-        Error::UnAuthorizedCddProvider
+        Error::UnauthorizedCallerDidMissingCdd
     );
 }
 

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -30,6 +30,7 @@ type ProtocolFee = pallet_protocol_fee::Pallet<TestStorage>;
 type TransactionPayment = pallet_transaction_payment::Pallet<TestStorage>;
 type ChargeTransactionPayment = pallet_transaction_payment::ChargeTransactionPayment<TestStorage>;
 type Error = pallet_relayer::Error<TestStorage>;
+type IdentityError = pallet_identity::Error<TestStorage>;
 
 // Relayer Test Helper functions
 // =======================================
@@ -395,14 +396,9 @@ fn do_relayer_paying_key_missing_cdd_test() {
     let (bob_sign, _) = make_account_without_cdd(bob_acc.clone()).unwrap();
 
     // Add authorization for using Bob as the paying key for Alice.
-    assert_ok!(Relayer::set_paying_key(bob_sign, alice.acc(), 10u128));
-
-    // Alice tries to accept the paying key, but the paying key
-    // is without a CDD.
-    let auth_id = get_last_auth_id(&Signatory::Account(alice.acc()));
-    assert_eq!(
-        Relayer::accept_paying_key(alice.origin(), auth_id),
-        Err(Error::PayingKeyCddMissing.into()),
+    assert_noop!(
+        Relayer::set_paying_key(bob_sign, alice.acc(), 10u128),
+        IdentityError::UnauthorizedCallerDidMissingCdd
     );
 }
 

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -396,9 +396,14 @@ fn do_relayer_paying_key_missing_cdd_test() {
     let (bob_sign, _) = make_account_without_cdd(bob_acc.clone()).unwrap();
 
     // Add authorization for using Bob as the paying key for Alice.
-    assert_noop!(
-        Relayer::set_paying_key(bob_sign, alice.acc(), 10u128),
-        IdentityError::UnauthorizedCallerDidMissingCdd
+    assert_ok!(Relayer::set_paying_key(bob_sign, alice.acc(), 10u128));
+
+    // Alice tries to accept the paying key, but the paying key
+    // is without a CDD.
+    let auth_id = get_last_auth_id(&Signatory::Account(alice.acc()));
+    assert_eq!(
+        Relayer::accept_paying_key(alice.origin(), auth_id),
+        Err(Error::PayingKeyCddMissing.into()),
     );
 }
 

--- a/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
@@ -13,7 +13,7 @@ use polymesh_primitives::{ClaimType, Condition, ConditionType, CountryCode, Scop
 use polymesh_runtime_common::Weight;
 
 use super::setup::{add_and_affirm_simple_instruction, create_and_issue_sample_asset_with_venue};
-use crate::storage::{root, EventTest, User};
+use crate::storage::{EventTest, User, RuntimeOrigin};
 use crate::{ExtBuilder, TestStorage};
 
 type Asset = pallet_asset::Pallet<TestStorage>;
@@ -256,7 +256,7 @@ fn frozen_asset() {
 }
 
 #[test]
-fn missing_cdd_claim() {
+fn sender_missing_cdd_claim() {
     ExtBuilder::default()
         .cdd_providers(vec![AccountKeyring::Eve.to_account_id()])
         .build()
@@ -267,12 +267,42 @@ fn missing_cdd_claim() {
 
             add_and_affirm_simple_instruction(alice, bob, dave, SettlementType::SettleAfterLock);
 
-            let cdd_1_id = Identity::get_identity(&AccountKeyring::Eve.to_account_id()).unwrap();
-            Identity::invalidate_cdd_claims(root(), cdd_1_id, Timestamp::get(), None).unwrap();
+            Identity::revoke_claim(
+                RuntimeOrigin::signed(AccountKeyring::Eve.to_account_id()),
+                alice.did,
+                Claim::CustomerDueDiligence(Default::default()),
+            )
+            .unwrap();
 
             assert_noop!(
                 Settlement::lock_instruction(dave.origin(), InstructionId(0), Weight::MAX),
-                IdentityError::UnauthorizedCallerDidMissingCdd
+                Error::<TestStorage>::FailedAssetTransferringConditions
+            );
+        });
+}
+
+#[test]
+fn rcv_missing_cdd_claim() {
+    ExtBuilder::default()
+        .cdd_providers(vec![AccountKeyring::Eve.to_account_id()])
+        .build()
+        .execute_with(|| {
+            let bob = User::new(AccountKeyring::Bob);
+            let dave = User::new(AccountKeyring::Dave);
+            let alice = User::new(AccountKeyring::Alice);
+
+            add_and_affirm_simple_instruction(alice, bob, dave, SettlementType::SettleAfterLock);
+
+            Identity::revoke_claim(
+                RuntimeOrigin::signed(AccountKeyring::Eve.to_account_id()),
+                bob.did,
+                Claim::CustomerDueDiligence(Default::default()),
+            )
+            .unwrap();
+
+            assert_noop!(
+                Settlement::lock_instruction(dave.origin(), InstructionId(0), Weight::MAX),
+                Error::<TestStorage>::FailedAssetTransferringConditions
             );
         });
 }

--- a/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
@@ -25,6 +25,7 @@ type System = frame_system::Pallet<TestStorage>;
 type Timestamp = pallet_timestamp::Pallet<TestStorage>;
 
 type AssetError = pallet_asset::Error<TestStorage>;
+type IdentityError = pallet_identity::Error<TestStorage>;
 type PortfolioError = pallet_portfolio::Error<TestStorage>;
 type NFTError = pallet_nft::Error<TestStorage>;
 
@@ -271,7 +272,7 @@ fn missing_cdd_claim() {
 
             assert_noop!(
                 Settlement::lock_instruction(dave.origin(), InstructionId(0), Weight::MAX),
-                Error::<TestStorage>::FailedAssetTransferringConditions
+                IdentityError::UnauthorizedCallerDidMissingCdd
             );
         });
 }

--- a/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/lock_instruction.rs
@@ -13,7 +13,7 @@ use polymesh_primitives::{ClaimType, Condition, ConditionType, CountryCode, Scop
 use polymesh_runtime_common::Weight;
 
 use super::setup::{add_and_affirm_simple_instruction, create_and_issue_sample_asset_with_venue};
-use crate::storage::{EventTest, User, RuntimeOrigin};
+use crate::storage::{EventTest, RuntimeOrigin, User};
 use crate::{ExtBuilder, TestStorage};
 
 type Asset = pallet_asset::Pallet<TestStorage>;

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -374,7 +374,7 @@ fn batch_secondary_with_permissions() {
     let high_risk_name: PortfolioName = b"high risk".into();
     assert_noop!(
         Portfolio::create_portfolio(bob.origin(), high_risk_name.clone()),
-        pallet_permissions::Error::<TestStorage>::UnauthorizedCaller
+        pallet_identity::Error::<TestStorage>::UnauthorizedCallerMissingPermissions
     );
 
     // Call one disallowed and one allowed extrinsic in a batch.
@@ -388,7 +388,7 @@ fn batch_secondary_with_permissions() {
         }),
     ];
     let expected_error: DispatchError =
-        pallet_permissions::Error::<TestStorage>::UnauthorizedCaller.into();
+        pallet_identity::Error::<TestStorage>::UnauthorizedCallerMissingPermissions.into();
     assert_ok!(Utility::batch(bob.origin(), calls.clone()));
     assert_event_doesnt_exist!(EventTest::Utility(Event::BatchCompleted));
     assert_event_exists!(


### PR DESCRIPTION
## changelog

### other
- Moves the CDD check from the Signed Extension to the Identity pallet. This will remove the need for CDD for some extrinsics;
- Adds the following errors to the identity pallet: `UnauthorizedCallerFrozenDid`, `UnauthorizedCallerDidMissingCdd`, `UnauthorizedCallerMissingPermissions`

