### PR TITLE
Simplify Same DID transfers

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -2302,9 +2302,7 @@ impl<T: AssetConfig> Pallet<T> {
         let destination =
             Self::ensure_asset_and_holding_permissions(origin, asset_id, destination_kind, false)?;
 
-        let sender_did = pallet_identity::Pallet::<T>::asset_holder_did(&source)?;
         let holder_did = pallet_identity::Pallet::<T>::asset_holder_did(&destination)?;
-        ensure!(sender_did != holder_did, Error::<T>::SenderSameAsReceiver);
 
         Self::validate_asset_transfer(
             asset_id,
@@ -3228,6 +3226,8 @@ impl<T: AssetConfig> Pallet<T> {
         let sender_did = pallet_identity::Pallet::<T>::asset_holder_did(&sender)?;
         let receiver_did = pallet_identity::Pallet::<T>::asset_holder_did(&receiver)?;
 
+        ensure!(sender_did != receiver_did, Error::<T>::SenderSameAsReceiver);
+
         ensure!(
             BalanceOf::<T>::get(asset_id, &sender_did) >= transfer_value,
             Error::<T>::InsufficientBalance
@@ -3653,7 +3653,7 @@ impl<T: AssetConfig> Pallet<T> {
 
     /// If the asset is granular (see: [`Pallet::ensure_asset_granular`]) and the holder has at least
     /// `value` balance that is not locked, returns what would be the new balance of `holder` after a transfer of `value`.
-    fn ensure_sufficient_balance(
+    pub fn ensure_sufficient_balance(
         holder: &AssetHolder,
         asset_id: &AssetId,
         value: Balance,

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -713,7 +713,7 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Returns `Ok` if `sender` has all nfts and they are not locked. Otherwise, returns an `Err`.
-    fn ensure_nft_ownership(sender: &AssetHolder, nfts: &NFTs) -> DispatchResult {
+    pub fn ensure_nft_ownership(sender: &AssetHolder, nfts: &NFTs) -> DispatchResult {
         for nft_id in nfts.ids() {
             ensure!(
                 Self::is_holder_of_nft(nfts.asset_id(), nft_id, sender),
@@ -763,11 +763,20 @@ impl<T: Config> Pallet<T> {
             *balance = balance.saturating_add(transferred_amount)
         });
 
+        Self::transfer_holders_nfts(sender, receiver, nfts)?;
+
+        Ok(())
+    }
+
+    pub fn transfer_holders_nfts(
+        sender: &AssetHolder,
+        receiver: AssetHolder,
+        nfts: &NFTs,
+    ) -> DispatchResult {
         for nft_id in nfts.ids() {
             Self::remove_nft_from_asset_holder(nfts.asset_id(), nft_id, sender)?;
             Self::add_nft_holding(nfts.asset_id().clone(), *nft_id, receiver.clone())?;
         }
-
         Ok(())
     }
 

--- a/pallets/runtime/tests/src/settlement_pallet/transfer_funds.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/transfer_funds.rs
@@ -1,12 +1,10 @@
 use frame_support::{assert_noop, assert_ok};
 use sp_keyring::Sr25519Keyring;
 
-use pallet_asset::Allowances;
+use pallet_asset::{Allowances, BalanceOf};
 use polymesh_primitives::asset::{AssetHolder, AssetHolderKind, AssetType, NonFungibleType};
 use polymesh_primitives::nft::{NFTId, NFTOwnerStatus};
-use polymesh_primitives::{
-    Balance, Fund, FundDescription, HoldingsUpdateReason, NFTs, PortfolioId,
-};
+use polymesh_primitives::{Balance, Fund, FundDescription, NFTs, PortfolioId};
 
 use crate::asset_pallet::setup::ISSUE_AMOUNT;
 use crate::storage::User;
@@ -72,17 +70,17 @@ fn same_identity_transfer_succeeds() {
         );
         assert_eq!(Asset::get_holders_balance(&to, &asset_id), 100);
 
-        // AssetBalanceUpdated emitted with instruction_id: None (direct transfer).
-        let events = frame_system::Pallet::<TestStorage>::events();
-        assert!(events.iter().any(|record| {
-            matches!(
-                &record.event,
-                crate::storage::EventTest::Asset(pallet_asset::Event::AssetBalanceUpdated(
-                    _did, a_id, amount, Some(src), Some(dst),
-                    HoldingsUpdateReason::Transferred { instruction_id: None, .. }
-                )) if *a_id == asset_id && *amount == 100 && *src == from && *dst == to
-            )
-        }));
+        let mut events = frame_system::Pallet::<TestStorage>::events();
+
+        assert_eq!(
+            events.pop().unwrap().event,
+            crate::storage::RuntimeEvent::Settlement(pallet_settlement::Event::FundsTransferred(
+                alice.did,
+                from,
+                to,
+                fungible_fund(asset_id, 100)
+            ))
+        );
     });
 }
 
@@ -157,6 +155,10 @@ fn spender_same_identity_uses_direct_transfer() {
             ISSUE_AMOUNT - 100
         );
         assert_eq!(Asset::get_holders_balance(&to, &asset_id), 100);
+        assert_eq!(
+            BalanceOf::<TestStorage>::get(&asset_id, &alice.did),
+            ISSUE_AMOUNT
+        );
     });
 }
 
@@ -321,32 +323,6 @@ fn spender_nft_rejected() {
         assert_noop!(
             Settlement::transfer_funds(bob.origin(), from, to, nft_fund),
             SettlementError::AllowancesNotSupportedForNFTs
-        );
-    });
-}
-
-#[test]
-fn spender_atomicity_failed_transfer_restores_allowance() {
-    ExtBuilder::default().build().execute_with(|| {
-        let alice = User::new(Sr25519Keyring::Alice);
-        let bob = User::new(Sr25519Keyring::Bob);
-        let asset_id = create_and_issue_to_account(&alice);
-
-        assert_ok!(Asset::approve(alice.origin(), asset_id, bob.acc(), 500));
-        assert_ok!(Asset::freeze(alice.origin(), asset_id));
-
-        let from = Some(AssetHolder::Account(alice.acc()));
-        let to = AssetHolder::Portfolio(PortfolioId::default_portfolio(alice.did));
-
-        assert_noop!(
-            Settlement::transfer_funds(bob.origin(), from, to, fungible_fund(asset_id, 100)),
-            AssetError::InvalidTransferFrozenAsset
-        );
-
-        // Allowance unchanged — extrinsic rollback reverts the decrement.
-        assert_eq!(
-            Allowances::<TestStorage>::get((&alice.acc(), &bob.acc(), asset_id)),
-            500
         );
     });
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -192,6 +192,14 @@ pub mod pallet {
         /// - `IdentityId`: The [`IdentityId`] of the mediator.
         /// - `InstructionId`: The [`InstructionId`] of the instruction.
         InstructionUnlocked(IdentityId, InstructionId),
+        /// Funds have been transferred
+        ///
+        /// Parameters:
+        /// - `IdentityId`: The [`IdentityId`] of the caller.
+        /// - `AssetHolder`: The source [`AssetHolder`] of the transfer.
+        /// - `AssetHolder`: The destination [`AssetHolder`] of the transfer.
+        /// - `Fund`: The [`Fund`] being transferred.
+        FundsTransferred(IdentityId, AssetHolder, AssetHolder, Fund),
     }
 
     pub trait WeightInfo {
@@ -1612,28 +1620,27 @@ impl<T: Config> Pallet<T> {
             )?;
             match fund.description {
                 FundDescription::Fungible { asset_id, amount } => {
-                    Asset::<T>::base_transfer(
-                        resolved_from,
-                        to,
+                    ensure!(amount > 0, Error::<T>::ZeroAmount);
+                    Asset::<T>::ensure_sufficient_balance(&resolved_from, &asset_id, amount)?;
+                    Asset::<T>::transfer_holders_balance(
+                        resolved_from.clone(),
+                        to.clone(),
                         asset_id,
                         amount,
-                        None,
-                        fund.memo,
-                        origin_did,
-                        weight_meter,
                     )?;
                 }
-                FundDescription::NonFungible(nfts) => {
-                    Nft::<T>::simplified_nft_transfer(
-                        resolved_from,
-                        to,
-                        nfts,
-                        None,
-                        fund.memo,
-                        origin_did,
-                    )?;
+                FundDescription::NonFungible(ref nfts) => {
+                    ensure!(nfts.len() > 0, Error::<T>::ZeroAmount);
+                    Nft::<T>::ensure_nft_ownership(&resolved_from, nfts)?;
+                    Nft::<T>::transfer_holders_nfts(&resolved_from, to.clone(), nfts)?;
                 }
             }
+            Self::deposit_event(Event::FundsTransferred(
+                origin_did,
+                resolved_from,
+                to,
+                fund.clone(),
+            ));
             None
         } else {
             // Cross-identity: authorize and create settlement instruction.

--- a/primitives/src/portfolio.rs
+++ b/primitives/src/portfolio.rs
@@ -29,6 +29,13 @@ pub struct Fund {
     pub memo: Option<Memo>,
 }
 
+impl Fund {
+    /// Creates a new [`Fund`] with the given description and memo.
+    pub fn new(description: FundDescription, memo: Option<Memo>) -> Self {
+        Self { description, memo }
+    }
+}
+
 /// Defines the types of tokens that can be moved.
 #[derive(Decode, DecodeWithMemTracking, Encode, Eq, PartialEq, TypeInfo)]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## changelog
### other
 - Skip compliance for same DID transfers; 
 - Adds `SenderSameAsReceiver` check to `validate_asset_transfer`;
 - Adds ` FundsTransferred`event;
