### PR TITLE
Fix distroless healthcheck

### DIFF
--- a/.docker/Dockerfile.distroless
+++ b/.docker/Dockerfile.distroless
@@ -19,13 +19,9 @@ RUN apt update && \
     mkdir /var/lib/polymesh && \
     chown 4001:4001 /var/lib/polymesh
 
-FROM busybox:stable-uclibc as busybox
-
 FROM gcr.io/distroless/cc
 USER 4001:4001
 
-# Distroless doesn't have a shell, which is needed for the health check.
-COPY --from=busybox /bin/sh /bin/sh
 COPY --from=install /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 COPY --from=install --chown=4001:4001 /var/lib/polymesh /var/lib/polymesh
 COPY --chown=4002:4002 --from=gobuild      /opt/health-check/polymesh-health-check /usr/local/bin/check
@@ -40,4 +36,4 @@ HEALTHCHECK \
     --start-period=120s \
     --timeout=5s \
     --retries=6 \
-    CMD /usr/local/bin/check liveness
+    CMD [ "/usr/local/bin/check", "liveness" ]

--- a/.docker/Dockerfile.distroless
+++ b/.docker/Dockerfile.distroless
@@ -19,9 +19,13 @@ RUN apt update && \
     mkdir /var/lib/polymesh && \
     chown 4001:4001 /var/lib/polymesh
 
+FROM busybox:stable-uclibc as busybox
+
 FROM gcr.io/distroless/cc
 USER 4001:4001
 
+# Distroless doesn't have a shell, which is needed for the health check.
+COPY --from=busybox /bin/sh /bin/sh
 COPY --from=install /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 COPY --from=install --chown=4001:4001 /var/lib/polymesh /var/lib/polymesh
 COPY --chown=4002:4002 --from=gobuild      /opt/health-check/polymesh-health-check /usr/local/bin/check

--- a/.docker/arm64/Dockerfile.distroless
+++ b/.docker/arm64/Dockerfile.distroless
@@ -19,9 +19,13 @@ RUN apt update && \
     mkdir /var/lib/polymesh && \
     chown 4001:4001 /var/lib/polymesh
 
+FROM busybox:stable-uclibc as busybox
+
 FROM gcr.io/distroless/cc
 USER 4001:4001
 
+# Distroless doesn't have a shell, which is needed for the health check.
+COPY --from=busybox /bin/sh /bin/sh
 COPY --from=install /lib/aarch64-linux-gnu/libz.so.1 /lib/aarch64-linux-gnu/libz.so.1
 COPY --from=install --chown=4001:4001 /var/lib/polymesh /var/lib/polymesh
 COPY --chown=4002:4002 --from=gobuild      /opt/health-check/polymesh-health-check /usr/local/bin/check

--- a/.docker/arm64/Dockerfile.distroless
+++ b/.docker/arm64/Dockerfile.distroless
@@ -19,13 +19,9 @@ RUN apt update && \
     mkdir /var/lib/polymesh && \
     chown 4001:4001 /var/lib/polymesh
 
-FROM busybox:stable-uclibc as busybox
-
 FROM gcr.io/distroless/cc
 USER 4001:4001
 
-# Distroless doesn't have a shell, which is needed for the health check.
-COPY --from=busybox /bin/sh /bin/sh
 COPY --from=install /lib/aarch64-linux-gnu/libz.so.1 /lib/aarch64-linux-gnu/libz.so.1
 COPY --from=install --chown=4001:4001 /var/lib/polymesh /var/lib/polymesh
 COPY --chown=4002:4002 --from=gobuild      /opt/health-check/polymesh-health-check /usr/local/bin/check
@@ -40,4 +36,4 @@ HEALTHCHECK \
     --start-period=120s \
     --timeout=5s \
     --retries=6 \
-    CMD /usr/local/bin/check liveness
+    CMD [ "/usr/local/bin/check", "liveness" ]

--- a/.docker/src/health-check/health-check.go
+++ b/.docker/src/health-check/health-check.go
@@ -1,88 +1,87 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "github.com/AdamSLevy/jsonrpc2/v14"
-    "net/http"
-    "io/ioutil"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/AdamSLevy/jsonrpc2/v14"
 )
 
 type systemHealth struct {
-    IsSyncing       bool    `json:"isSyncing"`
-    Peers           float64 `json:"peers"`
-    ShouldHavePeers bool    `json:"shouldHavePeers"`
+	IsSyncing       bool    `json:"isSyncing"`
+	Peers           float64 `json:"peers"`
+	ShouldHavePeers bool    `json:"shouldHavePeers"`
 }
 
