### PR TITLE
Update agents when transferring asset ownership

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -1784,6 +1784,10 @@ impl<T: AssetConfig> Pallet<T> {
             SecurityTokensOwnedByUser::<T>::remove(previous_owner, asset_id);
             SecurityTokensOwnedByUser::<T>::insert(caller_did, asset_id, true);
 
+            // Removes the old owner from the external agents list and adds the new owner as a full agent
+            ExternalAgents::<T>::unchecked_add_agent(asset_id, caller_did, AgentGroup::Full)?;
+            ExternalAgents::<T>::try_mutate_agents_group(asset_id, previous_owner, None)?;
+
             // Updates asset details.
             asset_details.owner_did = caller_did;
             Assets::<T>::insert(asset_id, asset_details);

--- a/pallets/external-agents/src/lib.rs
+++ b/pallets/external-agents/src/lib.rs
@@ -515,7 +515,7 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Ensure that `agent` is an agent of `asset_id` and set the group to `group`.
-    fn try_mutate_agents_group(
+    pub fn try_mutate_agents_group(
         asset_id: AssetId,
         agent: IdentityId,
         group: Option<AgentGroup>,

--- a/pallets/runtime/tests/src/asset_pallet/asset_ownership_transfer.rs
+++ b/pallets/runtime/tests/src/asset_pallet/asset_ownership_transfer.rs
@@ -1,0 +1,74 @@
+use frame_support::assert_ok;
+use sp_keyring::AccountKeyring;
+
+use pallet_asset::SecurityTokensOwnedByUser;
+use pallet_external_agents::GroupOfAgent;
+use polymesh_primitives::agent::AgentGroup;
+use polymesh_primitives::{AuthorizationData, Signatory};
+
+use crate::asset_pallet::setup::create_and_issue_sample_asset;
+use crate::ext_builder::ExtBuilder;
+use crate::storage::{TestStorage, User};
+
+#[test]
+fn transfer_token_ownership_agents_check() {
+    ExtBuilder::default().build().execute_with(|| {
+        let bob = User::new(AccountKeyring::Bob);
+        let dave = User::new(AccountKeyring::Dave);
+        let alice = User::new(AccountKeyring::Alice);
+
+        let asset_id = create_and_issue_sample_asset(&alice);
+
+        let agent_auth_id = pallet_identity::Pallet::<TestStorage>::add_auth(
+            alice.did,
+            Signatory::from(dave.did),
+            AuthorizationData::BecomeAgent(asset_id, AgentGroup::Full),
+            None,
+        )
+        .unwrap();
+
+        assert_ok!(
+            pallet_external_agents::Pallet::<TestStorage>::accept_become_agent(
+                dave.origin(),
+                agent_auth_id
+            )
+        );
+
+        let asset_transfer_auth_id = pallet_identity::Pallet::<TestStorage>::add_auth(
+            alice.did,
+            Signatory::from(bob.did),
+            AuthorizationData::TransferAssetOwnership(asset_id),
+            None,
+        )
+        .unwrap();
+
+        assert_ok!(
+            pallet_asset::Pallet::<TestStorage>::accept_asset_ownership_transfer(
+                bob.origin(),
+                asset_transfer_auth_id
+            )
+        );
+
+        // Asset owner is updated
+        assert_eq!(
+            SecurityTokensOwnedByUser::<TestStorage>::get(alice.did, asset_id),
+            false
+        );
+        assert_eq!(
+            SecurityTokensOwnedByUser::<TestStorage>::get(bob.did, asset_id),
+            true
+        );
+        // Old asset owner is removed from external agents
+        assert_eq!(GroupOfAgent::<TestStorage>::get(asset_id, alice.did), None);
+        // New asset owner is added from external agents
+        assert_eq!(
+            GroupOfAgent::<TestStorage>::get(asset_id, bob.did),
+            Some(AgentGroup::Full)
+        );
+        // Previous permissioned agent remains
+        assert_eq!(
+            GroupOfAgent::<TestStorage>::get(asset_id, dave.did),
+            Some(AgentGroup::Full)
+        );
+    })
+}

--- a/pallets/runtime/tests/src/asset_pallet/mod.rs
+++ b/pallets/runtime/tests/src/asset_pallet/mod.rs
@@ -1,4 +1,5 @@
 mod accept_ticker_transfer;
+mod asset_ownership_transfer;
 mod base_transfer;
 mod controller_transfer;
 mod issue;

--- a/pallets/runtime/tests/src/asset_test.rs
+++ b/pallets/runtime/tests/src/asset_test.rs
@@ -484,12 +484,6 @@ fn transfer_token_ownership() {
             true
         );
 
-        assert_ok!(ExternalAgents::unchecked_add_agent(
-            asset_id,
-            alice.did,
-            AgentGroup::Full
-        ));
-        assert_ok!(ExternalAgents::abdicate(owner.origin(), asset_id));
         assert_eq!(
             Asset::accept_asset_ownership_transfer(bob.origin(), auth_id_bob),
             Err(EAError::UnauthorizedAgent.into())
@@ -678,17 +672,6 @@ fn freeze_unfreeze_asset() {
             auth_id
         ));
 
-        // Not enough; bob needs to become an agent.
-        assert_noop!(
-            Asset::unfreeze(bob.origin(), asset_id),
-            EAError::UnauthorizedAgent
-        );
-
-        assert_ok!(ExternalAgents::unchecked_add_agent(
-            asset_id,
-            bob.did,
-            AgentGroup::Full
-        ));
         assert_ok!(Asset::unfreeze(bob.origin(), asset_id));
         assert_noop!(
             Asset::unfreeze(bob.origin(), asset_id),


### PR DESCRIPTION
## changelog
### other
 - Removes the old asset owner from the agents list;
 - Adds the new owner as an agent with full permissions;
