### PR TITLE
Soften CDD requirements part II; Add TransferWithMemo event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "polymesh"
-version = "7.3.0"
+version = "7.4.0"
 dependencies = [
  "clap",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymesh"
-version = "7.3.0"
+version = "7.4.0"
 authors = ["PolymeshAssociation"]
 build = "build.rs"
 edition = "2021"
@@ -359,8 +359,8 @@ substrate-build-script-utils = { version = "3.0.0" }
 [features]
 default = ["std"]
 disable_fees = [
-    "pallet-transaction-payment/disable_fees", 
-    "polymesh-runtime-develop/disable_fees", 
+    "pallet-transaction-payment/disable_fees",
+    "polymesh-runtime-develop/disable_fees",
     "polymesh-runtime-mainnet/disable_fees",
     "polymesh-runtime-testnet/disable_fees",
 ]

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -319,6 +319,13 @@ pub mod pallet {
         /// Final argument indicates the destination balance type.
         /// \[from, to, balance, destination_status]
         ReserveRepatriated(T::AccountId, T::AccountId, Balance, Status),
+        /// Transfer with memo succeeded.
+        TransferWithMemo {
+            from: T::AccountId,
+            to: T::AccountId,
+            amount: Balance,
+            memo: Option<Memo>,
+        },
     }
 
     #[pallet::pallet]
@@ -878,13 +885,20 @@ impl<T: Config> Pallet<T> {
         let transactor_id = T::IdentityFn::get_identity(transactor);
         let dest_id = T::IdentityFn::get_identity(dest);
 
+        Self::deposit_event(Event::TransferWithMemo {
+            from: transactor.clone(),
+            to: dest.clone(),
+            amount: value,
+            memo: memo.clone(),
+        });
+
         Self::deposit_event(Event::Transfer(
             transactor_id,
             transactor.clone(),
             dest_id,
             dest.clone(),
             value,
-            memo,
+            memo.clone(),
         ));
 
         Ok(())

--- a/pallets/balances/src/lib.rs
+++ b/pallets/balances/src/lib.rs
@@ -898,7 +898,7 @@ impl<T: Config> Pallet<T> {
             dest_id,
             dest.clone(),
             value,
-            memo.clone(),
+            memo,
         ));
 
         Ok(())

--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -51,7 +51,6 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::ensure_signed;
-use pallet_identity::PermissionedCallOriginData;
 use polymesh_primitives::{
     extract_auth, traits::SubsidiserTrait, AuthorizationData, Balance, EventDid, IdentityId,
     Signatory, TransactionError,
@@ -305,6 +304,8 @@ pub mod pallet {
         Overflow,
         /// The extrinsic expected a different `AuthorizationType` than what the `data.auth_type()` is.
         BadAuthorizationType,
+        /// The caller's identity was not found.
+        IdentityNotFound,
     }
 }
 
@@ -324,7 +325,7 @@ impl<T: Config> Pallet<T> {
     fn base_accept_paying_key(origin: T::RuntimeOrigin, auth_id: u64) -> DispatchResult {
         let caller_key = ensure_signed(origin)?;
         let user_did =
-            <Identity<T>>::get_identity(&caller_key).ok_or(Error::<T>::UserKeyCddMissing)?;
+            <Identity<T>>::get_identity(&caller_key).ok_or(Error::<T>::IdentityNotFound)?;
         let signer = Signatory::Account(caller_key.clone());
 
         <Identity<T>>::accept_auth_with(&signer, auth_id, |data, auth_by| -> DispatchResult {
@@ -357,17 +358,15 @@ impl<T: Config> Pallet<T> {
         user_key: T::AccountId,
         paying_key: T::AccountId,
     ) -> DispatchResult {
-        let PermissionedCallOriginData {
-            sender,
-            primary_did: sender_did,
-            ..
-        } = <Identity<T>>::ensure_origin_call_permissions(origin)?;
+        let caller_key = ensure_signed(origin)?;
+        let caller_did =
+            Identity::<T>::get_identity(&caller_key).ok_or(Error::<T>::IdentityNotFound)?;
 
         // Allow: `origin == user_key` or `origin == paying_key`.
-        if sender != user_key && sender != paying_key {
+        if caller_key != user_key && caller_key != paying_key {
             // Allow: `origin == primary key of user_key's identity`.
             ensure!(
-                <Identity<T>>::get_identity(&user_key) == Some(sender_did),
+                Identity::<T>::get_identity(&user_key) == Some(caller_did),
                 Error::<T>::NotAuthorizedForUserKey
             );
         }
@@ -384,7 +383,7 @@ impl<T: Config> Pallet<T> {
         <Subsidies<T>>::remove(&user_key);
 
         Self::deposit_event(Event::RemovedPayingKey(
-            sender_did.for_event(),
+            caller_did.for_event(),
             user_key,
             paying_key,
         ));
@@ -397,14 +396,12 @@ impl<T: Config> Pallet<T> {
         action: UpdateAction,
         amount: Balance,
     ) -> DispatchResult {
-        let PermissionedCallOriginData {
-            sender: paying_key,
-            primary_did: paying_did,
-            ..
-        } = <Identity<T>>::ensure_origin_call_permissions(origin)?;
+        let caller_key = ensure_signed(origin)?;
+        let caller_did =
+            Identity::<T>::get_identity(&caller_key).ok_or(Error::<T>::IdentityNotFound)?;
 
         // Check if the current paying key matches.
-        let mut subsidy = Self::ensure_is_paying_key(&user_key, &paying_key)?;
+        let mut subsidy = Self::ensure_is_paying_key(&user_key, &caller_key)?;
 
         // Update polyx limit.
         let old_remaining = subsidy.remaining;
@@ -421,9 +418,9 @@ impl<T: Config> Pallet<T> {
         <Subsidies<T>>::insert(&user_key, subsidy);
 
         Self::deposit_event(Event::UpdatedPolyxLimit(
-            paying_did.for_event(),
+            caller_did.for_event(),
             user_key,
-            paying_key,
+            caller_key,
             new_remaining,
             old_remaining,
         ));

--- a/pallets/relayer/src/lib.rs
+++ b/pallets/relayer/src/lib.rs
@@ -457,15 +457,6 @@ impl<T: Config> Pallet<T> {
         Ok(auth_id)
     }
 
-    /// Check if the `key` has a valid CDD.
-    fn key_has_valid_cdd(key: &T::AccountId) -> bool {
-        if let Some(did) = <Identity<T>>::get_identity(key) {
-            <Identity<T>>::has_valid_cdd(did)
-        } else {
-            false
-        }
-    }
-
     /// Ensure that `paying_key` is the paying key for `user_key`.
     fn ensure_is_paying_key(
         user_key: &T::AccountId,
@@ -493,16 +484,6 @@ impl<T: Config> Pallet<T> {
         ensure!(
             <Identity<T>>::get_identity(&paying_key) == Some(from),
             Error::<T>::NotAuthorizedForPayingKey
-        );
-
-        // Ensure both user_key and paying_key have valid CDD.
-        ensure!(
-            <Identity<T>>::has_valid_cdd(user_did),
-            Error::<T>::UserKeyCddMissing
-        );
-        ensure!(
-            Self::key_has_valid_cdd(&paying_key),
-            Error::<T>::PayingKeyCddMissing
         );
 
         // Remove existing subsidy for the user_key, if it exists.

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -55,7 +55,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_003_003,
+    spec_version: 7_004_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -53,7 +53,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_003_003,
+    spec_version: 7_004_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -55,7 +55,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     // `spec_version: aaa_bbb_ccd` should match node version v`aaa.bbb.cc`
     // N.B. `d` is unpinned from the binary version
-    spec_version: 7_003_003,
+    spec_version: 7_004_000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/pallets/runtime/tests/src/relayer_test.rs
+++ b/pallets/runtime/tests/src/relayer_test.rs
@@ -357,13 +357,13 @@ fn do_user_remove_paying_key_test() {
 }
 
 #[test]
-fn relayer_user_key_missing_cdd_test() {
+fn relayer_user_key_without_cdd_test() {
     ExtBuilder::default()
         .monied(true)
         .build()
-        .execute_with(&do_relayer_user_key_missing_cdd_test);
+        .execute_with(&do_relayer_user_key_without_cdd_test);
 }
-fn do_relayer_user_key_missing_cdd_test() {
+fn do_relayer_user_key_without_cdd_test() {
     let alice = User::new(AccountKeyring::Alice);
     let bob_acc = AccountKeyring::Bob.to_account_id();
     let (bob_sign, _) = make_account_without_cdd(bob_acc.clone()).unwrap();
@@ -377,20 +377,17 @@ fn do_relayer_user_key_missing_cdd_test() {
 
     // Bob tries to accept the paying key, without having a CDD.
     let auth_id = get_last_auth_id(&Signatory::Account(bob_acc.clone()));
-    assert_eq!(
-        Relayer::accept_paying_key(bob_sign, auth_id),
-        Err(Error::UserKeyCddMissing.into()),
-    );
+    assert_ok!(Relayer::accept_paying_key(bob_sign, auth_id),);
 }
 
 #[test]
-fn relayer_paying_key_missing_cdd_test() {
+fn relayer_paying_key_without_cdd_test() {
     ExtBuilder::default()
         .monied(true)
         .build()
-        .execute_with(&do_relayer_paying_key_missing_cdd_test);
+        .execute_with(&do_relayer_paying_key_without_cdd_test);
 }
-fn do_relayer_paying_key_missing_cdd_test() {
+fn do_relayer_paying_key_without_cdd_test() {
     let alice = User::new(AccountKeyring::Alice);
     let bob_acc = AccountKeyring::Bob.to_account_id();
     let (bob_sign, _) = make_account_without_cdd(bob_acc.clone()).unwrap();
@@ -401,10 +398,7 @@ fn do_relayer_paying_key_missing_cdd_test() {
     // Alice tries to accept the paying key, but the paying key
     // is without a CDD.
     let auth_id = get_last_auth_id(&Signatory::Account(alice.acc()));
-    assert_eq!(
-        Relayer::accept_paying_key(alice.origin(), auth_id),
-        Err(Error::PayingKeyCddMissing.into()),
-    );
+    assert_ok!(Relayer::accept_paying_key(alice.origin(), auth_id),);
 }
 
 #[test]

--- a/pallets/runtime/tests/src/utility_test.rs
+++ b/pallets/runtime/tests/src/utility_test.rs
@@ -164,6 +164,8 @@ fn batch_optimistic_failures_listed() {
         );
         // skip Balances::Transfer event.
         events.pop().unwrap();
+        events.pop().unwrap();
+
         assert_eq!(
             events.pop().unwrap().event,
             EventTest::Utility(Event::ItemFailed { error: ERROR })
@@ -282,16 +284,6 @@ fn _relay_unhappy_cases() {
             transaction.clone()
         ),
         Error::InvalidSignature
-    );
-
-    assert_noop!(
-        Utility::relay_tx(
-            origin.clone(),
-            bob.clone(),
-            AccountKeyring::Bob.sign(&transaction.encode()).into(),
-            transaction.clone()
-        ),
-        Error::TargetCddMissing
     );
 
     let _ = register_keyring_account_with_balance(AccountKeyring::Bob, 1_000).unwrap();

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -88,7 +88,7 @@ use pallet_balances::Config as BalancesConfig;
 use pallet_identity::{Config as IdentityConfig, Context};
 use pallet_permissions::with_call_metadata;
 use polymesh_common_utilities::identity::AuthorizationNonce;
-use polymesh_primitives::{crypto::verify_signature, traits::CheckCdd, IdentityId};
+use polymesh_primitives::{crypto::verify_signature, IdentityId};
 
 type Identity<T> = pallet_identity::Pallet<T>;
 
@@ -360,11 +360,6 @@ pub mod pallet {
             ensure!(
                 verify_signature::<T, _, _>(&target, &signature, &call, false),
                 Error::<T>::InvalidSignature
-            );
-
-            ensure!(
-                T::CddChecker::check_key_cdd(&target),
-                Error::<T>::TargetCddMissing
             );
 
             <Nonces<T>>::insert(target.clone(), target_nonce + 1);


### PR DESCRIPTION

## changelog

### new events
- Adds `TransferWithMemo` to the balances pallet;

### other
- Removes cdd check from relayer;
- Removes cdd check from relay_tx;