-
 func testJSONRPC(readinessCheck bool) {
-    var c jsonrpc2.Client
-    params := []float64{}
-    var r systemHealth
-    err := c.Request(nil, "http://localhost:9933", "system_health", params, &r)
-    if _, ok := err.(jsonrpc2.Error); ok {
-        fmt.Printf("Error checking jsonrpc port. %v\n", err)
-        os.Exit(1)
-    }
-    if err != nil {
-        fmt.Printf("Error checking jsonrpc port! %v\n", err)
-        os.Exit(1)
-    }
-    //fmt.Printf("Node syncing: %v\n", r.IsSyncing )
-    //fmt.Printf("Should have peers: %v\n", r.ShouldHavePeers )
-    //fmt.Printf("Number of peers: %v\n", r.Peers )
-    if r.IsSyncing && readinessCheck {
-        fmt.Printf("Node is syncing" )
-        os.Exit(1)
-    }
+	var c jsonrpc2.Client
+	params := []float64{}
+	var r systemHealth
+	err := c.Request(nil, "http://localhost:9944", "system_health", params, &r)
+	if _, ok := err.(jsonrpc2.Error); ok {
+		fmt.Printf("Error checking jsonrpc port. %v\n", err)
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Printf("Error checking jsonrpc port! %v\n", err)
+		os.Exit(1)
+	}
+	//fmt.Printf("Node syncing: %v\n", r.IsSyncing )
+	//fmt.Printf("Should have peers: %v\n", r.ShouldHavePeers )
+	//fmt.Printf("Number of peers: %v\n", r.Peers )
+	if r.IsSyncing && readinessCheck {
+		fmt.Printf("Node is syncing")
+		os.Exit(1)
+	}
 }
 
 func testPrometheus() {
-    resp, err := http.Get("http://localhost:9615/metrics")
-    if err != nil {
-        fmt.Printf( "Error checking prometheus exporter! %v\n", err )
-        os.Exit(1)
-    }
-    defer resp.Body.Close()
-    _, err2 := ioutil.ReadAll(resp.Body)
-    if err2 != nil {
-        fmt.Printf( "Error reading prometheus metrics! %v\n", err2 )
-        os.Exit(1)
-    }
-    if resp.StatusCode > 299 {
-        fmt.Printf("Response status is %v", resp.StatusCode )
-        os.Exit(1)
-    }
+	resp, err := http.Get("http://localhost:9615/metrics")
+	if err != nil {
+		fmt.Printf("Error checking prometheus exporter! %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	_, err2 := ioutil.ReadAll(resp.Body)
+	if err2 != nil {
+		fmt.Printf("Error reading prometheus metrics! %v\n", err2)
+		os.Exit(1)
+	}
+	if resp.StatusCode > 299 {
+		fmt.Printf("Response status is %v", resp.StatusCode)
+		os.Exit(1)
+	}
 }
 
 func printHelp(progname string) {
-    fmt.Printf(`Use:
+	fmt.Printf(`Use:
     %v [command]
     Commands:
     * help: print this help
-    * liveness: return 0 if localhost polymesh has both the RPC (9933) and prometheus (9615) ports open and responsive, 1 otherwise
+    * liveness: return 0 if localhost polymesh has both the WS/RPC (9944) and prometheus (9615) ports open and responsive, 1 otherwise
     * readiness: return 0 if liveness check passes and the node is not syncing, 1 otherwise
     `, progname)
 }
 
 func main() {
-    args := os.Args
-    if len(args) != 2 {
-        printHelp(args[0])
-        os.Exit(1)
-    }
-    if args[1] == "liveness" {
-        testJSONRPC(false)
-    } else if args[1] == "readiness" {
-        testJSONRPC(true)
-    } else if args[1] == "help" {
-        printHelp(args[0])
-        os.Exit(0)
-    } else {
-        printHelp(args[0])
-        os.Exit(1)
-    }
+	args := os.Args
+	if len(args) != 2 {
+		printHelp(args[0])
+		os.Exit(1)
+	}
+	if args[1] == "liveness" {
+		testJSONRPC(false)
+	} else if args[1] == "readiness" {
+		testJSONRPC(true)
+	} else if args[1] == "help" {
+		printHelp(args[0])
+		os.Exit(0)
+	} else {
+		printHelp(args[0])
+		os.Exit(1)
+	}
 
-    testPrometheus()
+	testPrometheus()
 }
-

--- a/.docker/src/rotate-keys/rotate-keys.go
+++ b/.docker/src/rotate-keys/rotate-keys.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "github.com/AdamSLevy/jsonrpc2/v14"
+	"fmt"
+	"os"
+
+	"github.com/AdamSLevy/jsonrpc2/v14"
 )
 
 func main() {
-    var c jsonrpc2.Client
-    params := []float64{}
-    var r string
-    err := c.Request(nil, "http://localhost:9933", "author_rotateKeys", params, &r)
-    if _, ok := err.(jsonrpc2.Error); ok {
-        fmt.Printf("Error checking jsonrpc port. %v\n", err)
-        os.Exit(1)
-    }
-    if err != nil {
-        fmt.Printf("Error checking jsonrpc port! %v\n", err)
-        os.Exit(1)
-    }
-    fmt.Println(r)
+	var c jsonrpc2.Client
+	params := []float64{}
+	var r string
+	err := c.Request(nil, "http://localhost:9944", "author_rotateKeys", params, &r)
+	if _, ok := err.(jsonrpc2.Error); ok {
+		fmt.Printf("Error checking jsonrpc port. %v\n", err)
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Printf("Error checking jsonrpc port! %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(r)
 }
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8495,7 +8495,6 @@ dependencies = [
  "pallet-staking-runtime-api",
  "pallet-statistics",
  "pallet-sto",
- "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",

--- a/integration/tests/contract_permissions.rs
+++ b/integration/tests/contract_permissions.rs
@@ -49,7 +49,7 @@ async fn contract_as_secondary_key_change_identity() -> Result<()> {
         .polymesh_contracts()
         .instantiate_with_code_perms(
             0,
-            Weight::from_parts(15_000_000_000, 0),
+            Weight::from_parts(1_000_000_000, 300_000),
             None,
             call_runtime_bytes.to_vec(),
             vec![0x9b, 0xae, 0x9d, 0x5e], // Selector for `new` constructor.
@@ -134,7 +134,7 @@ async fn contract_as_secondary_key_change_identity() -> Result<()> {
         .call(
             contract.into(),
             0,
-            Weight::from_parts(15_000_000_000, 0),
+            Weight::from_parts(15_000_000_000, 300_000),
             None,
             encoded_call,
         )?

--- a/pallets/runtime/mainnet/Cargo.toml
+++ b/pallets/runtime/mainnet/Cargo.toml
@@ -148,6 +148,7 @@ std = [
     "pallet-im-online/std",
     "pallet-indices/std",
     "pallet-multisig/std",
+    "pallet-nft/std",
     "pallet-offences/std",
     "pallet-permissions/std",
     "pallet-preimage/std",

--- a/pallets/runtime/testnet/Cargo.toml
+++ b/pallets/runtime/testnet/Cargo.toml
@@ -9,15 +9,14 @@ build = "build.rs"
 
 [dependencies]
 # Common
-polymesh-runtime-common = { workspace = true, default-features = false }
 polymesh-primitives = { workspace = true, default-features = false }
+polymesh-runtime-common = { workspace = true, default-features = false }
 polymesh-weights = { workspace = true, default-features = false }
 
 # Our pallets
 pallet-asset = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, default-features = false }
 pallet-base = { workspace = true, default-features = false }
-pallet-sto = { workspace = true, default-features = false }
 pallet-committee = { workspace = true, default-features = false }
 pallet-compliance-manager = { workspace = true, default-features = false }
 pallet-corporate-actions = { workspace = true, default-features = false }
@@ -34,10 +33,10 @@ pallet-relayer = { workspace = true, default-features = false }
 pallet-settlement = { workspace = true, default-features = false }
 pallet-validators = { workspace = true, default-features = false }
 pallet-statistics = { workspace = true, default-features = false }
+pallet-sto = { workspace = true, default-features = false }
 pallet-transaction-payment = { workspace = true, default-features = false }
 pallet-treasury = { workspace = true, default-features = false }
 pallet-utility = { workspace = true, default-features = false }
-pallet-sudo = { workspace = true, default-features = false }
 polymesh-contracts = { workspace = true, default-features = false }
 polymesh-transaction-payment = { workspace = true, default-features = false }
 
@@ -136,7 +135,6 @@ std = [
     "pallet-beefy/std",
     "pallet-beefy-mmr/std",
     "pallet-mmr/std",
-    "pallet-sto/std",
     "pallet-committee/std",
     "pallet-compliance-manager/std",
     "pallet-contracts/std",
@@ -166,11 +164,13 @@ std = [
     "pallet-staking/std",
     "pallet-validators/std",
     "pallet-statistics/std",
+    "pallet-sto/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",
     "polymesh-transaction-payment/std",
     "pallet-treasury/std",
     "pallet-utility/std",
+    "polymesh-contracts/std",
     "polymesh-primitives/std",
     "polymesh-runtime-common/std",
     "polymesh-weights/std",
@@ -191,9 +191,9 @@ std = [
     "sp-std/std",
     "sp-transaction-pool/std",
     "sp-version/std",
-    "polymesh-contracts/std",
     "sp-genesis-builder/std",
 ]
+
 runtime-benchmarks = [
     "frame-election-provider-support/runtime-benchmarks",
     "frame-support/runtime-benchmarks",


### PR DESCRIPTION
## changelog

### other

- Fix docker HEALTHCHECK in our Distroless image.
- Update RPC port to 9944 in health-check and rotate-keys tools.
- Fix deterministic build of Testnet runtime.
- Fix contracts gas limit in Rust integration tests.

