### PR TITLE
Add support for release candidates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "7.3.0"
+version = "7.3.0-rc1"
 dependencies = [
  "clap",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "7.3.0"
+version = "7.3.0-rc1"
 authors = ["PolymeshAssociation"]
 build = "build.rs"
 edition = "2021"

--- a/scripts/check_spec_and_cargo_version.sh
+++ b/scripts/check_spec_and_cargo_version.sh
@@ -8,10 +8,14 @@ else
 fi
 POLYMESH_VERSION=`grep -h -r ' spec_version: ' pallets/runtime/*/src/runtime.rs | sort -u | sed -e 's/.*spec_version: \([0-9]\+\)_[0]*\([0-9]\+\)_[0]*\([0-9]\+\)[0-9],/\1.\2.\3/g'`
 
-if head Cargo.toml | grep -q $POLYMESH_VERSION; then
+NODE_PKG_VERSION=`cargo info -q --color never polymesh | grep "^version:" | sed -e 's/version: \([0-9a-z.-]*\) .*/\1/g'`
+
+if echo "$NODE_PKG_VERSION" | grep -q $POLYMESH_VERSION; then
 	echo "Spec version matches Polymesh version."
 	exit 0
 else
 	echo "Spec version doesn't match Polymesh version."
+	echo "Version from spec_version=$POLYMESH_VERSION"
+	echo "Version from node package=$NODE_PKG_VERSION"
 	exit 1
 fi


### PR DESCRIPTION
Update our version checking to support `-rc1` release candidates for improved release cycle.