### PR TITLE
Replace randomness with BABE randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.4.1",
+ "rustc_version",
  "zeroize",
 ]
 
@@ -2033,7 +2033,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.1",
+ "rustc_version",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -2319,7 +2319,7 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "syn 2.0.111",
 ]
 
@@ -2361,7 +2361,7 @@ dependencies = [
  "convert_case 0.10.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "syn 2.0.111",
  "unicode-xid",
 ]
@@ -5735,7 +5735,7 @@ dependencies = [
  "equivalent",
  "parking_lot 0.12.5",
  "portable-atomic",
- "rustc_version 0.4.1",
+ "rustc_version",
  "smallvec",
  "tagptr",
  "uuid",
@@ -6799,17 +6799,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
-]
-
-[[package]]
-name = "pallet-insecure-randomness-collective-flip"
-version = "33.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame",
- "safe-mix",
- "scale-info",
 ]
 
 [[package]]
@@ -8331,7 +8320,6 @@ dependencies = [
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
- "pallet-insecure-randomness-collective-flip",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nft",
@@ -8419,7 +8407,6 @@ dependencies = [
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
- "pallet-insecure-randomness-collective-flip",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nft",
@@ -8508,7 +8495,6 @@ dependencies = [
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
- "pallet-insecure-randomness-collective-flip",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nft",
@@ -8600,7 +8586,6 @@ dependencies = [
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
- "pallet-insecure-randomness-collective-flip",
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nft",
@@ -9643,15 +9628,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
@@ -9807,15 +9783,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "safe-mix"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-dependencies = [
- "rustc_version 0.2.3",
-]
 
 [[package]]
 name = "safe_arch"
@@ -11325,15 +11292,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
@@ -11712,7 +11670,7 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
  "ring 0.17.14",
- "rustc_version 0.4.1",
+ "rustc_version",
  "sha2 0.10.9",
  "subtle 2.6.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ pallet-election-provider-multi-phase = { git = "https://github.com/PolymeshAssoc
 pallet-grandpa = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
 pallet-im-online = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
 pallet-indices = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
 pallet-mmr = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
 pallet-offences = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }
 pallet-preimage = { git = "https://github.com/PolymeshAssociation/polkadot-sdk", branch = "polymesh-v8-stable2512", default-features = false }

--- a/pallets/identity/src/keys.rs
+++ b/pallets/identity/src/keys.rs
@@ -23,7 +23,7 @@ use crate::{
 use codec::Encode as _;
 use frame_support::dispatch::DispatchResult;
 use frame_support::ensure;
-use frame_support::traits::{Currency as _, Get as _};
+use frame_support::traits::{Currency as _, Get as _, Randomness as _};
 use frame_system::ensure_signed;
 use pallet_base::{ensure_custom_length_ok, ensure_custom_string_limited};
 use pallet_permissions::{AccountCallPermissionsData, CheckAccountCallPermissions};
@@ -53,8 +53,6 @@ const MAX_NAME_LEN: usize = 60;
 
 // Limit the maximum memory/cpu cost of a key's permissions.
 const MAX_PERMISSION_COMPLEXITY: usize = 1_000_000;
-
-type System<T> = frame_system::Pallet<T>;
 
 impl<T: Config> Pallet<T> {
     /// Does the identity given by `did` exist?
@@ -773,17 +771,14 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Create a new DID out of the parent block hash and a `nonce`.
+    /// Create a new DID from BABE randomness and a `nonce`.
     fn make_did() -> Result<IdentityId, DispatchError> {
         let nonce = MultiPurposeNonce::<T>::get() + 7u64;
         // Even if this transaction fails, nonce should be increased for added unpredictability of dids
         MultiPurposeNonce::<T>::put(&nonce);
 
-        // TODO: Look into getting randomness from `pallet_babe`.
-        // NB: We can't get the current block's hash while processing
-        // an extrinsic, so we use parent hash here.
-        let parent_hash = System::<T>::parent_hash();
-        let did = IdentityId(blake2_256(&(USER, parent_hash, nonce).encode()));
+        let (randomness, _) = T::Randomness::random(&nonce.encode());
+        let did = IdentityId(blake2_256(&(USER, randomness, nonce).encode()));
 
         // Make sure there's no pre-existing entry for the DID
         // This should never happen but just being defensive here

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -276,6 +276,9 @@ pub mod pallet {
         /// before it is considered unusable.
         #[pallet::constant]
         type MaxAuthRetries: Get<u8>;
+
+        /// Source of randomness for DID generation.
+        type Randomness: frame_support::traits::Randomness<Self::Hash, BlockNumberFor<Self>>;
     }
 
     #[pallet::event]

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -108,6 +108,7 @@ macro_rules! misc_pallet_impls {
             /// The set code logic, just the default since we're not a parachain.
             type SingleBlockMigrations = (
                 UpgradeSessionKeys,
+                RemoveRandomnessCollectiveFlipStorage,
                 pallet_contracts::Migration<Runtime>,
                 pallet_grandpa::migrations::MigrateV4ToV5<Runtime>,
                 pallet_im_online::migration::v1::Migration<Runtime>,
@@ -516,7 +517,7 @@ macro_rules! misc_pallet_impls {
 
         impl pallet_contracts::Config for Runtime {
             type Time = Timestamp;
-            type Randomness = RandomnessCollectiveFlip;
+            type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
             type Currency = Balances;
             type RuntimeEvent = RuntimeEvent;
             type RuntimeCall = RuntimeCall;
@@ -618,7 +619,13 @@ macro_rules! misc_pallet_impls {
             pub const PreimageHoldReason: RuntimeHoldReason = RuntimeHoldReason::Preimage(pallet_preimage::HoldReason::Preimage);
 
             pub const BridgePalletName: &'static str = "Bridge";
+            pub const RandomnessCollectiveFlipPalletName: &'static str = "RandomnessCollectiveFlip";
         }
+
+        type RemoveRandomnessCollectiveFlipStorage = frame_support::migrations::RemovePallet<
+            RandomnessCollectiveFlipPalletName,
+            <Runtime as frame_system::Config>::DbWeight
+        >;
 
         impl pallet_preimage::Config for Runtime {
             type RuntimeEvent = RuntimeEvent;
@@ -662,8 +669,6 @@ macro_rules! misc_pallet_impls {
             type EquivocationReportSystem =
               pallet_grandpa::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;
         }
-
-        impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
 
         impl pallet_treasury::Config for Runtime {
             type Currency = Balances;

--- a/pallets/runtime/develop/Cargo.toml
+++ b/pallets/runtime/develop/Cargo.toml
@@ -77,7 +77,6 @@ pallet-election-provider-multi-phase = { workspace = true, default-features = fa
 pallet-grandpa = { workspace = true, default-features = false }
 pallet-im-online = { workspace = true, default-features = false }
 pallet-indices = { workspace = true, default-features = false }
-pallet-insecure-randomness-collective-flip = { workspace = true, default-features = false }
 pallet-mmr = { workspace = true, default-features = false }
 pallet-offences = { workspace = true, default-features = false }
 pallet-preimage = { workspace = true, default-features = false }
@@ -146,7 +145,6 @@ std = [
     "pallet-group-rpc-runtime-api/std",
     "pallet-im-online/std",
     "pallet-indices/std",
-    "pallet-insecure-randomness-collective-flip/std",
     "pallet-multisig/std",
     "pallet-nft/std",
     "pallet-pips/std",

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -203,6 +203,7 @@ impl pallet_identity::Config for Runtime {
     type InitialPOLYX = InitialPOLYX;
     type MaxGivenAuths = MaxGivenAuths;
     type MaxAuthRetries = MaxAuthRetries;
+    type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -395,9 +395,6 @@ mod runtime {
     #[runtime::pallet_index(23)]
     pub type ImOnline = pallet_im_online::Pallet<Runtime>;
 
-    #[runtime::pallet_index(24)]
-    pub type RandomnessCollectiveFlip = pallet_insecure_randomness_collective_flip::Pallet<Runtime>;
-
     #[runtime::pallet_index(25)]
     pub type Sudo = pallet_sudo::Pallet<Runtime>;
 

--- a/pallets/runtime/mainnet/Cargo.toml
+++ b/pallets/runtime/mainnet/Cargo.toml
@@ -79,7 +79,6 @@ pallet-election-provider-multi-phase = { workspace = true, default-features = fa
 pallet-grandpa = { workspace = true, default-features = false }
 pallet-im-online = { workspace = true, default-features = false }
 pallet-indices = { workspace = true, default-features = false }
-pallet-insecure-randomness-collective-flip = { workspace = true, default-features = false }
 pallet-mmr = { workspace = true, default-features = false }
 pallet-offences = { workspace = true, default-features = false }
 pallet-preimage = { workspace = true, default-features = false }
@@ -159,7 +158,6 @@ std = [
     "pallet-protocol-fee-rpc-runtime-api/std",
     "pallet-protocol-fee/std",
     "pallet-relayer/std",
-    "pallet-insecure-randomness-collective-flip/std",
     "pallet-scheduler/std",
     "pallet-session/std",
     "pallet-settlement/std",

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -202,6 +202,7 @@ impl pallet_identity::Config for Runtime {
     type InitialPOLYX = InitialPOLYX;
     type MaxGivenAuths = MaxGivenAuths;
     type MaxAuthRetries = MaxAuthRetries;
+    type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/mainnet/src/runtime.rs
+++ b/pallets/runtime/mainnet/src/runtime.rs
@@ -387,9 +387,6 @@ mod runtime {
     #[runtime::pallet_index(23)]
     pub type ImOnline = pallet_im_online::Pallet<Runtime>;
 
-    #[runtime::pallet_index(24)]
-    pub type RandomnessCollectiveFlip = pallet_insecure_randomness_collective_flip::Pallet<Runtime>;
-
     #[runtime::pallet_index(26)]
     pub type Asset = pallet_asset::Pallet<Runtime>;
 

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -80,7 +80,6 @@ pallet-election-provider-multi-phase = { workspace = true, default-features = fa
 pallet-grandpa = { workspace = true, default-features = false }
 pallet-im-online = { workspace = true, default-features = false }
 pallet-indices = { workspace = true, default-features = false }
-pallet-insecure-randomness-collective-flip = { workspace = true, default-features = false }
 pallet-mmr = { workspace = true, default-features = false }
 pallet-offences = { workspace = true, default-features = false }
 pallet-preimage = { workspace = true, default-features = false }
@@ -162,7 +161,6 @@ std = [
     "pallet-protocol-fee-rpc-runtime-api/std",
     "pallet-protocol-fee/std",
     "pallet-relayer/std",
-    "pallet-insecure-randomness-collective-flip/std",
     "pallet-scheduler/std",
     "pallet-session/std",
     "pallet-settlement/std",

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -395,9 +395,6 @@ mod runtime {
     #[runtime::pallet_index(23)]
     pub type ImOnline = pallet_im_online::Pallet<Runtime>;
 
-    #[runtime::pallet_index(24)]
-    pub type RandomnessCollectiveFlip = pallet_insecure_randomness_collective_flip::Pallet<Runtime>;
-
     #[runtime::pallet_index(26)]
     pub type Asset = pallet_asset::Pallet<Runtime>;
 

--- a/pallets/runtime/testnet/src/runtime.rs
+++ b/pallets/runtime/testnet/src/runtime.rs
@@ -210,6 +210,7 @@ impl pallet_identity::Config for Runtime {
     type InitialPOLYX = InitialPOLYX;
     type MaxGivenAuths = MaxGivenAuths;
     type MaxAuthRetries = MaxAuthRetries;
+    type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 }
 
 impl pallet_committee::Config<GovernanceCommittee> for Runtime {

--- a/pallets/runtime/tests/Cargo.toml
+++ b/pallets/runtime/tests/Cargo.toml
@@ -81,7 +81,6 @@ pallet-election-provider-multi-phase = { workspace = true, default-features = fa
 pallet-grandpa = { workspace = true, default-features = false }
 pallet-im-online = { workspace = true, default-features = false }
 pallet-indices = { workspace = true, default-features = false }
-pallet-insecure-randomness-collective-flip = { workspace = true, default-features = false }
 pallet-mmr = { workspace = true, default-features = false }
 pallet-offences = { workspace = true, default-features = false }
 pallet-preimage = { workspace = true, default-features = false }
@@ -155,7 +154,6 @@ std = [
     "pallet-pips/std",
     "pallet-portfolio/std",
     "pallet-relayer/std",
-    "pallet-insecure-randomness-collective-flip/std",
     "pallet-scheduler/std",
     "pallet-session/std",
     "pallet-staking/std",

--- a/pallets/runtime/tests/src/corporate_actions_test.rs
+++ b/pallets/runtime/tests/src/corporate_actions_test.rs
@@ -85,7 +85,7 @@ fn test(logic: impl FnOnce(AssetId, [User; 3])) {
             let asset_id = create_and_issue_sample_asset(&alice);
 
             // Execute the test.
-            logic(asset_id, [alice, bob, charlie])
+            logic(asset_id, [alice, charlie, bob])
         });
 }
 

--- a/pallets/runtime/tests/src/group_test.rs
+++ b/pallets/runtime/tests/src/group_test.rs
@@ -325,10 +325,10 @@ fn disable_member_we() {
         None,
         None
     ));
-    assert_eq!(CommitteeGroup::get_members(), vec![charlie_id, alice_id]);
+    assert_eq!(CommitteeGroup::get_members(), vec![alice_id, charlie_id]);
     assert_eq!(
         CommitteeGroup::get_valid_members(),
-        vec![charlie_id, alice_id, bob_id]
+        vec![alice_id, charlie_id, bob_id]
     );
 
     // Revoke at

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -327,9 +327,6 @@ mod runtime {
     #[runtime::pallet_index(23)]
     pub type ImOnline = pallet_im_online::Pallet<Runtime>;
 
-    #[runtime::pallet_index(24)]
-    pub type RandomnessCollectiveFlip = pallet_insecure_randomness_collective_flip::Pallet<Runtime>;
-
     #[runtime::pallet_index(25)]
     pub type Sudo = pallet_sudo::Pallet<Runtime>;
 

--- a/pallets/runtime/tests/src/storage.rs
+++ b/pallets/runtime/tests/src/storage.rs
@@ -685,6 +685,7 @@ impl pallet_identity::Config for TestStorage {
     type InitialPOLYX = InitialPOLYX;
     type MaxGivenAuths = MaxGivenAuths;
     type MaxAuthRetries = MaxAuthRetries;
+    type Randomness = pallet_babe::RandomnessFromOneEpochAgo<TestStorage>;
 }
 
 impl example::Config for TestStorage {}

--- a/pallets/weights/src/pallet_contracts.rs
+++ b/pallets/weights/src/pallet_contracts.rs
@@ -590,13 +590,11 @@ impl pallet_contracts::WeightInfo for SubstrateWeight {
 			.saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 			.saturating_add(Weight::from_parts(0, 2553).saturating_mul(n.into()))
 	}
-	/// Storage: `RandomnessCollectiveFlip::RandomMaterial` (r:1 w:0)
-	/// Proof: `RandomnessCollectiveFlip::RandomMaterial` (`max_values`: Some(1), `max_size`: Some(2594), added: 3089, mode: `Measured`)
+	/// Storage: `Babe::Randomness` (r:1 w:0)
+	/// Storage: `Babe::EpochStart` (r:1 w:0)
+	/// TODO: Weights need re-benchmarking after switching from RandomnessCollectiveFlip to Babe.
 	fn seal_random() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `1485`
-		// Minimum execution time: 2_304_000 picoseconds.
+		// Conservative overestimate from old RandomnessCollectiveFlip benchmarks.
 		Weight::from_parts(2_359_000, 1485)
 			.saturating_add(DbWeight::get().reads(1_u64))
 	}


### PR DESCRIPTION
## changelog

### new features

- Replaced `pallet-insecure-randomness-collective-flip` with `pallet_babe::RandomnessFromOneEpochAgo`

### other

- Removed `RandomnessCollectiveFlip` pallet index
- Removed `pallet-insecure-randomness-collective-flip` dependency

### data migration

- Added migration to remove `RandomnessCollectiveFlip` pallet index
