### PR TITLE
Update rotate keys functionality to use `author_rotateKeysWithOwner`

### DIFF
--- a/.docker/Dockerfile.debian
+++ b/.docker/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG golangbase=1.15
+ARG golangbase=1.24
 FROM golang:${golangbase} as gobuild
 
 ADD .docker/src/health-check/ /opt/health-check/

--- a/.docker/Dockerfile.distroless
+++ b/.docker/Dockerfile.distroless
@@ -1,4 +1,4 @@
-ARG golangbase=1.15
+ARG golangbase=1.24
 FROM golang:${golangbase} as gobuild
 
 ADD .docker/src/health-check/ /opt/health-check/

--- a/.docker/arm64/Dockerfile.debian
+++ b/.docker/arm64/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG golangbase=1.15
+ARG golangbase=1.24
 FROM golang:${golangbase} as gobuild
 
 ADD .docker/src/health-check/ /opt/health-check/

--- a/.docker/arm64/Dockerfile.distroless
+++ b/.docker/arm64/Dockerfile.distroless
@@ -1,4 +1,4 @@
-ARG golangbase=1.15
+ARG golangbase=1.24
 FROM golang:${golangbase} as gobuild
 
 ADD .docker/src/health-check/ /opt/health-check/

--- a/.docker/src/health-check/go.mod
+++ b/.docker/src/health-check/go.mod
@@ -1,6 +1,5 @@
 module polymesh-health-check
 
-go 1.13
+go 1.18
 
-require github.com/AdamSLevy/jsonrpc2/v14 v14.0.0
-
+require github.com/AdamSLevy/jsonrpc2/v14 v14.1.0

--- a/.docker/src/health-check/go.sum
+++ b/.docker/src/health-check/go.sum
@@ -1,11 +1,12 @@
-github.com/AdamSLevy/jsonrpc2 v2.0.0+incompatible h1:ut4YIGFeO2Mzyj7pNEmcHBAm/88qCDmZMyUn6EeuXI4=
-github.com/AdamSLevy/jsonrpc2 v2.0.0+incompatible/go.mod h1:6enYNa3tk//n6m8F7zXGhRbtTqpSeysaUcwZbLIHGYQ=
-github.com/AdamSLevy/jsonrpc2/v14 v14.0.0 h1:ofSXSSa9Opft4KtEcIEshKbI2CAynwtKNZj2ASFDucc=
-github.com/AdamSLevy/jsonrpc2/v14 v14.0.0/go.mod h1:ZakZtbCXxCz82NJvq7MoREtiQesnDfrtF6RFUGzQfLo=
+github.com/AdamSLevy/jsonrpc2/v14 v14.1.0 h1:Dy3M9aegiI7d7PF1LUdjbVigJReo+QOceYsMyFh9qoE=
+github.com/AdamSLevy/jsonrpc2/v14 v14.1.0/go.mod h1:ZakZtbCXxCz82NJvq7MoREtiQesnDfrtF6RFUGzQfLo=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-

--- a/.docker/src/health-check/health-check.go
+++ b/.docker/src/health-check/health-check.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -44,7 +44,7 @@ func testPrometheus() {
 		os.Exit(1)
 	}
 	defer resp.Body.Close()
-	_, err2 := ioutil.ReadAll(resp.Body)
+	_, err2 := io.ReadAll(resp.Body)
 	if err2 != nil {
 		fmt.Printf("Error reading prometheus metrics! %v\n", err2)
 		os.Exit(1)

--- a/.docker/src/rotate-keys/go.mod
+++ b/.docker/src/rotate-keys/go.mod
@@ -1,6 +1,5 @@
 module polymesh-rotate-keys
 
-go 1.13
+go 1.18
 
-require github.com/AdamSLevy/jsonrpc2/v14 v14.0.0
-
+require github.com/AdamSLevy/jsonrpc2/v14 v14.1.0

--- a/.docker/src/rotate-keys/go.sum
+++ b/.docker/src/rotate-keys/go.sum
@@ -1,5 +1,5 @@
-github.com/AdamSLevy/jsonrpc2/v14 v14.0.0 h1:ofSXSSa9Opft4KtEcIEshKbI2CAynwtKNZj2ASFDucc=
-github.com/AdamSLevy/jsonrpc2/v14 v14.0.0/go.mod h1:ZakZtbCXxCz82NJvq7MoREtiQesnDfrtF6RFUGzQfLo=
+github.com/AdamSLevy/jsonrpc2/v14 v14.1.0 h1:Dy3M9aegiI7d7PF1LUdjbVigJReo+QOceYsMyFh9qoE=
+github.com/AdamSLevy/jsonrpc2/v14 v14.1.0/go.mod h1:ZakZtbCXxCz82NJvq7MoREtiQesnDfrtF6RFUGzQfLo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -7,7 +7,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/.docker/src/rotate-keys/rotate-keys.go
+++ b/.docker/src/rotate-keys/rotate-keys.go
@@ -1,24 +1,41 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/AdamSLevy/jsonrpc2/v14"
 )
 
+type RotateKeysResult struct {
+	Keys  string `json:"keys"`
+	Proof string `json:"proof"`
+}
+
 func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: rotate-keys <owner-hex>")
+		os.Exit(1)
+	}
+	owner := os.Args[1]
+
 	var c jsonrpc2.Client
-	params := []float64{}
-	var r string
-	err := c.Request(nil, "http://localhost:9944", "author_rotateKeys", params, &r)
+	params := []string{owner}
+	var r RotateKeysResult
+	err := c.Request(nil, "http://localhost:9944", "author_rotateKeysWithOwner", params, &r)
 	if _, ok := err.(jsonrpc2.Error); ok {
-		fmt.Printf("Error checking jsonrpc port. %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error checking jsonrpc port. %v\n", err)
 		os.Exit(1)
 	}
 	if err != nil {
-		fmt.Printf("Error checking jsonrpc port! %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error checking jsonrpc port! %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Println(r)
+	out, err := json.Marshal(r)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding result: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
 }


### PR DESCRIPTION
Enhance the rotate keys functionality by updating the RPC call to `author_rotateKeysWithOwner`, which now requires an owner parameter. Additionally, update the Go version and dependencies to ensure compatibility with the latest features. 
## changelog

### new features

- Introduced a new command-line argument for specifying the owner when rotating keys.

### modified external API

- Updated the RPC function from `author_rotateKeys` to `author_rotateKeysWithOwner`.

### other

- Updated Go version and dependencies for improved performance and security.

