### PR TITLE
Update `ExistentialDeposit` and `GasScale` for EVM testing

### DIFF
--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -620,7 +620,7 @@ macro_rules! misc_pallet_impls {
             type FeeInfo = pallet_revive::evm::fees::Info<Address, polymesh_primitives::Signature, EthExtraImpl>;
             type MaxEthExtrinsicWeight = polymesh_runtime_common::MaxEthExtrinsicWeight;
             type DebugEnabled = frame_support::traits::ConstBool<false>;
-            type GasScale = frame_support::traits::ConstU32<1>;
+            type GasScale = frame_support::traits::ConstU32<100>;
             type OnBurn = ();
         }
 

--- a/pallets/runtime/develop/src/runtime.rs
+++ b/pallets/runtime/develop/src/runtime.rs
@@ -85,7 +85,7 @@ parameter_types! {
     pub const IndexDeposit: Balance = DOLLARS;
 
     // Balances:
-    pub const ExistentialDeposit: Balance = 0u128;
+    pub const ExistentialDeposit: Balance = 1u128;
     pub const BenchmarkEd: Balance = 1;
     pub const MaxLocks: u32 = 50;
     pub const MaxReserves: u32 = 50;


### PR DESCRIPTION
## changelog

### other

- Set `ExistentialDeposit` to `1` for devnet
- Set `GasScale` to `100` for more accurate gas prices