### PR TITLE
Enforce commission cap and permissions for both new and existing validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "hash-db",
  "log",
@@ -920,7 +920,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2928,7 +2928,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2961,7 +2961,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.13.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3213,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.4.0",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5666,7 +5666,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "log",
@@ -5685,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6339,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6367,7 +6367,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6425,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "46.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "46.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6537,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6766,7 +6766,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6785,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6819,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7040,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7112,7 +7112,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "30.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7227,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7567,6 +7567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "picosimd"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8cf1ae70818c6476eb2da0ac8f3f55ecdea41a7aa16824ea6efc4a31cccf41"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7638,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7649,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bs58",
  "futures",
@@ -7666,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -7691,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -7715,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -7743,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -7763,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -7780,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -7809,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7821,7 +7827,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -7869,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7904,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7913,12 +7919,13 @@ dependencies = [
 
 [[package]]
 name = "polkavm"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa028f713d0613f0f08b8b3367402cb859218854f6b96fcbe39a501862894d6f"
+checksum = "4323d016144b2852da47cee55ca5fc33dfe7517be1f52395759f247ecc5695f6"
 dependencies = [
  "libc",
  "log",
+ "picosimd",
  "polkavm-assembler",
  "polkavm-common",
  "polkavm-linux-raw",
@@ -7926,37 +7933,38 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4859a29e1f4ad64610c4bc2bfc40bb9a535068a034933a5b56b5e7a0febf105a"
+checksum = "b3a873fa7ace058d6507debf5fccb1d06bd3279f5b35dbaf70dc7fe94a6c415c"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-common"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
+checksum = "ed1b408db93d4f49f5c651a7844682b9d7a561827b4dc6202c10356076c055c9"
 dependencies = [
  "log",
+ "picosimd",
  "polkavm-assembler",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
+checksum = "acb4463fb0b9dbfafdc1d1a1183df4bf7afa3350d124f29d5700c6bee54556b5"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069dc7995cde6e612b868a02ce48b54397c6d2582bd1b97b63aabbe962cd779"
+checksum = "993ff45b972e09babe68adce7062c3c38a84b9f50f07b7caf393a023eaa6c74a"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
@@ -7966,9 +7974,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
+checksum = "0a4f5352e13c1ca5f0e4d7b4a804fbb85b0e02c45cae435d101fe71081bc8ed8"
 dependencies = [
  "polkavm-derive-impl",
  "syn 2.0.111",
@@ -7976,9 +7984,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb896023e5bd89bba40311797d8d42490fa4a1fd5256c74820753c5722d1e67"
+checksum = "6739125c4f8f44b4282b6531d765d599f20514e9b608737c6c3544594d08f995"
 dependencies = [
  "dirs",
  "gimli 0.31.1",
@@ -7992,9 +8000,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28919f542476f4158cc71e6c072b1051f38f4b514253594ac3ad80e3c0211fc8"
+checksum = "604b23cdb201979304449f53d21bfd5fb1724c03e3ea889067c9a3bf7ae33862"
 
 [[package]]
 name = "polling"
@@ -9792,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "sp-core",
@@ -9803,7 +9811,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -9835,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "log",
@@ -9857,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9872,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -9898,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -9909,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "bip39",
@@ -9951,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "fnv",
  "futures",
@@ -9977,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10005,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -10028,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10065,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10087,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "34.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10121,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "34.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10141,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10154,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -10198,7 +10206,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.40.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10218,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -10241,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -10264,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10277,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "polkavm",
@@ -10288,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "anyhow",
  "log",
@@ -10304,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "console",
  "futures",
@@ -10320,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -10334,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -10362,7 +10370,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10411,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10421,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -10440,7 +10448,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10461,7 +10469,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10496,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10515,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bs58",
  "bytes",
@@ -10536,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bytes",
  "fnv",
@@ -10570,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10579,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10611,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10631,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -10655,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10688,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -10703,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "directories",
@@ -10767,7 +10775,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10778,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "clap",
  "fs4",
@@ -10791,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.55.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10810,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -10830,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "chrono",
  "futures",
@@ -10849,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "chrono",
  "console",
@@ -10877,7 +10885,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -10888,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -10920,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -10938,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -11692,7 +11700,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "hash-db",
@@ -11714,7 +11722,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -11728,7 +11736,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11740,7 +11748,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -11754,7 +11762,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11766,7 +11774,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -11776,7 +11784,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11795,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "futures",
@@ -11809,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11825,7 +11833,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11843,7 +11851,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11863,7 +11871,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11880,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11891,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -11938,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11951,7 +11959,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -11961,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -11971,7 +11979,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11981,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11991,7 +11999,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12003,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12016,7 +12024,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bytes",
  "docify",
@@ -12042,7 +12050,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12052,7 +12060,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -12063,7 +12071,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -12072,7 +12080,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -12082,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12093,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12110,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12123,7 +12131,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12133,7 +12141,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "backtrace",
  "regex",
@@ -12142,7 +12150,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12152,7 +12160,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -12183,7 +12191,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12201,7 +12209,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "Inflector",
  "expander",
@@ -12214,7 +12222,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12228,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12241,7 +12249,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "hash-db",
  "log",
@@ -12261,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -12285,12 +12293,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12302,7 +12310,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12314,7 +12322,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -12326,7 +12334,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12335,7 +12343,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12349,7 +12357,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -12374,7 +12382,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12391,7 +12399,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -12403,7 +12411,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12415,7 +12423,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -12481,7 +12489,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -12502,7 +12510,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "environmental",
  "frame-support",
@@ -12526,7 +12534,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -12638,7 +12646,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -12650,12 +12658,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -12675,7 +12683,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -12689,12 +12697,12 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -12735,9 +12743,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74791ddeaaa6de42e7cc8a715c83eb73303f513f90af701fd07eb2caad92ed84"
+checksum = "f8c6dc0f90e23c521465b8f7e026af04a48cc6f00c51d88a8d313d33096149de"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -12834,9 +12842,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69516e8ff0e9340a0f21b8398da7f997571af4734ee81deada5150a2668c8443"
+checksum = "c269228a2e5de4c0c61ed872b701967ee761df0f167d5b91ecec1185bca65793"
 dependencies = [
  "darling 0.20.11",
  "parity-scale-codec",
@@ -13464,7 +13472,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13475,7 +13483,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -15025,7 +15033,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#9758872d647e8038d101e44b6b92bf524329912f"
+source = "git+https://github.com/PolymeshAssociation/polkadot-sdk?branch=polymesh-v8-stable2512#b6946c70dd092816cefe8a12b0b5af78a076f916"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/pallets/runtime/tests/src/staking_extra_tests.rs
+++ b/pallets/runtime/tests/src/staking_extra_tests.rs
@@ -1,5 +1,6 @@
-use frame_support::assert_ok;
+use frame_support::{assert_noop, assert_ok};
 use sp_keyring::Sr25519Keyring;
+use sp_runtime::Perbill;
 
 use polymesh_primitives::{AuthorizationData, Permissions};
 
@@ -77,4 +78,50 @@ fn updating_controller() {
                 )
             );
         });
+}
+
+#[test]
+fn existing_validator_cannot_bypass_commission_cap() {
+    ExtBuilder::default().build().execute_with(|| {
+        let cap = Perbill::from_percent(20);
+        pallet_validators::ValidatorCommissionCap::<TestStorage>::put(cap);
+
+        let alice: User = User::new(Sr25519Keyring::Alice);
+        assert_ok!(
+            pallet_validators::Pallet::<TestStorage>::add_permissioned_validator(
+                Origin::root(),
+                alice.did,
+                None
+            )
+        );
+        assert_ok!(pallet_staking::Pallet::<TestStorage>::bond(
+            alice.origin(),
+            10_000_000,
+            pallet_staking::RewardDestination::Account(alice.acc())
+        ));
+
+        let prefs_at_cap = pallet_staking::ValidatorPrefs {
+            commission: cap,
+            blocked: false,
+        };
+        let prefs_over_cap = pallet_staking::ValidatorPrefs {
+            commission: Perbill::from_percent(100),
+            blocked: false,
+        };
+
+        // Register at the cap — succeeds.
+        assert_ok!(pallet_staking::Pallet::<TestStorage>::validate(
+            Origin::signed(alice.acc()),
+            prefs_at_cap,
+        ));
+
+        // Already-registered validator tries to exceed cap — must be rejected.
+        assert_noop!(
+            pallet_staking::Pallet::<TestStorage>::validate(
+                Origin::signed(alice.acc()),
+                prefs_over_cap,
+            ),
+            pallet_validators::Error::<TestStorage>::CommissionTooHigh
+        );
+    });
 }

--- a/pallets/validators/src/permissioned.rs
+++ b/pallets/validators/src/permissioned.rs
@@ -106,19 +106,23 @@ impl<T: Config> PermissionedStaking<T> for Pallet<T> {
             Error::<T>::CommissionTooHigh
         );
 
-        let stash_did = pallet_identity::Pallet::<T>::get_identity(stash)
-            .ok_or(Error::<T>::StashIdentityDoesNotExist)?;
-        let mut stash_did_prefs = PermissionedIdentity::<T>::get(stash_did)
-            .ok_or(Error::<T>::StashIdentityNotPermissioned)?;
+        // Only increment running_count and ref count for new validators.
+        // Existing validators are already counted.
+        if !pallet_staking::Validators::<T>::contains_key(stash) {
+            let stash_did = pallet_identity::Pallet::<T>::get_identity(stash)
+                .ok_or(Error::<T>::StashIdentityDoesNotExist)?;
+            let mut stash_did_prefs = PermissionedIdentity::<T>::get(stash_did)
+                .ok_or(Error::<T>::StashIdentityNotPermissioned)?;
 
-        // Ensure the identity doesn't run more validators than the intended count
-        ensure!(
-            stash_did_prefs.running_count < stash_did_prefs.intended_count,
-            StakingError::<T>::TooManyValidators
-        );
-        stash_did_prefs.running_count += 1;
-        pallet_identity::Pallet::<T>::add_account_key_ref_count(&stash);
-        PermissionedIdentity::<T>::insert(stash_did, stash_did_prefs);
+            // Ensure the identity doesn't run more validators than the intended count
+            ensure!(
+                stash_did_prefs.running_count < stash_did_prefs.intended_count,
+                StakingError::<T>::TooManyValidators
+            );
+            stash_did_prefs.running_count += 1;
+            pallet_identity::Pallet::<T>::add_account_key_ref_count(&stash);
+            PermissionedIdentity::<T>::insert(stash_did, stash_did_prefs);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## changelog

### other

- adjusted `on_validate` to only increment counts for new validators, because the validation is now used for both new and existing validators
- bumped polkadot-sdk dependency to apply related fix https://github.com/PolymeshAssociation/polkadot-sdk/pull/7
