### PR TITLE
Remove ticker DIDs from storage

### DIFF
--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -116,7 +116,7 @@ use polymesh_primitives::{
     traits::{CddAndFeeDetails, IdentityFnTrait},
     AssetPermissions, Authorization, AuthorizationData, AuthorizationType, Balance, CddId, Claim,
     ClaimType, CustomClaimTypeId, DidRecord, ExtrinsicPermissions, IdentityClaim, IdentityId,
-    KeyRecord, Permissions, PortfolioPermissions, Scope, SecondaryKey, Signatory, Ticker,
+    KeyRecord, Permissions, PortfolioPermissions, Scope, SecondaryKey, Signatory,
 };
 use polymesh_primitives::{SystematicIssuers, GC_DID};
 use scale_info::TypeInfo;
@@ -124,7 +124,7 @@ use sp_runtime::traits::{Dispatchable, IdentifyAccount, Member, Verify};
 use sp_std::prelude::*;
 use sp_std::vec::Vec;
 
-storage_migration_ver!(7);
+storage_migration_ver!(8);
 
 pub trait WeightInfo {
     fn create_child_identity() -> Weight;
@@ -320,11 +320,6 @@ pub mod pallet {
         ///
         /// (DID, claim)
         ClaimRevoked(IdentityId, IdentityClaim),
-
-        /// Asset's identity registered.
-        ///
-        /// (Asset DID, ticker)
-        AssetDidRegistered(IdentityId, Ticker),
 
         /// New authorization added.
         ///
@@ -560,7 +555,7 @@ pub mod pallet {
     impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
         fn build(&self) {
             MultiPurposeNonce::<T>::put(1);
-            StorageVersion::<T>::put(Version::new(7));
+            StorageVersion::<T>::put(Version::new(8));
 
             polymesh_primitives::SYSTEMATIC_ISSUERS
                 .iter()

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -334,25 +334,23 @@ macro_rules! misc_pallet_impls {
         impl frame_support::traits::OnRuntimeUpgrade for RemoveTickerDidRecords {
             fn on_runtime_upgrade() -> Weight {
                 use codec::Encode;
-                use sp_runtime::traits::Hash;
+
+                const TARGET_VERSION: pallet_identity::Version = pallet_identity::Version::new(8);
 
                 let current_version = pallet_identity::StorageVersion::<Runtime>::get();
-                if current_version >= pallet_identity::Version::new(8) {
+                if current_version >= TARGET_VERSION {
                     log::info!("identity::RemoveTickerDidRecords: Already at version >= 8, skipping.");
                     return <Runtime as frame_system::Config>::DbWeight::get().reads(1);
                 }
 
-                let tickers = pallet_asset::UniqueTickerRegistration::<Runtime>::iter_keys()
-                    .collect::<Vec<_>>();
-
                 const SECURITY_TOKEN_PREFIX: &[u8; 15] = b"SECURITY_TOKEN:";
 
                 let mut removed = 0u64;
-                for ticker in &tickers {
-                    let mut buf = SECURITY_TOKEN_PREFIX.encode();
-                    buf.append(&mut ticker.encode());
-                    let hash = sp_runtime::traits::BlakeTwo256::hash(&buf[..]);
-                    let did = polymesh_primitives::IdentityId::try_from(hash.as_ref())
+                let mut ticker_count = 0u64;
+                for ticker in pallet_asset::UniqueTickerRegistration::<Runtime>::iter_keys() {
+                    ticker_count += 1;
+                    let hash = (SECURITY_TOKEN_PREFIX, ticker).using_encoded(sp_io::hashing::blake2_256);
+                    let did = polymesh_primitives::IdentityId::try_from(&hash[..])
                         .expect("BlakeTwo256 output is 32 bytes = IdentityId size");
 
                     if pallet_identity::DidRecords::<Runtime>::contains_key(&did) {
@@ -361,9 +359,8 @@ macro_rules! misc_pallet_impls {
                     }
                 }
 
-                pallet_identity::StorageVersion::<Runtime>::put(pallet_identity::Version::new(8));
+                pallet_identity::StorageVersion::<Runtime>::put(TARGET_VERSION);
 
-                let ticker_count = tickers.len() as u64;
                 log::info!(
                     "identity::RemoveTickerDidRecords: Removed {} asset DidRecords from {} tickers. Storage version set to 8.",
                     removed,

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -108,6 +108,7 @@ macro_rules! misc_pallet_impls {
             /// The set code logic, just the default since we're not a parachain.
             type SingleBlockMigrations = (
                 UpgradeSessionKeys,
+                RemoveTickerDidRecords,
                 pallet_contracts::Migration<Runtime>,
                 pallet_grandpa::migrations::MigrateV4ToV5<Runtime>,
                 pallet_im_online::migration::v1::Migration<Runtime>,
@@ -325,6 +326,54 @@ macro_rules! misc_pallet_impls {
             fn on_runtime_upgrade() -> Weight {
                 Session::upgrade_keys::<OldSessionKeys, _>(transform_session_keys);
                 Perbill::from_percent(50) * polymesh_runtime_common::RuntimeBlockWeights::get().max_block
+            }
+        }
+
+        /// Removes `DidRecord` entries that were created for asset tickers.
+        pub struct RemoveTickerDidRecords;
+        impl frame_support::traits::OnRuntimeUpgrade for RemoveTickerDidRecords {
+            fn on_runtime_upgrade() -> Weight {
+                use codec::Encode;
+                use sp_runtime::traits::Hash;
+
+                let current_version = pallet_identity::StorageVersion::<Runtime>::get();
+                if current_version >= pallet_identity::Version::new(8) {
+                    log::info!("identity::RemoveTickerDidRecords: Already at version >= 8, skipping.");
+                    return <Runtime as frame_system::Config>::DbWeight::get().reads(1);
+                }
+
+                let tickers = pallet_asset::UniqueTickerRegistration::<Runtime>::iter_keys()
+                    .collect::<Vec<_>>();
+
+                const SECURITY_TOKEN_PREFIX: &[u8; 15] = b"SECURITY_TOKEN:";
+
+                let mut removed = 0u64;
+                for ticker in &tickers {
+                    let mut buf = SECURITY_TOKEN_PREFIX.encode();
+                    buf.append(&mut ticker.encode());
+                    let hash = sp_runtime::traits::BlakeTwo256::hash(&buf[..]);
+                    let did = polymesh_primitives::IdentityId::try_from(hash.as_ref())
+                        .expect("BlakeTwo256 output is 32 bytes = IdentityId size");
+
+                    if pallet_identity::DidRecords::<Runtime>::contains_key(&did) {
+                        pallet_identity::DidRecords::<Runtime>::remove(&did);
+                        removed += 1;
+                    }
+                }
+
+                pallet_identity::StorageVersion::<Runtime>::put(pallet_identity::Version::new(8));
+
+                let ticker_count = tickers.len() as u64;
+                log::info!(
+                    "identity::RemoveTickerDidRecords: Removed {} asset DidRecords from {} tickers. Storage version set to 8.",
+                    removed,
+                    ticker_count,
+                );
+
+                // Reads: 1 (version check) + ticker_count (iter_keys) + ticker_count (contains_key).
+                // Writes: 1 (version put) + removed (DidRecords removals).
+                <Runtime as frame_system::Config>::DbWeight::get()
+                    .reads_writes(1 + (2 * ticker_count), 1 + removed)
             }
         }
 

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -34,8 +34,6 @@ pub mod currency {
 pub mod did {
     /// prefix for user dids
     pub const USER: &[u8; 5] = b"USER:";
-    /// prefix for security token dids
-    pub const SECURITY_TOKEN: &[u8; 15] = b"SECURITY_TOKEN:";
 
     /// Governance Committee DID. It is used in systematic CDD claim for Governance Committee members.
     pub const GOVERNANCE_COMMITTEE_DID: &[u8; 32] = b"system:governance_committee\0\0\0\0\0";

--- a/primitives/src/identity.rs
+++ b/primitives/src/identity.rs
@@ -52,8 +52,6 @@ pub mod limits {
 /// Identity record.
 ///
 /// Used to check if an identity exists and lookup its primary key.
-///
-/// Asset Identities don't have a primary key.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[derive(Serialize, Deserialize)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -419,7 +419,7 @@ macro_rules! storage_migration_ver {
             const MAX: u8 = $ver;
 
             /// Build const version and do compile-time maximum version check.
-            const fn new(ver: u8) -> Self {
+            pub const fn new(ver: u8) -> Self {
                 Self(ver)
             }
 

--- a/scripts/cli/index.js
+++ b/scripts/cli/index.js
@@ -456,11 +456,9 @@ async function addClaimsBatchToDid(api, accounts, dids, n_claims, fast) {
     // Holds the batch of claims
     let claims = [];
 
-    const asset_did = reqImports.tickerToDid(reqImports.ticker);
-
     // Stores the value of each claim
     let claim_record = {target: dids[0],
-                        claim: { Exempted: asset_did },
+                        claim: { Exempted: dids[0] },
                         expiry: null};
 
     // This fills the claims array with claim_values up to n_claims amount

--- a/scripts/cli/src/util/init.ts
+++ b/scripts/cli/src/util/init.ts
@@ -230,18 +230,6 @@ export async function keyToIdentityIds(
   return <IdentityId>(0 as unknown);
 }
 
-// Returns the asset did
-export function tickerToDid(ticker: Ticker) {
-  let tickerString = String.fromCharCode.apply(ticker);
-  let tickerUintArray = Uint8Array.from(tickerString, (x) => x.charCodeAt(0));
-  return blake2AsHex(
-    u8aConcat(
-      stringToU8a("SECURITY_TOKEN:"),
-      u8aFixLength(tickerUintArray, 96, true)
-    )
-  );
-}
-
 export async function generateStashKeys(
   accounts: string[]
 ): Promise<KeyringPair[]> {

--- a/scripts/cli/util/init.mjs
+++ b/scripts/cli/util/init.mjs
@@ -322,16 +322,6 @@ async function issueTokenPerDid(api, accounts, ticker, amount, fundingRound) {
 
 }
 
-// Returns the asset did
-function tickerToDid(ticker) {
-  return blake2AsHex(
-    u8aConcat(
-      stringToU8a("SECURITY_TOKEN:"),
-      u8aFixLength(stringToU8a(ticker), 96, true)
-    )
-  );
-}
-
 // Creates claim compliance for an asset
 async function createClaimCompliance(api, accounts, dids, ticker) {
 
@@ -682,7 +672,6 @@ let reqImports = {
   receiverConditions1,
   createClaimCompliance,
   addClaimsToDids,
-  tickerToDid,
   sendTransaction,
   generateStashKeys,
   generateEntity,


### PR DESCRIPTION
## changelog

### modified events

- Removed `AssetDidRegistered` event

### other

- Removed `SECURITY_TOKEN` constant
- Removed `tickerToDid` helper from TypeScript CLI scripts (init.ts, init.mjs)

### data migration

- Added `RemoveTickerDidRecords` migration (identity storage version 7 → 8) that iterates `UniqueTickerRegistration` entries, derives the `SECURITY_TOKEN:<ticker>` DID for each ticker, and removes its `DidRecord`