### PR TITLE
fix: push only commit-SHA tags to ECR for debian images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -757,15 +757,17 @@ jobs:
             export VERSION=`./scripts/version.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1"`
             aws ecr get-login-password --region us-west-2 \
               | docker login --username AWS --password-stdin $ECR_REGISTRY
-            docker buildx imagetools create \
-              --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest-$CIRCLE_BRANCH-debian \
-              $DOCKERHUB_IMAGE:latest-$CIRCLE_BRANCH-debian
-            docker buildx imagetools create \
-              --tag $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION-$CIRCLE_BRANCH-debian \
-              $DOCKERHUB_IMAGE:$VERSION-$CIRCLE_BRANCH-debian
-            docker buildx imagetools create \
-              --tag $ECR_REGISTRY/$ECR_REPOSITORY:$CIRCLE_SHA1 \
-              $DOCKERHUB_IMAGE:$VERSION-$CIRCLE_BRANCH-debian
+
+            # polymesh/polymesh is an IMMUTABLE ECR repo, and only the commit SHA
+            # is pushed (matching the SHA-tag convention our ECS services use).
+            # Skip if the tag is already there so reruns of the same commit don't fail.
+            if docker buildx imagetools inspect "$ECR_REGISTRY/$ECR_REPOSITORY:$CIRCLE_SHA1" >/dev/null 2>&1; then
+              echo "Tag $CIRCLE_SHA1 already exists in ECR - skipping"
+            else
+              docker buildx imagetools create \
+                --tag $ECR_REGISTRY/$ECR_REPOSITORY:$CIRCLE_SHA1 \
+                $DOCKERHUB_IMAGE:$VERSION-$CIRCLE_BRANCH-debian
+            fi
   build-docker-distroless:
     environment:
       IMAGE_NAME: polymeshassociation/polymesh


### PR DESCRIPTION
* Pushes only the `$CIRCLE_SHA1` tag, and skips the push (instead of failing) if that tag already exists in ECR, so reruns of the same commit are a no-op rather than a failure.